### PR TITLE
Configure Nuxt to use `@nuxt/icon`

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -60,6 +60,7 @@ export default defineNuxtConfig({
 
   // Modules: https://nuxt.com/docs/api/nuxt-config#modules-1.
   modules: [
+    '@nuxt/icon',
   ],
 
   // Shared build configuration: https://nuxt.com/docs/api/nuxt-config#build.


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/451

# How

* Add `@nuxt/icon` to `module` field in Nuxt config file.
