### PR TITLE
Remove redundant styles for `<p>`

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,8 +8,3 @@ body {
   color: var(--color-text-primary);
   background-color: var(--color-background);
 }
-
-p {
-  font-size: var(--font-size-base);
-  line-height: var(--line-height-base);
-}


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/562

# How

* Remove redundant styles for `<p>` as the policy for line-height takes effect.
* `line-height: 1.618` is set in the reset stylesheet. It should not be overwritten.
