### PR TITLE
Implement `useDebounce()` composable

### DIFF
--- a/composables/useDebounce.js
+++ b/composables/useDebounce.js
@@ -1,0 +1,34 @@
+/**
+ * Debounce execution of a function.
+ *
+ * @param {{
+ *   callback: Function
+ *   timeInMs?: number
+ * }} callback
+ * @returns {(...args: Array<any>) => void} Debounced function.
+ */
+export function useDebounce ({
+  callback,
+  timeInMs = 300,
+}) {
+  /** @type {{ current: ReturnType<typeof setTimeout> | null }} */
+  const timerRef = {
+    current: null,
+  }
+
+  /**
+   * Debounced function.
+   *
+   * @param {Array<any>} args
+   * @returns {void}
+   */
+  return (...args) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+
+    timerRef.current = setTimeout(() => {
+      callback(...args)
+    }, timeInMs)
+  }
+}


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/693

# How

* Implement `useDebounce()` composable. It returns a debounced function.
* Default debounce time is 300ms.
* This composable is mostly used for search field.
