### PR TITLE
Implement `vOnClickOutside` directive

### DIFF
--- a/app/vue/directives/vOnClickOutside.js
+++ b/app/vue/directives/vOnClickOutside.js
@@ -10,7 +10,7 @@ const HIDDEN_STYLE = /** @type {const} */ ({
 })
 
 /** @type {import('vue').ObjectDirective} */
-export const vOnClickOutside = {
+export default {
   mounted (
     element,
     binding


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/702

# How

* Built `vOnClickOutside` directive using Event: `composedPath()` method.
* This directive is mainly used for dropdown elements.
* Listener will be cleared when the element is unmounted.
* If the element is hidden with `display: none`, the callback function is not executed.

# Usage

```vue
<script>
import {
  defineComponent,
} from 'vue'

import {
  vOnClickOutside,
} from '~/app/vue/directives/vOnClickOutside';

export default defineComponent({
  directives: {
    onClickOutside: vOnClickOutside,
  },

  // ...Create context here...
})
</script>

<template>
  <div v-on-click-outside="context.closeDropdown()"
    :class="{
      hidden: context.isOpen,
    }"
  >
    <input type="text">
  </div>
</template>
```

When the dropdown is being displayed and the user clicks outside, the callback function will be invoked.

