### PR TITLE
Update `competitions` query to use image field

### DIFF
--- a/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule.js
@@ -42,7 +42,7 @@ export default class CompetitionsQueryGraphqlCapsule extends BaseAppGraphqlCapsu
  *   }
  *   totalPrize: number
  *   minimumDeposit: number
- *   imageUrl?: string
+ *   image?: string
  *   schedules: Array<{
  *     categogry: {
  *       categoryId: number

--- a/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlPayload.js
@@ -23,7 +23,7 @@ export default class CompetitionsQueryGraphqlPayload extends BaseAppGraphqlPaylo
             }
             totalPrize
             minimumDeposit
-            imageUrl
+            image
             schedules {
               category {
                 categoryId

--- a/app/vue/contexts/AppLeagueCardContext.js
+++ b/app/vue/contexts/AppLeagueCardContext.js
@@ -85,13 +85,13 @@ export default class AppLeagueCardContext extends BaseFuroContext {
   }
 
   /**
-   * get: imageUrl
+   * get: image
    *
-   * @returns {CompetitionEntity['imageUrl'] | null}
+   * @returns {CompetitionEntity['image'] | null}
    */
-  get imageUrl () {
+  get image () {
     return this.extractCompetition()
-      ?.imageUrl
+      ?.image
       ?? null
   }
 
@@ -191,7 +191,7 @@ export default class AppLeagueCardContext extends BaseFuroContext {
    * @returns {string} Image URL
    */
   genenrateImageUrl () {
-    return this.imageUrl ?? ''
+    return this.image ?? ''
   }
 
   /**


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/708

# How

* Update `competitions` query to use image field according to changes from the Backend.

# Screenshots

![image](https://github.com/user-attachments/assets/0a5837f2-8d20-45ec-a5cb-003e2585f61e)

