### PR TITLE
Fix a small typo in AppLeagueCardContext

### DIFF
--- a/app/vue/contexts/AppLeagueCardContext.js
+++ b/app/vue/contexts/AppLeagueCardContext.js
@@ -190,7 +190,7 @@ export default class AppLeagueCardContext extends BaseFuroContext {
    *
    * @returns {string} Image URL
    */
-  genenrateImageUrl () {
+  generateImageUrl () {
     return this.image ?? ''
   }
 

--- a/components/units/AppLeagueCard.vue
+++ b/components/units/AppLeagueCard.vue
@@ -52,7 +52,7 @@ export default defineComponent({
             {{ context.title }}
           </h4>
 
-          <img :src="context.genenrateImageUrl()"
+          <img :src="context.generateImageUrl()"
             :alt="context.host?.name"
             class="image"
           >


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/740

# How

* Fix typo `genenrateImageUrl` → `generateImageUrl`.
