### PR TITLE
Fix incorrect type for competition getter

### DIFF
--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -98,7 +98,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   /**
    * get: competition
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity>}
+   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity}
    */
   get competition () {
     return this.competitionCapsuleRef.value


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/815

# How

* Fix incorrect type for `competition` getter.
