### PR TITLE
Make header stay at the cloud layer

### DIFF
--- a/components/units/AppDefaultLayout.vue
+++ b/components/units/AppDefaultLayout.vue
@@ -140,6 +140,8 @@ export default defineComponent({
   top: 0;
 
   background-color: var(--color-background-header);
+
+  z-index: calc(var(--value-z-index-layer-staying) + 0);
 }
 
 .unit-body > .header > .inner {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/858

# How

* Some CSS properties create stacking context, which can potentially make them cascade over the header.
* This PR made the header stay at the cloud layer to ensure that it does not get cascaded over by those elements.
