### PR TITLE
Make sidebar stay in cloud layer instead of overlay layer

### DIFF
--- a/components/units/AppDefaultLayout.vue
+++ b/components/units/AppDefaultLayout.vue
@@ -218,7 +218,7 @@ export default defineComponent({
 
   background-color: var(--color-background-nav);
 
-  z-index: calc(var(--value-z-index-layer-staying) + 0);
+  z-index: calc(var(--value-z-index-layer-staying) + 1000);
 }
 
 .unit-body > .search {
@@ -229,7 +229,7 @@ export default defineComponent({
 
   background-color: var(--color-background-search-panel);
 
-  z-index: calc(var(--value-z-index-layer-staying) + 0);
+  z-index: calc(var(--value-z-index-layer-staying) + 1000);
 }
 
 .unit-body.open-search > .search {
@@ -281,7 +281,7 @@ export default defineComponent({
 
   display: none;
 
-  z-index: calc(var(--value-z-index-layer-staying) + 0);
+  z-index: calc(var(--value-z-index-layer-staying) + 1000);
 }
 
 .unit-body.open-search > .backdrop {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/813

# How

* Use `--value-z-index-layer-staying instead` of `--value-z-index-layer-overlay` for the sidebar.
* Plus `1000` to ensure that it is higher than the header.
