### PR TITLE
Build `<AppLoadingLayout>` component from `<FuroLoadingLayout>`

### DIFF
--- a/components/units/AppLoadingLayout.vue
+++ b/components/units/AppLoadingLayout.vue
@@ -1,0 +1,69 @@
+<script>
+import {
+  defineComponent,
+} from 'vue'
+
+import {
+  Icon,
+} from '#components'
+
+import FuroLoadingLayout from '@openreachtech/furo-nuxt/lib/components/FuroLoadingLayout.vue'
+
+export default defineComponent({
+  name: 'AppLoadingLayout',
+
+  components: {
+    Icon,
+    FuroLoadingLayout,
+  },
+
+  inheritAttrs: false,
+
+  props: {
+    isLoading: {
+      type: Boolean,
+      required: true,
+    },
+  },
+})
+</script>
+
+<template>
+  <FuroLoadingLayout class="design"
+    v-bind="{
+      ...$attrs,
+      ...$props,
+    }"
+  >
+    <template #contents>
+      <slot name="contents" />
+    </template>
+
+    <template #loader>
+      <slot name="loader">
+        <div class="unit-loader">
+          <Icon name="svg-spinners:90-ring-with-bg"
+            size="1.5rem"
+          />
+        </div>
+      </slot>
+    </template>
+  </FuroLoadingLayout>
+</template>
+
+<style scoped>
+.unit-loader {
+  border-radius: 0.5rem;
+
+  padding-block: 1rem;
+  padding-inline: 1rem;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  min-height: 14rem;
+
+  background-color: var(--color-background-skeleton);
+}
+</style>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1069

# How

* Built `<AppLoadingLayout>` component from `<FuroLoadingLayout>`.

# Screenshots

![image](https://github.com/user-attachments/assets/a65c3b8a-25a3-4dcb-b623-17e8c981fd47)

Custom loader slot with `<AppSkeleton>`

![image](https://github.com/user-attachments/assets/f4113965-e935-463f-9d6d-e430ad8b8a73)

