### PR TITLE
Add loading skeleton for competitions list

### DIFF
--- a/app/vue/contexts/CompetitionsPageContext.js
+++ b/app/vue/contexts/CompetitionsPageContext.js
@@ -153,6 +153,15 @@ export default class CompetitionsPageContext extends BaseFuroContext {
   }
 
   /**
+   * get: isLoadingCompetitions
+   *
+   * @returns {boolean} `true` if competitions is loading.
+   */
+  get isLoadingCompetitions () {
+    return this.statusReactive.isLoadingCompetitions
+  }
+
+  /**
    * Generate pagination.
    *
    * @returns {Pagination} Pagination object.

--- a/pages/(competitions)/competitions/index.vue
+++ b/pages/(competitions)/competitions/index.vue
@@ -69,7 +69,7 @@ export default defineComponent({
   <div class="unit-container">
     <LeagueHeroSection />
 
-    <AppLoadingLayout :is-loading="context.statusReactive.isLoadingCompetitions">
+    <AppLoadingLayout :is-loading="context.isLoadingCompetitions">
       <template #contents>
         <div>
           <div class="unit-cards">


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1115

# How

* Add loading skeleton for competitions list.

# Screenshots

![image](https://github.com/user-attachments/assets/ea1337a5-5d64-43bd-a584-57aeb05040f0)

