### PR TITLE
Scope styles of default layout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -74,8 +74,7 @@ export default {
   </AppDefaultLayout>
 </template>
 
-<!-- never use <style scoped> here -->
-<style>
+<style scoped>
 .unit-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1203

# How

* Styles of default layout is leaking into other files because they were not scoped. Since the layout does not need to override the style of furo component, I used `<style scoped>` instead of `@layer`.
