### PR TITLE
add legacy-peer-deps=true in .npmrc.pages

### DIFF
--- a/.npmrc.pages
+++ b/.npmrc.pages
@@ -1,2 +1,3 @@
 @openreachtech:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${TOKEN_FOR_GITHUB}
+legacy-peer-deps=true


### PR DESCRIPTION
# Error Log
```
2025-03-08T09:23:58.26185Z	Cloning repository...
2025-03-08T09:23:59.198449Z	From https://github.com/openreachtech/dydx-trading-competition-frontend
2025-03-08T09:23:59.198861Z	 * branch            2fdffc8a8cc8fa87bc0cf44609582175e5a999e0 -> FETCH_HEAD
2025-03-08T09:23:59.199049Z	
2025-03-08T09:23:59.262198Z	HEAD is now at 2fdffc8 Re-run build
2025-03-08T09:23:59.262663Z	
2025-03-08T09:23:59.337104Z	
2025-03-08T09:23:59.3376Z	Using v2 root directory strategy
2025-03-08T09:23:59.35662Z	Success: Finished cloning repository files
2025-03-08T09:24:00.869238Z	Checking for configuration in a Wrangler configuration file (BETA)
2025-03-08T09:24:00.869879Z	
2025-03-08T09:24:01.970777Z	No wrangler.toml file found. Continuing.
2025-03-08T09:24:02.037275Z	Detected the following tools from environment: npm@9.6.7, nodejs@18.17.1
2025-03-08T09:24:02.037794Z	Installing project dependencies: npm clean-install --progress=false
2025-03-08T09:24:04.740398Z	npm ERR! code ERESOLVE
2025-03-08T09:24:04.743847Z	npm ERR! ERESOLVE could not resolve
2025-03-08T09:24:04.744067Z	npm ERR! 
2025-03-08T09:24:04.744212Z	npm ERR! While resolving: vite-plugin-node-stdlib-browser@0.2.1
2025-03-08T09:24:04.744364Z	npm ERR! Found: vite@6.0.6
2025-03-08T09:24:04.744492Z	npm ERR! node_modules/vite
2025-03-08T09:24:04.744611Z	npm ERR!   peer vite@"*" from @nuxt/devtools@1.7.0
2025-03-08T09:24:04.744718Z	npm ERR!   node_modules/@nuxt/devtools
2025-03-08T09:24:04.744819Z	npm ERR!     @nuxt/devtools@"^1.6.4" from nuxt@3.15.0
2025-03-08T09:24:04.744935Z	npm ERR!     node_modules/nuxt
2025-03-08T09:24:04.745026Z	npm ERR!       nuxt@"^3.15.0" from the root project
2025-03-08T09:24:04.745122Z	npm ERR!       1 more (@openreachtech/furo-nuxt)
2025-03-08T09:24:04.745218Z	npm ERR!   peer vite@"*" from @nuxt/devtools-kit@1.7.0
2025-03-08T09:24:04.745336Z	npm ERR!   node_modules/@nuxt/devtools-kit
2025-03-08T09:24:04.745439Z	npm ERR!     @nuxt/devtools-kit@"1.7.0" from @nuxt/devtools@1.7.0
2025-03-08T09:24:04.745535Z	npm ERR!     node_modules/@nuxt/devtools
2025-03-08T09:24:04.745632Z	npm ERR!       @nuxt/devtools@"^1.6.4" from nuxt@3.15.0
2025-03-08T09:24:04.745741Z	npm ERR!       node_modules/nuxt
2025-03-08T09:24:04.745835Z	npm ERR!         nuxt@"^3.15.0" from the root project
2025-03-08T09:24:04.745973Z	npm ERR!         1 more (@openreachtech/furo-nuxt)
2025-03-08T09:24:04.746099Z	npm ERR!     @nuxt/devtools-kit@"^1.6.4" from @nuxt/icon@1.10.3
2025-03-08T09:24:04.746212Z	npm ERR!     node_modules/@nuxt/icon
2025-03-08T09:24:04.746378Z	npm ERR!       dev @nuxt/icon@"^1.10.3" from the root project
2025-03-08T09:24:04.746494Z	npm ERR!   7 more (@nuxt/vite-builder, @vitejs/plugin-vue, ...)
2025-03-08T09:24:04.746604Z	npm ERR! 
2025-03-08T09:24:04.746755Z	npm ERR! Could not resolve dependency:
2025-03-08T09:24:04.74687Z	npm ERR! peer vite@"^2.0.0 || ^3.0.0 || ^4.0.0" from vite-plugin-node-stdlib-browser@0.2.1
2025-03-08T09:24:04.747008Z	npm ERR! node_modules/vite-plugin-node-stdlib-browser
2025-03-08T09:24:04.747144Z	npm ERR!   dev vite-plugin-node-stdlib-browser@"^0.2.1" from the root project
2025-03-08T09:24:04.747267Z	npm ERR! 
2025-03-08T09:24:04.747399Z	npm ERR! Conflicting peer dependency: vite@4.5.9
2025-03-08T09:24:04.747579Z	npm ERR! node_modules/vite
2025-03-08T09:24:04.747714Z	npm ERR!   peer vite@"^2.0.0 || ^3.0.0 || ^4.0.0" from vite-plugin-node-stdlib-browser@0.2.1
2025-03-08T09:24:04.747845Z	npm ERR!   node_modules/vite-plugin-node-stdlib-browser
2025-03-08T09:24:04.747985Z	npm ERR!     dev vite-plugin-node-stdlib-browser@"^0.2.1" from the root project
2025-03-08T09:24:04.748107Z	npm ERR! 
2025-03-08T09:24:04.748211Z	npm ERR! Fix the upstream dependency conflict, or retry
2025-03-08T09:24:04.74836Z	npm ERR! this command with --force or --legacy-peer-deps
2025-03-08T09:24:04.748465Z	npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
2025-03-08T09:24:04.748602Z	npm ERR! 
2025-03-08T09:24:04.748738Z	npm ERR! 
2025-03-08T09:24:04.74883Z	npm ERR! For a full report see:
2025-03-08T09:24:04.748913Z	npm ERR! /opt/buildhome/.npm/_logs/2025-03-08T09_24_02_716Z-eresolve-report.txt
2025-03-08T09:24:04.749059Z	
2025-03-08T09:24:04.74917Z	npm ERR! A complete log of this run can be found in: /opt/buildhome/.npm/_logs/2025-03-08T09_24_02_716Z-debug-0.log
2025-03-08T09:24:04.760619Z	Error: Exit with error code: 1
2025-03-08T09:24:04.760789Z	    at ChildProcess.<anonymous> (/snapshot/dist/run-build.js)
2025-03-08T09:24:04.76098Z	    at Object.onceWrapper (node:events:652:26)
2025-03-08T09:24:04.761112Z	    at ChildProcess.emit (node:events:537:28)
2025-03-08T09:24:04.761235Z	    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
2025-03-08T09:24:04.769976Z	Failed: build command exited with code: 1
2025-03-08T09:24:05.487383Z	Failed: error occurred while running build command
```

## Solution

- add `legacy-peer-deps=true` in `.npmrc.pages`
- ※ add env variables `NPM_FLAGS` (`--legacy-peer-deps`) in dashboard is not working 
