### PR TITLE
Fix incorrect ESLint regex of `no-restricted-syntax` rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -111,7 +111,7 @@ export default [
           message: 'Never use for',
         },
         {
-          selector: 'Identifier[name=/.+(Data|Info|(?<![gs]et)Item|List|Manager)$/]', // 'Identifier[name=/.+(Data|Info|Item|List|Manager)$/]'
+          selector: 'Identifier[name=/.+((?<!signTyped)Data|Info|(?<![gs]et|remove)Item|List|Manager)$/]', // 'Identifier[name=/.+(Data|Info|Item|List|Manager)$/]'
           message: 'Not allowed to use "Data", "Info", "Item", "List", and "Manager" as suffix of identifier.',
         },
         {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1275

# How

* Fix incorrect negative lookbehind sytax.
* Add native API exceptions for the rule.
