### PR TITLE
Remove redundant spacing between League Schedules and League Details sections

### DIFF
--- a/components/competition-id/SectionSchedules.vue
+++ b/components/competition-id/SectionSchedules.vue
@@ -97,6 +97,8 @@ export default defineComponent({
 
 <style scoped>
 .unit-section {
+  /* Reset block-start margin of base styles. */
+  margin-block-start: 0;
   margin-inline: calc(-1 * var(--size-body-padding-inline-mobile));
 
   border-block-width: var(--size-thinnest);


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1061

# How

* The base styles add spacing between each section. This PR reset the margin value to `0`.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/15e0ace7-6d63-4aac-b414-d94cd96e9dc7)

## After

![image](https://github.com/user-attachments/assets/a59498d0-6abb-4a45-805c-60185be0885d)
