### PR TITLE
Clamp title of league card to two lines if possible

### DIFF
--- a/components/units/AppLeagueCard.vue
+++ b/components/units/AppLeagueCard.vue
@@ -173,9 +173,26 @@ export default defineComponent({
 }
 
 .unit-headline > .heading {
+  --max-line-count: 2;
+
   font-size: var(--font-size-large);
   font-weight: 700;
   line-height: var(--size-line-height-large);
+
+  min-height: calc(var(--max-line-count) * var(--size-line-height-large));
+}
+
+/* If line-clamp is supported, use it. Otherwise, min-height is still two lines, which is not ideal but not ugly. */
+@supports (line-clamp: 2) or ((-webkit-line-clamp: 2) and (display: -webkit-box) and (-webkit-box-orient: vertical)) {
+  .unit-headline > .heading {
+    display: -webkit-box;
+    line-clamp: var(--max-line-count);
+    -webkit-line-clamp: var(--max-line-count);
+    -webkit-box-orient: vertical;
+
+    height: calc(var(--size-line-height-large) * var(--max-line-count));
+    overflow: hidden;
+  }
 }
 
 .unit-headline > .image {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1388

# How

* If supported, use `line-clamp` to clamp the title of league card to 2 lines only.
* If not supported, the min-height of the title is still set to minimum of 2 lines, which is not ideal but not ugly.

> [!note]
> - `line-clamp` is not a baseline feature. However, `-webkit-line-clamp` seems to be working fine on all famous browsers: Chromium, Firefox, Safari. Therefore, I would like to use this feature to achieve the desired appearance.
> - I have also tried experimenting with other approaches like using `::after` with a content of `...`, or fading the text content with gradient. They are not reliable.
> - This PR chose to follow the practicality instead of the baseline policy.

# Screenshots

All browsers look like this (_Chromium, Firefox, Safari_):

![image](https://github.com/user-attachments/assets/6bd3da8e-af54-43ea-b54a-14c6f60daeb7)