### PR TITLE
Display last calculated date for competition leaderboard

### DIFF
--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -194,6 +194,35 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   }
 
   /**
+   * Generate last calculated date.
+   *
+   * @returns {string} Last calculated date.
+   */
+  generateLastCalculatedAt () {
+    const lastCalculatedAt = this.rankings
+      .at(0)
+      ?.calculatedAt
+      ?? null
+
+    if (!lastCalculatedAt) {
+      return 'Last updated: Unknown'
+    }
+
+    const date = new Date(lastCalculatedAt)
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    })
+
+    return `Last Updated: ${formatter.format(date)}`
+  }
+
+  /**
    * Generate pagination result
    *
    * @returns {PaginationResult} Pagination result.

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -80,7 +80,7 @@ export default defineComponent({
       </div>
 
       <span class="note">
-        Last updated: March 12, 2025, 14:02:30
+        {{ context.generateLastCalculatedAt() }}
       </span>
 
       <AppTable :header-entries="context.tableHeaderEntries"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1253

# How

* Display last calculated date for competition leaderboard.

# Screenshot

![Screenshot From 2025-03-13 15-24-40](https://github.com/user-attachments/assets/6955deea-6037-4bfb-a98a-017dffcb81ed)

