### PR TITLE
View the month of the selected date on selection

### DIFF
--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -344,6 +344,9 @@ export default class AppDatePikcerContext extends BaseFuroContext {
   selectDate ({
     date,
   }) {
+    this.dateReactive.currentMonth = date.month
+    this.dateReactive.currentYear = date.year
+
     const selectedDate = new Date()
 
     selectedDate.setUTCFullYear(date.year)


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1423

# How

* When selecting a page from the previous/next month, the view stays at the same month.
* The native behavior is to jump to the month of the selected date.

# Screencasts

## Before

https://github.com/user-attachments/assets/2553176e-4e03-4c40-babb-51e98dfc14f5

## After

https://github.com/user-attachments/assets/0efad03e-edfb-4949-a833-13dc3478c8ad


