### PR TITLE
Add root class to AppInput to control layout from parent elements

### DIFF
--- a/app/vue/contexts/AppInputContext.js
+++ b/app/vue/contexts/AppInputContext.js
@@ -34,4 +34,18 @@ export default class AppInputContext extends BaseFuroContext {
   get rootClass () {
     return this.props.rootClass
   }
+
+  /**
+   * Generate input classes.
+   *
+   * @returns {Array<string | Record<string, boolean>>} CSS classes
+   */
+  generateInputClasses () {
+    return [
+      this.rootClass,
+      {
+        error: this.hasError,
+      },
+    ]
+  }
 }

--- a/components/units/AppInput.vue
+++ b/components/units/AppInput.vue
@@ -52,9 +52,7 @@ export default defineComponent({
 
 <template>
   <span class="unit-input"
-    :class="{
-      error: context.hasError,
-    }"
+    :class="context.generateInputClasses()"
   >
     <input v-bind="$attrs"
       class="input"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1476

# How

* Attributes are pass to the underlying `<input>` element of AppInput. When the class attribute is passed to the component, `input` will receive it, not the root `span` element.
* Often we have to control the layout from the parent component, this requires a class to be passed to the root element of AppInput. This PR attempted to address the issue.
