### PR TITLE
Use `input[type="number"]` for integer fields

### DIFF
--- a/components/competition-add/AddCompetitionFormStepDetails.vue
+++ b/components/competition-add/AddCompetitionFormStepDetails.vue
@@ -107,7 +107,8 @@ export default defineComponent({
       </p>
 
       <div class="uploader">
-        <input type="hidden"
+        <input type="number"
+          class="input hidden"
           name="imageId"
           :value="context.imageIdRef.value"
         >
@@ -256,5 +257,9 @@ export default defineComponent({
   justify-content: center;
 
   text-align: center;
+}
+
+.input.hidden {
+  display: none;
 }
 </style>

--- a/components/competition-add/AddCompetitionFormStepTimeline.vue
+++ b/components/competition-add/AddCompetitionFormStepTimeline.vue
@@ -90,8 +90,9 @@ export default defineComponent({
                   Start Date (MM/DD/YYYY)
                 </span>
 
-                <input type="hidden"
+                <input type="number"
                   name="categoryId"
+                  class="input hidden"
                   :value="phase.startDateInputId"
                 >
 
@@ -112,8 +113,9 @@ export default defineComponent({
                 End Date
               </span>
 
-              <input type="hidden"
+              <input type="number"
                 name="categoryId"
+                class="input hidden"
                 :disabled="!phase.endDateExtractionKey"
                 :value="phase.endDateInputId"
               >
@@ -295,6 +297,10 @@ export default defineComponent({
 }
 
 .unit-stage.hide-end-date > .content > .unit-pickers > .date.end {
+  display: none;
+}
+
+.input.hidden {
   display: none;
 }
 </style>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1525

# How

* The API requires integer for some fields. `input[type="hidden"]` elements do not get converted to number automatically.
* This PR replaced them with `input[type="number"]` and hide the elements with CSS.
