### PR TITLE
Fix incorrect signature details in BaseAppSignatureGraphqlPayload

### DIFF
--- a/app/graphql/client/BaseAppSignatureGraphqlPayload.js
+++ b/app/graphql/client/BaseAppSignatureGraphqlPayload.js
@@ -17,9 +17,7 @@ export default class BaseAppSignatureGraphqlPayload extends BaseAppGraphqlPayloa
    */
   extractFilteredVariables () {
     const walletStore = useWalletStore()
-    const {
-      signature,
-    } = walletStore.walletStoreRef.value.credential
+    const signature = walletStore.walletStoreRef.value.credential
 
     if (!signature) {
       return this.variables


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1537

# How

* `signature` is an object containing the signature details, not just a string.
