### PR TITLE
Remove redundant route

### DIFF
--- a/pages/(profiles)/profiles/[address]/past-competitions.vue
+++ b/pages/(profiles)/profiles/[address]/past-competitions.vue
@@ -1,6 +1,0 @@
-<template>
-  <!-- TODO: Fulfill page -->
-  <div>
-    Past competitions
-  </div>
-</template>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1573

# How

* Removed redundant route `profiles/[address]/past-competitions`.
* This part has already been included in a tab in `profile/[address]`, thus, redundant.
