### PR TITLE
Use small font-size for error messages

### DIFF
--- a/components/units/AppInput.vue
+++ b/components/units/AppInput.vue
@@ -115,6 +115,8 @@ export default defineComponent({
 }
 
 .unit-input > .error-message {
+  font-size: var(--font-size-small);
+
   color: var(--color-text-error);
 }
 

--- a/components/units/AppTextarea.vue
+++ b/components/units/AppTextarea.vue
@@ -104,6 +104,8 @@ export default defineComponent({
 }
 
 .unit-textarea > .error-message {
+  font-size: var(--font-size-small);
+
   color: var(--color-text-error);
 }
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1646

# How

* Use small font-size for error messages.
