### PR TITLE
Hide header cells of transfer history table

### DIFF
--- a/components/profile/ProfileTransferHistory.vue
+++ b/components/profile/ProfileTransferHistory.vue
@@ -57,6 +57,7 @@ export default defineComponent({
   <div class="unit-container">
     <AppTable :header-entries="context.tableHeaderEntries"
       :entries="context.generateTableEntries()"
+      should-hide-header-cells
       min-width="45rem"
     >
       <template #body-time="{ value }">


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1658

# How

* Hide header cells of transfer history table.

# Screenshots

![image](https://github.com/user-attachments/assets/8043f7b9-25e6-46ea-b616-c025ae11e075)

