### PR TITLE
Display placeholder league image for user profile

### DIFF
--- a/app/vue/contexts/profile/SectionProfileOverviewContext.js
+++ b/app/vue/contexts/profile/SectionProfileOverviewContext.js
@@ -107,7 +107,7 @@ export default class SectionProfileOverviewContext extends BaseFuroContext {
   get image () {
     return this.competition
       ?.image
-      ?? ''
+      ?? '/img/badges/league-badge-placeholder.png'
   }
 
   /**

--- a/components/profile/SectionProfileOverview.vue
+++ b/components/profile/SectionProfileOverview.vue
@@ -403,6 +403,12 @@ export default defineComponent({
 
   width: 2.25rem;
   height: 2.25rem;
+
+  background-color: var(--color-background-card);
+}
+
+.unit-description > .entry > .description.participation > .image[src='/img/badges/league-badge-placeholder.png'] {
+  object-fit: scale-down;
 }
 
 .unit-description > .entry > .description:where(.baseline, .profit) {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1659

# How

* Display placeholder league image for user profile.

# Screenshots

![image](https://github.com/user-attachments/assets/a8f86951-b7bb-4480-930c-07c7eead0fb5)
