### PR TITLE
Generate local account URL in account dropdown menu

### DIFF
--- a/app/vue/contexts/AppWalletAccountContext.js
+++ b/app/vue/contexts/AppWalletAccountContext.js
@@ -193,6 +193,19 @@ export default class AppWalletAccountContext extends BaseFuroContext {
   }
 
   /**
+   * Generate address URL on Mintscan.
+   *
+   * @returns {string}
+   */
+  generateAddressUrl () {
+    const localWalletAddress = this.walletStore.walletStoreRef.value.localWallet.address
+
+    return localWalletAddress
+      ? `https://www.mintscan.io/dydx/address/${localWalletAddress}`
+      : ''
+  }
+
+  /**
    * Generate local account's address.
    *
    * @returns {string} Source account's address.

--- a/components/units/AppWalletAccount.vue
+++ b/components/units/AppWalletAccount.vue
@@ -99,7 +99,9 @@ export default defineComponent({
               <span>{{ context.generateLocalAccountAddress() }}</span>
               <CopyButton :content-to-copy="context.localWalletAddress" />
               <LinkTooltipButton tooltip-message="View on Mintscan"
-                href="https://www.mintscan.io"
+                target="_blank"
+                rel="noopener noreferrer"
+                :href="context.generateAddressUrl()"
               />
             </span>
           </div>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1674

# How

* Use actual account URL in the account menu.

# Screenshots

![image](https://github.com/user-attachments/assets/5f8bfe1f-2a3c-4eae-8e07-16ef0e34dfce)

