### PR TITLE
Reduce top padding of table with hidden header cells

### DIFF
--- a/components/units/AppTable.vue
+++ b/components/units/AppTable.vue
@@ -163,6 +163,10 @@ export default defineComponent({
   overflow: auto;
 }
 
+.unit-table-container:has(.cell.head.hide-head) {
+  padding-block-start: 0.5rem;
+}
+
 .unit-table {
   border-collapse: collapse;
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1704

# How

* Table with hidden header cells now has less top padding. This aligns more with the given design.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/b93070f1-e029-4a08-8b23-5d88df64eccf)

## After

![image](https://github.com/user-attachments/assets/14dff71e-d1b6-42d7-a3c0-f91218e98c72)

