### PR TITLE
Format the value of financial metrics in profile overview

### DIFF
--- a/components/profile/ProfileFinancialOverviewContext.js
+++ b/components/profile/ProfileFinancialOverviewContext.js
@@ -109,6 +109,48 @@ export default class ProfileFinancialOverviewContext extends BaseFuroContext {
     openPerpetualPositions,
   }) {
     return Object.values(openPerpetualPositions)
+      .map(it => ({
+        ...it,
+        entryPrice: this.normalizeNumber({
+          numberString: it.entryPrice,
+        }),
+        size: this.normalizeNumber({
+          numberString: it.size,
+        }),
+        realizedPnl: this.normalizeNumber({
+          numberString: it.realizedPnl,
+        }),
+        unrealizedPnl: this.normalizeNumber({
+          numberString: it.unrealizedPnl,
+        }),
+        netFunding: this.normalizeNumber({
+          numberString: it.netFunding,
+        }),
+      }))
+  }
+
+  /**
+   * Normalize number.
+   *
+   * @param {{
+   *   numberString: string | null
+   * }} params - Parameters.
+   * @returns {string} Normalized number string.
+   */
+  normalizeNumber ({
+    numberString,
+  }) {
+    if (!numberString) {
+      return '--'
+    }
+
+    const figure = parseFloat(numberString)
+    const formatter = new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 2,
+    })
+
+    return formatter.format(figure)
   }
 
   /**


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1717

# How

* Format the value of financial metrics in profile overview.
* Based on Mintscans, the minimum fractional digit count is 1, the maximum fractional digit count is 2.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/374a3dfc-0552-4633-9ee3-dd751bfc29b4)

## After

![image](https://github.com/user-attachments/assets/46df6576-e2b2-47ef-b382-eadea34efef5)
