### PR TITLE
Display error message for `joinCompetition` mutation

### DIFF
--- a/components/dialogs/CompetitionEnrollmentDialog.vue
+++ b/components/dialogs/CompetitionEnrollmentDialog.vue
@@ -11,6 +11,7 @@ import {
 import AppButton from '~/components/units/AppButton.vue'
 import AppDialog from '~/components/units/AppDialog.vue'
 import AppInput from '~/components/units/AppInput.vue'
+import AppMessage from '~/components/units/AppMessage.vue'
 
 import CompetitionEnrollmentDialogContext from './CompetitionEnrollmentDialogContext'
 
@@ -19,6 +20,7 @@ export default defineComponent({
     AppButton,
     AppDialog,
     AppInput,
+    AppMessage,
   },
 
   props: {
@@ -37,6 +39,15 @@ export default defineComponent({
     validationMessage: {
       /** @type {import('vue').PropType<furo.ValidatorHashType['message']>} */
       type: Object,
+      default: null,
+      required: false,
+    },
+    errorMessageHash: {
+      /** @type {import('vue').PropType<import('./CompetitionEnrollmentDialogContext').PropsType['errorMessageHash']>} */
+      type: [
+        Object,
+        null,
+      ],
       default: null,
       required: false,
     },
@@ -129,6 +140,13 @@ export default defineComponent({
             Please make sure you have enough balance when enroll league.
           </p>
         </div>
+
+        <AppMessage :is-hidden="!context.joinCompetitionErrorMessage"
+          severity="error"
+          variant="box"
+        >
+          {{ context.joinCompetitionErrorMessage }}
+        </AppMessage>
 
         <AppButton class="button">
           Enroll League

--- a/components/dialogs/CompetitionEnrollmentDialogContext.js
+++ b/components/dialogs/CompetitionEnrollmentDialogContext.js
@@ -87,6 +87,15 @@ export default class CompetitionEnrollmentDialogContext extends AppDialogContext
   }
 
   /**
+   * get: errorMessageHash
+   *
+   * @returns {PropsType['errorMessageHash']}
+   */
+  get errorMessageHash () {
+    return this.props.errorMessageHash
+  }
+
+  /**
    * get: minimumDeposit
    *
    * @returns {string | null}
@@ -94,6 +103,17 @@ export default class CompetitionEnrollmentDialogContext extends AppDialogContext
   get minimumDeposit () {
     return this.competition
       ?.minimumDeposit
+      ?? null
+  }
+
+  /**
+   * get: joinCompetitionErrorMessage
+   *
+   * @returns {string | null}
+   */
+  get joinCompetitionErrorMessage () {
+    return this.errorMessageHash
+      ?.joinCompetition
       ?? null
   }
 
@@ -160,5 +180,8 @@ export default class CompetitionEnrollmentDialogContext extends AppDialogContext
  *   competition: import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity | null
  *   initialUsername: string | null
  *   validationMessage: furo.ValidatorHashType['message']
+ *   errorMessageHash: import('vue').Reactive<
+ *     import('~/pages/(competitions)/competitions/[competitionId]/CompetitionDetailsPageMutationContext').ErrorMessageHash
+ *   > | null
  * }} PropsType
  */

--- a/pages/(competitions)/competitions/[competitionId]/CompetitionDetailsPageMutationContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/CompetitionDetailsPageMutationContext.js
@@ -19,6 +19,7 @@ export default class CompetitionDetailsPageMutationContext extends BaseFuroConte
 
     graphqlClientHash,
     formClerkHash,
+    errorMessageHashReactive,
     statusReactive,
   }) {
     super({
@@ -28,6 +29,7 @@ export default class CompetitionDetailsPageMutationContext extends BaseFuroConte
 
     this.graphqlClientHash = graphqlClientHash
     this.formClerkHash = formClerkHash
+    this.errorMessageHashReactive = errorMessageHashReactive
     this.statusReactive = statusReactive
   }
 
@@ -45,6 +47,7 @@ export default class CompetitionDetailsPageMutationContext extends BaseFuroConte
     componentContext,
     graphqlClientHash,
     formClerkHash,
+    errorMessageHashReactive,
     statusReactive,
   }) {
     return /** @type {InstanceType<T>} */ (
@@ -53,6 +56,7 @@ export default class CompetitionDetailsPageMutationContext extends BaseFuroConte
         componentContext,
         graphqlClientHash,
         formClerkHash,
+        errorMessageHashReactive,
         statusReactive,
       })
     )
@@ -122,6 +126,10 @@ export default class CompetitionDetailsPageMutationContext extends BaseFuroConte
       },
       afterRequest: async capsule => {
         this.statusReactive.isJoining = false
+
+        if (capsule.hasError()) {
+          this.errorMessageHashReactive.joinCompetition = capsule.getResolvedErrorMessage()
+        }
       },
     }
   }
@@ -131,6 +139,7 @@ export default class CompetitionDetailsPageMutationContext extends BaseFuroConte
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<{}> & {
  *   graphqlClientHash: Record<GraphqlClientHashKeys, GraphqlClient>
  *   formClerkHash: Record<FormClerkHashKeys, FormClerk>
+ *   errorMessageHashReactive: import('vue').Reactive<ErrorMessageHash>
  *   statusReactive: StatusReactive
  * }} CompetitionDetailsPageMutationContextParams
  */
@@ -159,4 +168,8 @@ export default class CompetitionDetailsPageMutationContext extends BaseFuroConte
  * @typedef {{
  *   isJoining: boolean
  * }} StatusReactive
+ */
+
+/**
+ * @typedef {Record<GraphqlClientHashKeys, string | null>} ErrorMessageHash
  */

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -56,6 +56,9 @@ export default defineComponent({
       invokeRequestWithFormValueHash: joinCompetitionGraphqlClient.invokeRequestWithFormValueHash,
     })
 
+    const mutationErrorMessageHashReactive = reactive({
+      joinCompetition: null,
+    })
     const statusReactive = reactive({
       isLoading: false,
     })
@@ -85,6 +88,7 @@ export default defineComponent({
       formClerkHash: {
         joinCompetition: joinCompetitionFormClerk,
       },
+      errorMessageHashReactive: mutationErrorMessageHashReactive,
       statusReactive: mutationStatusReactive,
     }
     const mutationContext = CompetitionDetailsPageMutationContext.create(mutationArgs)
@@ -124,6 +128,7 @@ export default defineComponent({
       :competition="context.competition"
       :initial-username="context.addressName"
       :validation-message="mutationContext.joinCompetitionValidationMessage"
+      :error-message-hash="mutationContext.errorMessageHashReactive"
       @join-competition="mutationContext.joinCompetition({
         formElement: $event.formElement,
       })"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1734

# How

* Add `errorMessageHashReactive` to store the message from Backend.
* Display error message using `AppMessage` component.

# Screencasts

https://github.com/user-attachments/assets/02ac45b8-a6f2-4c12-935e-a62d43663e82
