### PR TITLE
Add logic to generate enroll-button label

### DIFF
--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -554,6 +554,29 @@ export default class SectionLeagueContext extends BaseFuroContext {
   }
 
   /**
+   * Generate content for enroll button.
+   *
+   * @returns {string}
+   */
+  generateEnrollButtonLabel () {
+    if (this.isTargetPeriodById({
+      startDateId: SCHEDULE_CATEGORY.REGISTRATION_START.ID,
+      endDateId: SCHEDULE_CATEGORY.REGISTRATION_END.ID,
+    })) {
+      return 'Enroll now'
+    }
+
+    if (!this.isTargetPeriodById({
+      startDateId: SCHEDULE_CATEGORY.REGISTRATION_START.ID,
+      endDateId: SCHEDULE_CATEGORY.REGISTRATION_END.ID,
+    })) {
+      return 'Registration ended'
+    }
+
+    return 'Enroll now'
+  }
+
+  /**
    * Whether description is expandable or not.
    *
    * @returns {boolean} `true` if description is long enough to be expandable.

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -149,7 +149,9 @@ export default defineComponent({
           <AppButton class="button"
             @click="context.showTermsDialog()"
           >
-            Enroll now
+            {{
+              context.generateEnrollButtonLabel()
+            }}
           </AppButton>
 
           <!-- NOTE: Participants here. Missing API -->


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1782

# How

* Added logic to generate enroll-button label.

# Screenshots

![image](https://github.com/user-attachments/assets/617b49ac-0b53-48bf-b8bc-5429eb82b1a2)
