### PR TITLE
Use min-width to ensure enroll-button does not get too long

### DIFF
--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -410,7 +410,9 @@ export default defineComponent({
 }
 
 .unit-details > .actions > .button {
-  padding-inline: 5rem;
+  min-width: 15rem;
+
+  justify-content: center;
 
   font-size: var(--font-size-medium);
   font-weight: 500;


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1786

# How

* Use min-width to ensure enroll-button does not get too long.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/aa75e00d-e1ab-4542-a203-16ea215ef268)

## After

![image](https://github.com/user-attachments/assets/83475706-3746-4c1f-9935-2433e70f6b2d)
