### PR TITLE
Calculate actual open perpetual position count

### DIFF
--- a/components/profile/ProfileFinancialOverview.vue
+++ b/components/profile/ProfileFinancialOverview.vue
@@ -55,7 +55,11 @@ export default defineComponent({
           <span class="position">
             <span class="label">Open Perpetual Positions</span>
             <span class="figure">
-              {{ 1 }}
+              {{
+                context.calculateOpenPerpetualPositionCount({
+                  openPerpetualPositions: childSubaccount.openPerpetualPositions,
+                })
+              }}
             </span>
           </span>
 

--- a/components/profile/ProfileFinancialOverviewContext.js
+++ b/components/profile/ProfileFinancialOverviewContext.js
@@ -154,6 +154,21 @@ export default class ProfileFinancialOverviewContext extends BaseFuroContext {
   }
 
   /**
+   * Calculate open perpetual position count.
+   *
+   * @param {{
+   *   openPerpetualPositions: import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOverview['subaccount']['childSubaccounts'][0]['openPerpetualPositions']
+   * }} params - Parameters.
+   * @returns {number}
+   */
+  calculateOpenPerpetualPositionCount ({
+    openPerpetualPositions,
+  }) {
+    return Object.keys(openPerpetualPositions)
+      .length
+  }
+
+  /**
    * Extract asset position size.
    *
    * @param {{


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1821

# How

* Calculate actual open perpetual position count.
* The number next to "Open Perpetual Positions" indicates its length. This number coresponds to the amount of positions that the subaccount has. One position per market. 

# Screenshots

![image](https://github.com/user-attachments/assets/1466efdb-0170-4e91-b540-8f3cd6de273a)

