### PR TITLE
Update TopRankingCard to display dynamic value

### DIFF
--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -222,6 +222,15 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   }
 
   /**
+   * Check if the competition has finished.
+   *
+   * @returns {boolean}
+   */
+  hasFinishedCompetition () {
+    return this.competitionStatusId === COMPETITION_STATUS.COMPLETED.ID
+  }
+
+  /**
    * Shorten wallet address.
    *
    * @param {{

--- a/app/vue/contexts/competition/TopRankingCardContext.js
+++ b/app/vue/contexts/competition/TopRankingCardContext.js
@@ -32,6 +32,15 @@ export default class TopRankingCardContext extends BaseFuroContext {
   }
 
   /**
+   * get: shouldHidePrize
+   *
+   * @returns {PropsType['shouldHidePrize']}
+   */
+  get shouldHidePrize () {
+    return this.props.shouldHidePrize
+  }
+
+  /**
    * get: rank.
    *
    * @returns {import('~/app/vue/contexts/competition/SectionLeaderboardContext').TopRanker['rank'] | null}
@@ -231,10 +240,22 @@ export default class TopRankingCardContext extends BaseFuroContext {
       `top-${this.rank}`,
     ]
   }
+
+  /**
+   * Generate CSS classes for prize.
+   *
+   * @returns {Record<string, boolean>} CSS classes.
+   */
+  generatePrizeClasses () {
+    return {
+      hidden: this.shouldHidePrize,
+    }
+  }
 }
 
 /**
  * @typedef {{
  *   rankDetails: import('~/app/vue/contexts/competition/SectionLeaderboardContext').TopRanker | null
+ *   shouldHidePrize: boolean
  * }} PropsType
  */

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -106,6 +106,7 @@ export default defineComponent({
           class="champion"
         >
           <TopRankingCard :rank-details="it"
+            :should-hide-prize="!context.hasFinishedCompetition()"
             class="card"
           />
 

--- a/components/competition-id/TopRankingCard.vue
+++ b/components/competition-id/TopRankingCard.vue
@@ -26,6 +26,11 @@ export default defineComponent({
       ],
       required: true,
     },
+    shouldHidePrize: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 
   setup (
@@ -106,7 +111,9 @@ export default defineComponent({
         </dd>
       </div>
 
-      <div class="entry">
+      <div class="entry"
+        :class="context.generatePrizeClasses()"
+      >
         <dt class="term">
           Prize
         </dt>
@@ -236,6 +243,10 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+}
+
+.unit-card > .profit > .entry.hidden {
+  display: none;
 }
 
 .unit-card > .profit > .entry:nth-of-type(2n) {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2191

# How

* Extract the top three dynamically based on the competition status id.
* Allow prize of top rankers to be hidden until the competition has finished.

# Screenshots

![image](https://github.com/user-attachments/assets/d2423f5b-51ec-4f83-987d-eb2a2ea32eca)
