### PR TITLE
Fix incorrect column key in leaderboard table

### DIFF
--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -170,7 +170,7 @@ export default defineComponent({
         <template #body-ongoingName="{ value, row }">
           <NuxtLink class="unit-name ongoing"
             :to="context.generateProfileUrl({
-              address: row.address,
+              address: row.ongoingAddress,
             })"
           >
             {{ value }}
@@ -237,7 +237,7 @@ export default defineComponent({
         <template #body-outcomeName="{ value, row }">
           <NuxtLink class="unit-name outcome"
             :to="context.generateProfileUrl({
-              address: row.address,
+              address: row.outcomeAddress,
             })"
           >
             {{ value }}


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2230

# How

* Fix incorrect column key in leaderboard table.
