### PR TITLE
Remove fade-out animation of AppDialog

### DIFF
--- a/components/units/AppDialog.vue
+++ b/components/units/AppDialog.vue
@@ -111,10 +111,6 @@ export default defineComponent({
     animation: fade-in 150ms var(--transition-timing-base) forwards;
   }
 
-  .furo-dialog:not([open]).design {
-    animation: fade-out 150ms var(--transition-timing-base) forwards;
-  }
-
   .unit-header {
     padding-block-end: 0.75rem;
 
@@ -155,25 +151,6 @@ export default defineComponent({
   @keyframes fade-in {
     0% {
       opacity: 0;
-      display: none;
-      transform: scale(0.95);
-    }
-
-    100% {
-      opacity: 1;
-      display: block;
-    }
-  }
-
-  @keyframes fade-out {
-    0% {
-      opacity: 1;
-      display: block;
-    }
-
-    100% {
-      opacity: 0;
-      display: none;
       transform: scale(0.95);
     }
   }


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2246

# How

- To make the transition work both way, `display: none` and `display: ...` have to be specified in the keyframes. However, the value of `display: ...` has to match the value the dialog is using itself. This is not really apparent for everyone and can cause unwanted side effect in the future.
- This PR just removed the fade-out animation :)
