### PR TITLE
Provide more intuitive error message for AddressAlreadyRegisteredToCompetition

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -536,7 +536,7 @@ export const ERROR_MESSAGE_HASH = {
   CompetitionParticipantAddressNotFound: 'Competition participant address not found',
   AddressNotFound: 'Address not found',
   ParticipantLimitExceeded: 'Participant limit exceeded',
-  AddressAlreadyRegisteredToCompetition: 'Address already registered to competition',
+  AddressAlreadyRegisteredToCompetition: 'You can only register to one competition at a time',
   InvalidCompetitionState: 'Invalid competition state',
   NameAlreadyBeenUsed: 'Name has already been used',
   CurrentDetailInformationSameToNewDetailInformation: 'No changes in detail information',


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2247

# How

* Provide more intuitive error message for AddressAlreadyRegisteredToCompetition.
* This error can occur if the user has already registered to another competition. However, the original message can cause people to misunderstand that they have already registered to the one that they are trying to register.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/fcfcb8d2-7973-4e25-babd-71127645c594)

## After

![image](https://github.com/user-attachments/assets/665f0533-ee94-4c79-9862-908b055703f4)

