### PR TITLE
Temporarily hide competition share button

### DIFF
--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -205,11 +205,12 @@ export default defineComponent({
           >
 
           <div class="buttons">
-            <button class="button">
+            <!-- TODO: Implement share feature. -->
+            <!-- <button class="button">
               <Icon name="heroicons:share"
                 size="1.25rem"
               />
-            </button>
+            </button> -->
 
             <CopyButton :content-to-copy="context.generateCompetitionUrl()"
               icon-name="heroicons:link"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2276

# How

* Temporarily hide competition share button.

# Screenshots

* Now there's only copy button.

![image](https://github.com/user-attachments/assets/a63743e9-83f3-41f4-a60c-61bfdf98fe7f)

