### PR TITLE
Use `setup-node` v4 for the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: 🏗 Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2332

# How

* Use `setup-node` v4 for the CI
