### PR TITLE
Provide more responsive styles for competition details section

### DIFF
--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -518,6 +518,7 @@ export default defineComponent({
   gap: 0.75rem;
 
   min-width: 0;
+  max-height: fit-content;
 }
 
 .unit-meta > .actions {

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -334,7 +334,7 @@ export default defineComponent({
       #181825 46.63%,
       rgba(24, 24, 37, 0.00) 100%
     );
-  background-position: center;
+  background-position: top;
   background-size: cover;
   background-repeat: no-repeat;
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2341

# How

* Make sure the right panel does not grow pass its own height.
* Make sure the background image does not shift when description is expanded.

# Screencasts 

## Before

https://github.com/user-attachments/assets/0f23288b-a37b-40d9-b4de-d97fc75d92b1

## After

https://github.com/user-attachments/assets/ac7774bf-305b-45b5-85a8-6889f9de11c0