### PR TITLE
Change hover effect strategy of AppButton to avoid problem with Safari

### DIFF
--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -55,7 +55,7 @@
   --color-background-button-competition-step: var(--palette-layer-3);
   --color-background-button-highlight-hover: var(--palette-purple-faded);
 
-  --color-background-button-hover-overlay: var(--palette-black);
+  --color-background-button-hover-overlay-darken: var(--palette-black);
 
   --color-background-badge-info: var(--palette-purple-faded);
   --color-background-badge-success: var(--palette-green-faded);
@@ -267,5 +267,5 @@
 
   /* Values */
   --value-golden-ratio: 1.618;
-  --value-button-hover-overlay-opacity: 72%; /* Used in color-mix(), must be percentage. */
+  --value-button-hover-overlay-darken-opacity: 72%; /* Used in color-mix(), must be percentage. */
 }

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -55,6 +55,8 @@
   --color-background-button-competition-step: var(--palette-layer-3);
   --color-background-button-highlight-hover: var(--palette-purple-faded);
 
+  --color-background-button-hover-overlay: var(--palette-black);
+
   --color-background-badge-info: var(--palette-purple-faded);
   --color-background-badge-success: var(--palette-green-faded);
   --color-background-badge-warn: var(--palette-yellow-faded);
@@ -265,4 +267,5 @@
 
   /* Values */
   --value-golden-ratio: 1.618;
+  --value-button-hover-overlay-opacity: 72%; /* Used in color-mix(), must be percentage. */
 }

--- a/components/units/AppButton.vue
+++ b/components/units/AppButton.vue
@@ -122,6 +122,8 @@ export default defineComponent({
 
 <style scoped>
 .unit-button {
+  --color-background-button: var(--color-background-button-primary);
+
   border-radius: 0.5rem;
   border-style: solid;
   border-width: var(--size-thinnest);
@@ -132,6 +134,7 @@ export default defineComponent({
 
   display: inline-grid;
 
+  background-color: var(--color-background-button);
   color: var(--color-text-primary);
 
   font-size: var(--font-size-small);
@@ -139,7 +142,7 @@ export default defineComponent({
   line-height: 1;
 
   transition: filter 0.3s var(--transition-timing-base),
-    --color-darken-filter 0.3s var(--transition-timing-base),
+    background-color 0.3s var(--transition-timing-base),
     border-color 0.3s var(--transition-timing-base),
     color 0.3s var(--transition-timing-base);
 
@@ -164,47 +167,33 @@ export default defineComponent({
 
 /* Variants */
 .unit-button.primary {
-  background-color: var(--color-background-button-primary);
+  --color-background-button: var(--color-background-button-primary);
 }
 
 .unit-button.neutral {
-  border-color: var(--color-border-button-neutral);
-
-  background-color: var(--color-background-button-neutral);
+  --color-background-button: var(--color-background-button-neutral);
 }
 
 .unit-button.success {
-  background-color: var(--color-background-button-success);
+  --color-background-button: var(--color-background-button-success);
 }
 
 .unit-button.error {
-  background-color: var(--color-background-button-error);
+  --color-background-button: var(--color-background-button-error);
 }
 
 .unit-button.muted {
   border-color: var(--color-border-button-muted);
 
-  background-color: var(--color-background-button-muted);
-}
-
-/* Appearance */
-/* NOTE: Custom property to add transition to gradient. */
-@property --color-darken-filter {
-  syntax: '<color>';
-  initial-value: #00000000;
-  inherits: false;
-}
-
-.unit-button.filled {
-  background-image: linear-gradient(
-    to bottom,
-    var(--color-darken-filter),
-    var(--color-darken-filter)
-  );
+  --color-background-button: var(--color-background-button-muted);
 }
 
 .unit-button.filled:not(:disabled):hover {
-  --color-darken-filter: #00000047;
+  background-color: color-mix(
+    in srgb,
+    var(--color-background-button) var(--value-button-hover-overlay-opacity),
+    var(--color-background-button-hover-overlay)
+  );
 }
 
 .unit-button.outlined {

--- a/components/units/AppButton.vue
+++ b/components/units/AppButton.vue
@@ -191,8 +191,8 @@ export default defineComponent({
 .unit-button.filled:not(:disabled):hover {
   background-color: color-mix(
     in srgb,
-    var(--color-background-button) var(--value-button-hover-overlay-opacity),
-    var(--color-background-button-hover-overlay)
+    var(--color-background-button) var(--value-button-hover-overlay-darken-opacity),
+    var(--color-background-button-hover-overlay-darken)
   );
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -726,12 +726,6 @@ export default defineComponent({
 /******** Call-to-action button ********/
 /* TODO: Should have shared styles between link-button and button */
 
-@property --color-darken-filter {
-  syntax: '<color>';
-  initial-value: #00000000;
-  inherits: false;
-}
-
 .button.call-to-action {
   border-radius: 0.5rem;
   border-style: solid;
@@ -747,18 +741,17 @@ export default defineComponent({
   color: var(--color-text-primary);
 
   background-color: var(--color-background-button-primary);
-  background-image: linear-gradient(
-    to bottom,
-    var(--color-darken-filter),
-    var(--color-darken-filter)
-  );
 
   transition: box-shadow 500ms var(--transition-timing-base),
-    --color-darken-filter 500ms var(--transition-timing-base);
+    background-color 500ms var(--transition-timing-base);
 }
 
 .button.call-to-action:hover {
-  --color-darken-filter: #00000047;
+  background-color: color-mix(
+    in srgb,
+    var(--color-background-button-primary) var(--value-button-hover-overlay-opacity),
+    var(--color-background-button-hover-overlay)
+  );
 
   box-shadow: 0 0 7rem 2rem var(--palette-purple-faded);
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -749,8 +749,8 @@ export default defineComponent({
 .button.call-to-action:hover {
   background-color: color-mix(
     in srgb,
-    var(--color-background-button-primary) var(--value-button-hover-overlay-opacity),
-    var(--color-background-button-hover-overlay)
+    var(--color-background-button-primary) var(--value-button-hover-overlay-darken-opacity),
+    var(--color-background-button-hover-overlay-darken)
   );
 
   box-shadow: 0 0 7rem 2rem var(--palette-purple-faded);


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2263

# How

Based on the design, when a user hovers their cursor on a button, a darken overlay (_pure black with 28% opacity_) will be applied to the button. This overlay only affects the background color, not the text color. To achieve this effect, I created a custom property throught `@property` and transition it inside `background-image`. This works well on most browsers, except for Safari.

https://github.com/user-attachments/assets/c85b5f84-3bcd-4220-9dc1-1b1c9379774b

As you can see, for whatever reason, the button gets smaller on hover, causing a layout shift.

This Pull Request changed the hover effect strategy by changing the background color with `color-mix()` instead.

Considerations made but were not chosen as the solution:
- Use color alpha channel → Have to define more variables. Alpha channel means the element is opaque, so the color will be affected by the element behind the button.
- Define colors explicitly → Have to define more colors. More work for Quyen-san and me.
- Add overlay through a pseudo element `::before` or a `<span>` → Hard to sync the DOM. Have to use `z-index` to make sure the text cascades over the overlay.

# Screencasts

https://github.com/user-attachments/assets/931628a4-7f5d-400c-ad22-0ba0e5369dd2