### PR TITLE
Revert border color of neutral button

### DIFF
--- a/components/units/AppButton.vue
+++ b/components/units/AppButton.vue
@@ -171,6 +171,8 @@ export default defineComponent({
 }
 
 .unit-button.neutral {
+  border-color: var(--color-border-button-neutral);
+
   --color-background-button: var(--color-background-button-neutral);
 }
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2391

# How

* Border color of neutral button was mistakenly removed in a past commit. This PR brings it back.
