### PR TITLE
Display the correct competition start date

### DIFF
--- a/components/dialogs/CompetitionTermsDialog.vue
+++ b/components/dialogs/CompetitionTermsDialog.vue
@@ -104,7 +104,7 @@ export default defineComponent({
 
               <p class="content">
                 Trading period: <span class="highlight">
-                  {{ context.extractCompetitionEndDate() }}
+                  {{ context.extractCompetitionStartDate() }}
                 </span> to <span class="highlight">
                   {{ context.extractCompetitionEndDate() }}
                 </span>.


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2387

# How

* Display the correct competition start date in competition terms dialog.
