### PR TITLE
Fix incorrect total prize calculation

### DIFF
--- a/components/competition-add/AddCompetitionFormStepPrizeContext.js
+++ b/components/competition-add/AddCompetitionFormStepPrizeContext.js
@@ -100,7 +100,12 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
   static calculateTotalPrize ({
     prizeRulesRef,
   }) {
-    const amounts = prizeRulesRef.value.map(prizeRule => Number(prizeRule.amount))
+    const amounts = prizeRulesRef.value.map(prizeRule => {
+      const amount = parseFloat(prizeRule.amount)
+      const multiplier = prizeRule.rankTo - prizeRule.rankFrom + 1
+
+      return amount * multiplier
+    })
     const totalAmount = amounts.reduce(
       (accumulator, currentValue) => accumulator + currentValue,
       0


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2381

# How

* Properly take rank ranges into account when calculating total Prize.

```
rank 2 to rank 4: $100
rank 2 to rank 4 → 4 - 2 + 1 = 3 participants will recieve this prize.
rank 2 to rank 4 → $100 * 3 = $300
```
