### PR TITLE
Search users with `searchAddresses` query

### DIFF
--- a/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlCapsule.js
@@ -1,0 +1,102 @@
+import BaseAppGraphqlCapsule from '~/app/graphql/client/BaseAppGraphqlCapsule'
+
+/**
+ * SearchAddresses query graphql capsule.
+ *
+ * @extends {BaseAppGraphqlCapsule<SearchAddressesQueryResponseContent>}
+ */
+export default class SearchAddressesQueryGraphqlCapsule extends BaseAppGraphqlCapsule {
+  /**
+   * Extract `searchAddresses`.
+   *
+   * @returns {SearchAddresses | null}
+   */
+  extractSearchAddresses () {
+    return this.extractContent()
+      ?.searchAddresses
+      ?? null
+  }
+
+  /**
+   * get: addresses
+   *
+   * @returns {Array<Address>}
+   */
+  get addresses () {
+    return this.extractSearchAddresses()
+      ?.addresses
+      ?? []
+  }
+
+  /**
+   * get: pagination
+   *
+   * @returns {Pagination | null}
+   */
+  get pagination () {
+    return this.extractSearchAddresses()
+      ?.pagination
+      ?? null
+  }
+
+  /**
+   * get: totalCount
+   *
+   * @returns {number | null}
+   */
+  get totalCount () {
+    return this.pagination
+      ?.totalCount
+      ?? null
+  }
+
+  /**
+   * get: limit
+   *
+   * @returns {number | null}
+   */
+  get limit () {
+    return this.pagination
+      ?.limit
+      ?? null
+  }
+
+  /**
+   * get: offset
+   *
+   * @returns {number | null}
+   */
+  get offset () {
+    return this.pagination
+      ?.offset
+      ?? null
+  }
+}
+
+/**
+ * @typedef {{
+ *   searchAddresses: SearchAddresses
+ * }} SearchAddressesQueryResponseContent
+ */
+
+/**
+ * @typedef {{
+ *   addresses: Array<Address>
+ *   pagination: Pagination
+ * }} SearchAddresses
+ */
+
+/**
+ * @typedef {{
+ *   address: string
+ *   name: string
+ * }} Address
+ */
+
+/**
+ * @typedef {{
+ *   totalCount: number
+ *   limit: number
+ *   offset: number
+ * }} Pagination
+ */

--- a/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlLauncher.js
@@ -1,0 +1,21 @@
+import BaseAppGraphqlLauncher from '~/app/graphql/client/BaseAppGraphqlLauncher'
+
+import SearchAddressesQueryGraphqlPayload from './SearchAddressesQueryGraphqlPayload'
+import SearchAddressesQueryGraphqlCapsule from './SearchAddressesQueryGraphqlCapsule'
+
+/**
+ * SearchAddresses query graphql launcher.
+ *
+ * @extends {BaseAppGraphqlLauncher}
+ */
+export default class SearchAddressesQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
+  /** @override */
+  static get Payload () {
+    return SearchAddressesQueryGraphqlPayload
+  }
+
+  /** @override */
+  static get Capsule () {
+    return SearchAddressesQueryGraphqlCapsule
+  }
+}

--- a/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlPayload.js
@@ -1,0 +1,43 @@
+import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
+
+/**
+ * SearchAddresses query payload.
+ *
+ * @extends {BaseAppGraphqlPayload<SearchAddressesQueryRequestVariables>}
+ */
+export default class SearchAddressesQueryGraphqlPayload extends BaseAppGraphqlPayload {
+  /** @override */
+  static get document () {
+    return /* GraphQL */ `
+      query SearchAddressesQuery ($input: SearchAddressesInput!) {
+        searchAddresses (input: $input) {
+          addresses {
+            address
+            name
+          }
+          pagination {
+            totalCount
+            limit
+            offset
+          }
+        }
+      }
+    `
+  }
+}
+
+/**
+ * @typedef {{
+ *   input: {
+ *     query: string
+ *     pagination: {
+ *       limit: number
+ *       offset: number
+ *       sort?: {
+ *         targetColumn: string
+ *         orderBy: string
+ *       }
+ *     }
+ *   }
+ * }} SearchAddressesQueryRequestVariables
+ */

--- a/app/vue/contexts/search/AddressesSearchBarContext.js
+++ b/app/vue/contexts/search/AddressesSearchBarContext.js
@@ -66,11 +66,11 @@ export default class AddressesSearchBarContext extends BaseFuroContext {
    * }} params - Parameters of this method.
    * @returns {Promise<void>}
    */
-  async searchAddressesByName ({
+  async searchAddresses ({
     query,
   }) {
     await this.graphqlClientHash
-      .searchAddressesByName
+      .searchAddresses
       .invokeRequestOnEvent({
         variables: {
           input: {
@@ -81,7 +81,7 @@ export default class AddressesSearchBarContext extends BaseFuroContext {
             },
           },
         },
-        hooks: this.searchAddressesByNameLauncherHooks,
+        hooks: this.searchAddressesLauncherHooks,
       })
   }
 
@@ -119,24 +119,24 @@ export default class AddressesSearchBarContext extends BaseFuroContext {
    * @returns {Addresses}
    */
   get addresses () {
-    return this.searchAddressesByNameCapsuleRef.value.addresses
+    return this.searchAddressesCapsuleRef.value.addresses
   }
 
   /**
-   * get: searchAddressesByNameCapsuleRef
+   * get: searchAddressesCapsuleRef
    *
-   * @returns {AddressesSearchBarContext['graphqlClientHash']['searchAddressesByName']['capsuleRef']}
+   * @returns {AddressesSearchBarContext['graphqlClientHash']['searchAddresses']['capsuleRef']}
    */
-  get searchAddressesByNameCapsuleRef () {
-    return this.graphqlClientHash.searchAddressesByName.capsuleRef
+  get searchAddressesCapsuleRef () {
+    return this.graphqlClientHash.searchAddresses.capsuleRef
   }
 
   /**
-   * get: SearchAddressesByNameLauncherHooks
+   * get: searchAddressesLauncherHooks
    *
    * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
    */
-  get searchAddressesByNameLauncherHooks () {
+  get searchAddressesLauncherHooks () {
     return {
       beforeRequest: async payload => {
         this.statusReactive.isLoading = true
@@ -171,7 +171,7 @@ export default class AddressesSearchBarContext extends BaseFuroContext {
  */
 
 /**
- * @typedef {'searchAddressesByName'} GraphqlClientHashKeys
+ * @typedef {'searchAddresses'} GraphqlClientHashKeys
  */
 
 /**
@@ -185,7 +185,5 @@ export default class AddressesSearchBarContext extends BaseFuroContext {
  */
 
 /**
- * @typedef {import('~/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlCapsule')
- *   .ResponseContent['searchAddressesByName']['addresses']
- * } Addresses
+ * @typedef {Array<import('~/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlCapsule').Address>} Addresses
  */

--- a/components/search/AddressesSearchBarHeader.vue
+++ b/components/search/AddressesSearchBarHeader.vue
@@ -14,7 +14,7 @@ import {
   useGraphqlClient,
 } from '@openreachtech/furo-nuxt'
 
-import SearchAddressesByNameQueryGraphqlLauncher from '~/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlLauncher'
+import SearchAddressesQueryGraphqlLauncher from '~/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlLauncher'
 
 import AddressesSearchBarContext from '~/app/vue/contexts/search/AddressesSearchBarContext'
 
@@ -31,14 +31,14 @@ export default defineComponent({
     const statusReactive = reactive({
       isLoading: false,
     })
-    const searchAddressesByNameGraphqlClient = useGraphqlClient(SearchAddressesByNameQueryGraphqlLauncher)
+    const searchAddressesGraphqlClient = useGraphqlClient(SearchAddressesQueryGraphqlLauncher)
 
     const args = {
       props,
       componentContext,
       statusReactive,
       graphqlClientHash: {
-        searchAddressesByName: searchAddressesByNameGraphqlClient,
+        searchAddresses: searchAddressesGraphqlClient,
       },
     }
     const context = AddressesSearchBarContext.create(args)
@@ -57,7 +57,7 @@ export default defineComponent({
     :is-loading="context.isLoading"
     placeholder="Search by address, name..."
     :results="context.addresses"
-    @search="query => context.searchAddressesByName({
+    @search="query => context.searchAddresses({
       query,
     })"
   >

--- a/components/search/AddressesSearchBarSide.vue
+++ b/components/search/AddressesSearchBarSide.vue
@@ -15,7 +15,7 @@ import {
   useGraphqlClient,
 } from '@openreachtech/furo-nuxt'
 
-import SearchAddressesByNameQueryGraphqlLauncher from '~/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlLauncher'
+import SearchAddressesQueryGraphqlLauncher from '~/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlLauncher'
 
 import AddressesSearchBarSideContext from '~/app/vue/contexts/search/AddressesSearchBarSideContext'
 
@@ -33,14 +33,14 @@ export default defineComponent({
     const statusReactive = reactive({
       isLoading: false,
     })
-    const searchAddressesByNameGraphqlClient = useGraphqlClient(SearchAddressesByNameQueryGraphqlLauncher)
+    const searchAddressesGraphqlClient = useGraphqlClient(SearchAddressesQueryGraphqlLauncher)
 
     const args = {
       props,
       componentContext,
       statusReactive,
       graphqlClientHash: {
-        searchAddressesByName: searchAddressesByNameGraphqlClient,
+        searchAddresses: searchAddressesGraphqlClient,
       },
     }
     const context = AddressesSearchBarSideContext.create(args)
@@ -58,7 +58,7 @@ export default defineComponent({
     :class="context.generateSearchClasses()"
   >
     <AppSearchBar placeholder="Search by address, name..."
-      @search="query => context.searchAddressesByName({
+      @search="query => context.searchAddresses({
         query,
       })"
     />


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1755

# How

* Use `searchAddresses` instead of `searchAddressesByName` when searching for users.
