### PR TITLE
Update JSDoc of BaseAppGraphqlLauncher to remove generic

### DIFF
--- a/app/graphql/client/BaseAppGraphqlLauncher.js
+++ b/app/graphql/client/BaseAppGraphqlLauncher.js
@@ -5,10 +5,9 @@ import {
 import graphqlConfig from '~/app/graphql/graphql.config'
 
 /**
- * Company sponsors query graphql launcher.
+ * Base class for all app graphql launchers.
  *
- * @template T
- * @extends {BaseGraphqlLauncher<typeof BaseAppGraphqlLauncher>}
+ * @extends {BaseGraphqlLauncher}
  */
 export default class BaseAppGraphqlLauncher extends BaseGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlLauncher.js
@@ -5,7 +5,7 @@ import AddCompetitionMutationGraphqlCapsule from '~/app/graphql/client/mutations
 /**
  * AddCompetitionMutation graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof AddCompetitionMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class AddCompetitionMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlLauncher.js
+++ b/app/graphql/client/mutations/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlLauncher.js
@@ -6,7 +6,7 @@ import CompetitionFinalOutcomeQueryGraphqlCapsule from './CompetitionFinalOutcom
 /**
  * CompetitionFinalOutcome query graphql launcher.
  *
- * @extends {BaseAppGraphqlLauncher<typeof CompetitionFinalOutcomeQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class CompetitionFinalOutcomeQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/joinCompetition/JoinCompetitionMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/joinCompetition/JoinCompetitionMutationGraphqlLauncher.js
@@ -5,7 +5,7 @@ import JoinCompetitionMutationGraphqlCapsule from './JoinCompetitionMutationGrap
 /**
  * JoinCompetitionMutation graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof JoinCompetitionMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class JoinCompetitionMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/putAddressName/PutAddressNameMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/putAddressName/PutAddressNameMutationGraphqlLauncher.js
@@ -5,7 +5,7 @@ import PutAddressNameMutationGraphqlCapsule from './PutAddressNameMutationGraphq
 /**
  * PutAddressNameMutation graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof PutAddressNameMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class PutAddressNameMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/unregisterFromCompetition/UnregisterFromCompetitionMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/unregisterFromCompetition/UnregisterFromCompetitionMutationGraphqlLauncher.js
@@ -6,7 +6,7 @@ import UnregisterFromCompetitionMutationGraphqlCapsule from './UnregisterFromCom
 /**
  * UnregisterFromCompetition mutation graphql launcher.
  *
- * @extends {BaseAppGraphqlLauncher<typeof UnregisterFromCompetitionMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class UnregisterFromCompetitionMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/updateCompetition/UpdateCompetitionMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/updateCompetition/UpdateCompetitionMutationGraphqlLauncher.js
@@ -5,7 +5,7 @@ import UpdateCompetitionMutationGraphqlCapsule from './UpdateCompetitionMutation
 /**
  * UpdateCompetitionMutation graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof UpdateCompetitionMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class UpdateCompetitionMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/updateCompetitionPrizeRules/UpdateCompetitionPrizeRulesMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/updateCompetitionPrizeRules/UpdateCompetitionPrizeRulesMutationGraphqlLauncher.js
@@ -5,7 +5,7 @@ import UpdateCompetitionPrizeRulesMutationGraphqlCapsule from './UpdateCompetiti
 /**
  * UpdateCompetitionPrizeRulesMutation graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof UpdateCompetitionPrizeRulesMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class UpdateCompetitionPrizeRulesMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/updateCompetitionSchedules/UpdateCompetitionSchedulesMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/updateCompetitionSchedules/UpdateCompetitionSchedulesMutationGraphqlLauncher.js
@@ -5,7 +5,7 @@ import UpdateCompetitionSchedulesMutationGraphqlCapsule from './UpdateCompetitio
 /**
  * UpdateCompetitionSchedulesMutation graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof UpdateCompetitionSchedulesMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class UpdateCompetitionSchedulesMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/updateCompetitionStatus/UpdateCompetitionStatusMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/updateCompetitionStatus/UpdateCompetitionStatusMutationGraphqlLauncher.js
@@ -5,7 +5,7 @@ import UpdateCompetitionStatusMutationGraphqlCapsule from './UpdateCompetitionSt
 /**
  * UpdateCompetitionStatusMutation graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof UpdateCompetitionStatusMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class UpdateCompetitionStatusMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/mutations/uploadImage/UploadImageMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/uploadImage/UploadImageMutationGraphqlLauncher.js
@@ -5,7 +5,7 @@ import UploadImageMutationGraphqlCapsule from './UploadImageMutationGraphqlCapsu
 /**
  * UploadImageMutation graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof UploadImageMutationGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class UploadImageMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlLauncher.js
@@ -5,7 +5,7 @@ import AddressCurrentCompetitionQueryGraphqlPayload from '~/app/graphql/client/q
 /**
  * AddressCurrentCompetitionQuery graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof AddressCurrentCompetitionQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class AddressCurrentCompetitionQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/addressCurrentCompetitionTransfers/AddressCurrentCompetitionTransfersQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/addressCurrentCompetitionTransfers/AddressCurrentCompetitionTransfersQueryGraphqlLauncher.js
@@ -5,7 +5,7 @@ import AddressCurrentCompetitionTransfersQueryGraphqlPayload from '~/app/graphql
 /**
  * AddressCurrentCompetitionTransfersQuery graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof AddressCurrentCompetitionTransfersQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class AddressCurrentCompetitionTransfersQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/addressName/AddressNameQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/addressName/AddressNameQueryGraphqlLauncher.js
@@ -5,7 +5,7 @@ import AddressNameQueryGraphqlCapsule from './AddressNameQueryGraphqlCapsule'
 /**
  * AddressNameQuery graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof AddressNameQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class AddressNameQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/addressPastCompetitions/AddressPastCompetitionsQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/addressPastCompetitions/AddressPastCompetitionsQueryGraphqlLauncher.js
@@ -5,7 +5,7 @@ import AddressPastCompetitionsQueryGraphqlCapsule from '~/app/graphql/client/que
 /**
  * AddressPastCompetitionsQuery graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof AddressPastCompetitionsQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class AddressPastCompetitionsQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/competition/CompetitionQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/competition/CompetitionQueryGraphqlLauncher.js
@@ -5,7 +5,7 @@ import CompetitionQueryGraphqlCapsule from '~/app/graphql/client/queries/competi
 /**
  * Competition query graphql launcher.
  *
- * @extends {BaseAppGraphqlLauncher<typeof CompetitionQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class CompetitionQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlLauncher.js
@@ -5,7 +5,7 @@ import CompetitionLeaderboardQueryGraphqlCapsule from '~/app/graphql/client/quer
 /**
  * CompetitionLeaderboardQuery graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof CompetitionLeaderboardQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class CompetitionLeaderboardQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/competitionParticipant/CompetitionParticipantQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/competitionParticipant/CompetitionParticipantQueryGraphqlLauncher.js
@@ -6,7 +6,7 @@ import CompetitionParticipantQueryGraphqlCapsule from './CompetitionParticipantQ
 /**
  * CompetitionParticipant query graphql launcher.
  *
- * @extends {BaseAppGraphqlLauncher<typeof CompetitionParticipantQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class CompetitionParticipantQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/competitionParticipantStatuses/CompetitionParticipantStatusesQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/competitionParticipantStatuses/CompetitionParticipantStatusesQueryGraphqlLauncher.js
@@ -6,7 +6,7 @@ import CompetitionParticipantStatusesQueryGraphqlCapsule from './CompetitionPart
 /**
  * CompetitionParticipant query graphql launcher.
  *
- * @extends {BaseAppGraphqlLauncher<typeof CompetitionParticipantStatusesQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class CompetitionParticipantStatusesQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlLauncher.js
@@ -6,7 +6,7 @@ import CompetitionParticipantsQueryGraphqlCapsule from './CompetitionParticipant
 /**
  * CompetitionParticipants query graphql launcher.
  *
- * @extends {BaseAppGraphqlLauncher<typeof CompetitionParticipantsQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class CompetitionParticipantsQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/competitionStatistics/CompetitionStatisticsQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/competitionStatistics/CompetitionStatisticsQueryGraphqlLauncher.js
@@ -6,7 +6,7 @@ import CompetitionStatisticsQueryGraphqlCapsule from './CompetitionStatisticsQue
 /**
  * Competition Statistics query graphql launcher.
  *
- * @extends {BaseAppGraphqlLauncher<typeof CompetitionStatisticsQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class CompetitionStatisticsQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher.js
@@ -5,7 +5,7 @@ import CompetitionsQueryGraphqlCapsule from '~/app/graphql/client/queries/compet
 /**
  * Competitions query graphql launcher.
  *
- * @extends {BaseAppGraphqlLauncher<typeof CompetitionsQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class CompetitionsQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */

--- a/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlLauncher.js
@@ -5,7 +5,7 @@ import SearchAddressesByNameQueryGraphqlCapsule from '~/app/graphql/client/queri
 /**
  * SearchAddressesByNameQuery graphql launcher
  *
- * @extends {BaseAppGraphqlLauncher<typeof SearchAddressesByNameQueryGraphqlLauncher>}
+ * @extends {BaseAppGraphqlLauncher}
  */
 export default class SearchAddressesByNameQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
   /** @override */


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2404

# How

* BaseGraphqlLauncher in newer furo-nuxt versions does not require a generic.
