### PR TITLE
Fix incorrect status key when unregistering from competition

### DIFF
--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -89,7 +89,7 @@ export default defineComponent({
       isLoadingLeaderboard: true,
       isLoadingParticipant: true,
       isLoadingEnrolledParticipantsNumber: true,
-      isUnregisteringCompetition: false,
+      isUnregisteringFromCompetition: false,
     })
     const mutationStatusReactive = reactive({
       isJoining: false,


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2408

# How

* Fix incorrect status key when unregistering from competition.
