### PR TITLE
Disable enrollment button if the enrolled amount has already reached the upper limit

### DIFF
--- a/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule.js
@@ -64,6 +64,28 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
       ?.statusId
       ?? null
   }
+
+  /**
+   * get: participantUpperLimit
+   *
+   * @returns {number | null}
+   */
+  get participantUpperLimit () {
+    return this.extractCompetition()
+      ?.participantUpperLimit
+      ?? null
+  }
+
+  /**
+   * get: participantLowerLimit
+   *
+   * @returns {number | null}
+   */
+  get participantLowerLimit () {
+    return this.extractCompetition()
+      ?.participantLowerLimit
+      ?? null
+  }
 }
 
 /**

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -812,6 +812,26 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   }
 
   /**
+   * get: participantUpperLimit
+   *
+   * @returns {number | null}
+   */
+  get participantUpperLimit () {
+    return this.competitionCapsuleRef.value
+      .participantUpperLimit
+  }
+
+  /**
+   * get: participantLowerLimit
+   *
+   * @returns {number | null}
+   */
+  get participantLowerLimit () {
+    return this.competitionCapsuleRef.value
+      .participantLowerLimit
+  }
+
+  /**
    * get: competitionStatusId
    *
    * @returns {number | null}
@@ -957,6 +977,22 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   get enrolledParticipantsNumber () {
     return this.competitionEnrolledParticipantsNumberCapsule
       .enrolledParticipantsNumber
+  }
+
+  /**
+   * Check if the competition is full.
+   *
+   * @returns {boolean}
+   */
+  isCompetitionFull () {
+    if (
+      this.enrolledParticipantsNumber === null
+      || this.participantUpperLimit === null
+    ) {
+      return false
+    }
+
+    return this.enrolledParticipantsNumber >= this.participantUpperLimit
   }
 
   /**

--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -17,12 +17,14 @@ import CompetitionBadgeContext from '~/app/vue/contexts/badges/CompetitionBadgeC
 const ENROLLMENT_STATUS = {
   ENROLLED: 'enrolled',
   NOT_ENROLLED: 'notEnrolled',
+  NOT_ENROLLED_BUT_FULL: 'notEnrolledButFull',
   ENROLLMENT_CLOSED: 'enrollmentClosed',
 }
 
 const ENROLLMENT_ACTION_TEXT = {
   [ENROLLMENT_STATUS.ENROLLED]: 'You have enrolled',
   [ENROLLMENT_STATUS.NOT_ENROLLED]: 'Enroll now',
+  [ENROLLMENT_STATUS.NOT_ENROLLED_BUT_FULL]: 'Max participants reached',
   [ENROLLMENT_STATUS.ENROLLMENT_CLOSED]: 'Registration ended',
   DEFAULT: 'Enroll now',
 }
@@ -142,6 +144,15 @@ export default class SectionLeagueContext extends BaseFuroContext {
    */
   get enrolledParticipantsNumber () {
     return this.props.enrolledParticipantsNumber
+  }
+
+  /**
+   * get: isCompetitionFull
+   *
+   * @returns {PropsType['isCompetitionFull']}
+   */
+  get isCompetitionFull () {
+    return this.props.isCompetitionFull
   }
 
   /**
@@ -668,6 +679,7 @@ export default class SectionLeagueContext extends BaseFuroContext {
     const enrollmentStatus = this.generateEnrollmentStatus()
 
     return [
+      ENROLLMENT_STATUS.NOT_ENROLLED_BUT_FULL,
       ENROLLMENT_STATUS.ENROLLMENT_CLOSED,
     ]
       .includes(enrollmentStatus)
@@ -685,6 +697,10 @@ export default class SectionLeagueContext extends BaseFuroContext {
 
     if (this.isEnrollmentClosed()) {
       return ENROLLMENT_STATUS.ENROLLMENT_CLOSED
+    }
+
+    if (this.isCompetitionFull) {
+      return ENROLLMENT_STATUS.NOT_ENROLLED_BUT_FULL
     }
 
     return ENROLLMENT_STATUS.NOT_ENROLLED
@@ -878,5 +894,6 @@ export default class SectionLeagueContext extends BaseFuroContext {
  *   participantStatusId: number | null
  *   competitionStatusId: number | null
  *   enrolledParticipantsNumber: number | null
+ *   isCompetitionFull: boolean
  * }} PropsType
  */

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -69,6 +69,10 @@ export default defineComponent({
       ],
       required: true,
     },
+    isCompetitionFull: {
+      type: Boolean,
+      required: true,
+    },
   },
 
   emits: [

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -150,6 +150,7 @@ export default defineComponent({
   <div>
     <SectionLeague :competition="context.competition"
       :participant-status-id="context.participantStatusId"
+      :is-competition-full="context.isCompetitionFull()"
       :competition-status-id="context.competitionStatusId"
       :enrolled-participants-number="context.enrolledParticipantsNumber"
       @show-cancelation-dialog="context.showDialog({


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2397

# How

* Disable enrollment button if the enrolled amount has already reached the upper limit.

> [!note]
> - The refactoring logic for `enrollmentStatus` is included in another PR because I have already posted this one first...
> - After register/unregister, we should update the participants amount. I'm going to do it in another PR.
