### PR TITLE
Use more appropriate label for participant upper limit

### DIFF
--- a/components/units/AppLeagueCard.vue
+++ b/components/units/AppLeagueCard.vue
@@ -108,7 +108,7 @@ export default defineComponent({
           </span>
 
           <span class="unit">
-            participants
+            max participants
           </span>
         </span>
       </div>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2453

# How

* Use more appropriate label for participant upper limit.

# Screenshots

"participants" → "max participants".

![image](https://github.com/user-attachments/assets/e5d445ad-4e4e-4ed2-a9bb-ccaadd0674af)

