### PR TITLE
Extract top three rankers independently

### DIFF
--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -34,6 +34,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
     walletStore,
     graphqlClientHash,
     leaderboardEntriesRef,
+    topThreeLeaderboardEntriesRef,
     competitionCancelationDialogRef,
     statusReactive,
   }) {
@@ -46,6 +47,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
     this.walletStore = walletStore
     this.graphqlClientHash = graphqlClientHash
     this.leaderboardEntriesRef = leaderboardEntriesRef
+    this.topThreeLeaderboardEntriesRef = topThreeLeaderboardEntriesRef
     this.competitionCancelationDialogRef = competitionCancelationDialogRef
     this.statusReactive = statusReactive
   }
@@ -66,6 +68,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
     walletStore,
     graphqlClientHash,
     leaderboardEntriesRef,
+    topThreeLeaderboardEntriesRef,
     competitionCancelationDialogRef,
     statusReactive,
   }) {
@@ -77,6 +80,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
         walletStore,
         graphqlClientHash,
         leaderboardEntriesRef,
+        topThreeLeaderboardEntriesRef,
         competitionCancelationDialogRef,
         statusReactive,
       })
@@ -813,6 +817,15 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   }
 
   /**
+   * get: topThreeLeaderboardEntries
+   *
+   * @returns {LeaderboardEntries}
+   */
+  get topThreeLeaderboardEntries () {
+    return this.topThreeLeaderboardEntriesRef.value
+  }
+
+  /**
    * get: competitionCancelationDialog
    *
    * @returns {import('~/components/units/AppDialog.vue').default | null}
@@ -1188,6 +1201,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
  *   route: ReturnType<import('vue-router').useRoute>
  *   walletStore: import('~/stores/wallet').WalletStore
  *   leaderboardEntriesRef: import('vue').Ref<LeaderboardEntries>
+ *   topThreeLeaderboardEntriesRef: import('vue').Ref<LeaderboardEntries>
  *   competitionCancelationDialogRef: import('vue').Ref<import('~/components/units/AppDialog.vue').default | null>
  *   graphqlClientHash: {
  *     competition: GraphqlClient

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -250,12 +250,14 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
           hooks: this.competitionLauncherHooks,
         })
 
-      await this.fetchLeaderboardEntries()
-
+      // Top three and leaderboard invoke the same query.
+      // Make sure top three runs first to receive correct pagination result.
       const currentPage = this.extractCurrentPage()
       if (currentPage !== 1) {
         await this.fetchTopThreeLeaderboardEntries()
       }
+
+      await this.fetchLeaderboardEntries()
     })
 
     this.watch(

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -252,10 +252,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
 
       // Top three and leaderboard invoke the same query.
       // Make sure top three runs first to receive correct pagination result.
-      const currentPage = this.extractCurrentPage()
-      if (currentPage !== 1) {
-        await this.fetchTopThreeLeaderboardEntries()
-      }
+      await this.fetchTopThreeLeaderboardEntries()
 
       await this.fetchLeaderboardEntries()
     })
@@ -745,13 +742,6 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
         this.leaderboardEntriesRef.value = this.normalizeOngoingLeaderboardEntries({
           rankings: capsule.rankings,
         })
-
-        const currentPage = this.extractCurrentPage()
-        if (currentPage === 1) {
-          this.topThreeLeaderboardEntriesRef.value = this.normalizeOngoingTopThree({
-            rankings: capsule.rankings,
-          })
-        }
       },
     }
   }
@@ -781,13 +771,6 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
         this.leaderboardEntriesRef.value = this.normalizeLeaderboardFinalOutcomeEntries({
           outcomes: capsule.outcomes,
         })
-
-        const currentPage = this.extractCurrentPage()
-        if (currentPage === 1) {
-          this.topThreeLeaderboardEntriesRef.value = this.normalizeTopThreeFinalOutcome({
-            outcomes: capsule.outcomes,
-          })
-        }
       },
     }
   }

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -1201,7 +1201,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
  *   route: ReturnType<import('vue-router').useRoute>
  *   walletStore: import('~/stores/wallet').WalletStore
  *   leaderboardEntriesRef: import('vue').Ref<LeaderboardEntries>
- *   topThreeLeaderboardEntriesRef: import('vue').Ref<LeaderboardEntries>
+ *   topThreeLeaderboardEntriesRef: import('vue').Ref<TopThreeLeaderboardEntries>
  *   competitionCancelationDialogRef: import('vue').Ref<import('~/components/units/AppDialog.vue').default | null>
  *   graphqlClientHash: {
  *     competition: GraphqlClient
@@ -1283,6 +1283,21 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
  *   outcomeBaseline: number
  *   outcomePrize: string
  * }} NormalizedLeaderboardFinalOutcomeEntry
+ */
+
+/**
+ * @typedef {Array<NormalizedTopThreeLeaderboardEntry>} TopThreeLeaderboardEntries
+ */
+
+/**
+ * @typedef {{
+ *   rank: number
+ *   name: string
+ *   address: string
+ *   pnl: number
+ *   roi: number
+ *   prize: string | null
+ * }} NormalizedTopThreeLeaderboardEntry
  */
 
 /**

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -1016,7 +1016,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   /**
    * get: topThreeLeaderboardEntries
    *
-   * @returns {LeaderboardEntries}
+   * @returns {TopThreeLeaderboardEntries}
    */
   get topThreeLeaderboardEntries () {
     return this.topThreeLeaderboardEntriesRef.value

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -1229,6 +1229,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
  * @typedef {{
  *   isLoading: boolean
  *   isLoadingLeaderboard: boolean
+ *   isLoadingTopThree: boolean
  *   isLoadingParticipant: boolean
  *   isLoadingEnrolledParticipantsNumber: boolean
  *   isUnregisteringFromCompetition: boolean

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -65,6 +65,15 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   }
 
   /**
+   * get: topThreeLeaderboardEntries
+   *
+   * @returns {PropsType['topThreeLeaderboardEntries']} Top three leaderboard entries.
+   */
+  get topThreeLeaderboardEntries () {
+    return this.props.topThreeLeaderboardEntries
+  }
+
+  /**
    * get: leaderboardPaginationResult
    *
    * @returns {PropsType['leaderboardPaginationResult']} Pagination result.
@@ -123,29 +132,18 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   /**
    * Extract top three rankers.
    *
-   * @returns {Array<TopRanker | null>} Top three rankers.
+   * @returns {Array<import('~/app/vue/contexts/CompetitionDetailsPageContext').NormalizedTopThreeLeaderboardEntry | null>} Top three rankers.
    */
   generateTopThree () {
     if (this.shouldHideTopRankers()) {
       return []
     }
 
-    // Narrow type of this.competitionStatusId for extractor hash.
-    if (this.competitionStatusId === null) {
-      return []
-    }
-
-    const topRankerExtractorHash = {
-      [COMPETITION_STATUS.IN_PROGRESS.ID]: this.extractTopThreeOngoingLeaderboardEntries(),
-      [COMPETITION_STATUS.COMPLETED.ID]: this.extractTopThreeLeaderboardFinalOutcomeEntries(),
-    }
-
-    const firstThreeRankers = topRankerExtractorHash[this.competitionStatusId]
-      ?? []
-
     return Array.from(
       { length: 3 },
-      (it, index) => firstThreeRankers.at(index) ?? null
+      (it, index) => this.topThreeLeaderboardEntries
+        .at(index)
+        ?? null
     )
   }
 
@@ -426,6 +424,7 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
  *   isLoadingLeaderboard: boolean
  *   leaderboardTableHeaderEntries: Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>
  *   leaderboardTableEntries: import('~/app/vue/contexts/CompetitionDetailsPageContext').LeaderboardEntries
+ *   topThreeLeaderboardEntries: import('~/app/vue/contexts/CompetitionDetailsPageContext').TopThreeLeaderboardEntries
  *   leaderboardPaginationResult: PaginationResult
  *   lastLeaderboardUpdateTimestamp: string | null
  * }} PropsType

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -148,60 +148,6 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   }
 
   /**
-   * Extract first three ongoing leaderboard entries.
-   *
-   * @returns {Array<TopRanker>}
-   */
-  extractTopThreeOngoingLeaderboardEntries () {
-    if (this.competitionStatusId !== COMPETITION_STATUS.IN_PROGRESS.ID) {
-      return []
-    }
-
-    // Type assertion as TypeScript can not narrow the type of entries with the current structure.
-    const leaderboardEntries = /** @type {Array<import('~/app/vue/contexts/CompetitionDetailsPageContext').NormalizedOngoingLeaderboardEntry>} */ (
-      this.leaderboardTableEntries
-    )
-
-    return leaderboardEntries
-      .slice(0, 3)
-      .map(entry => ({
-        rank: entry.ongoingRank,
-        name: entry.ongoingName,
-        address: entry.ongoingAddress,
-        pnl: entry.ongoingPnl,
-        roi: entry.ongoingRoi,
-        prize: null,
-      }))
-  }
-
-  /**
-   * Extract first three leaderboard final outcome entries.
-   *
-   * @returns {Array<TopRanker>}
-   */
-  extractTopThreeLeaderboardFinalOutcomeEntries () {
-    if (this.competitionStatusId !== COMPETITION_STATUS.COMPLETED.ID) {
-      return []
-    }
-
-    // Type assertion as TypeScript can not narrow the type of entries with the current structure.
-    const leaderboardEntries = /** @type {Array<import('~/app/vue/contexts/CompetitionDetailsPageContext').NormalizedLeaderboardFinalOutcomeEntry>} */ (
-      this.leaderboardTableEntries
-    )
-
-    return leaderboardEntries
-      .slice(0, 3)
-      .map(entry => ({
-        rank: entry.outcomeRank,
-        name: entry.outcomeName,
-        address: entry.outcomeAddress,
-        pnl: entry.outcomePnl,
-        roi: entry.outcomeRoi,
-        prize: entry.outcomePrize,
-      }))
-  }
-
-  /**
    * Whether to hide top rankers or not.
    *
    * @returns {boolean}
@@ -428,15 +374,4 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
  *   leaderboardPaginationResult: PaginationResult
  *   lastLeaderboardUpdateTimestamp: string | null
  * }} PropsType
- */
-
-/**
- * @typedef {{
- *   rank: number
- *   name: string
- *   address: string
- *   pnl: number
- *   roi: number
- *   prize: string | null
- * }} TopRanker
  */

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -53,6 +53,15 @@ export default defineComponent({
       type: Array,
       required: true,
     },
+    topThreeLeaderboardEntries: {
+      /**
+       * @type {import('vue').PropType<
+       *   import('~/app/vue/contexts/competition/SectionLeaderboardContext').PropsType['topThreeLeaderboardEntries']
+       * >}
+       */
+      type: Array,
+      required: true,
+    },
     leaderboardPaginationResult: {
       /**
        * @type {import('vue').PropType<

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -89,6 +89,7 @@ export default defineComponent({
     const statusReactive = reactive({
       isLoading: false,
       isLoadingLeaderboard: true,
+      isLoadingTopThree: true,
       isLoadingParticipant: true,
       isLoadingEnrolledParticipantsNumber: true,
       isUnregisteringFromCompetition: false,

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -65,7 +65,7 @@ export default defineComponent({
 
     /** @type {import('vue').Ref<import('~/app/vue/contexts/CompetitionDetailsPageContext').LeaderboardEntries>} */
     const leaderboardEntriesRef = ref([])
-    /** @type {import('vue').Ref<import('~/app/vue/contexts/CompetitionDetailsPageContext').LeaderboardEntries>} */
+    /** @type {import('vue').Ref<import('~/app/vue/contexts/CompetitionDetailsPageContext').TopThreeLeaderboardEntries>} */
     const topThreeLeaderboardEntriesRef = ref([])
 
     const competitionGraphqlClient = useGraphqlClient(CompetitionQueryGraphqlLauncher)

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -65,6 +65,8 @@ export default defineComponent({
 
     /** @type {import('vue').Ref<import('~/app/vue/contexts/CompetitionDetailsPageContext').LeaderboardEntries>} */
     const leaderboardEntriesRef = ref([])
+    /** @type {import('vue').Ref<import('~/app/vue/contexts/CompetitionDetailsPageContext').LeaderboardEntries>} */
+    const topThreeLeaderboardEntriesRef = ref([])
 
     const competitionGraphqlClient = useGraphqlClient(CompetitionQueryGraphqlLauncher)
     const joinCompetitionGraphqlClient = useGraphqlClient(JoinCompetitionMutationGraphqlLauncher)
@@ -101,6 +103,7 @@ export default defineComponent({
       route,
       walletStore,
       leaderboardEntriesRef,
+      topThreeLeaderboardEntriesRef,
       competitionCancelationDialogRef,
       graphqlClientHash: {
         competition: competitionGraphqlClient,

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -177,6 +177,7 @@ export default defineComponent({
     <SectionSchedules :schedules="context.schedules" />
 
     <SectionLeaderboard :competition-status-id="context.competitionStatusId"
+      :top-three-leaderboard-entries="context.topThreeLeaderboardEntries"
       :leaderboard-table-entries="context.leaderboardEntries"
       :leaderboard-table-header-entries="context.generateLeaderboardHeaderEntries()"
       :is-loading-leaderboard="context.isLoadingLeaderboard"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2492

# How

* Create a dedicated ref for top three leaderboard entries.
* On first page, the top three are extracted from leaderboard entries.
* From second page onward, a separate API call will be made to fetch the top three.

# Screencasts

https://github.com/user-attachments/assets/aa4844c7-e931-4c95-9750-0b18c0951575
