### PR TITLE
Add Google tag for Analytics

### DIFF
--- a/.furo-env.development
+++ b/.furo-env.development
@@ -1,1 +1,2 @@
 ENDPOINT_URL = http://localhost:3900/graphql-customer
+GTAG_ID = your_gtag_id_here

--- a/plugins/001.gtag.client.js
+++ b/plugins/001.gtag.client.js
@@ -1,0 +1,60 @@
+import {
+  defineNuxtPlugin,
+  useHead,
+  useRuntimeConfig,
+} from '#imports'
+
+export default defineNuxtPlugin({
+  parallel: true,
+  setup () {
+    const runtimeConfig = useRuntimeConfig()
+    const gtagId = runtimeConfig.public.GTAG_ID
+
+    initializeGtag({
+      gtagId,
+    })
+
+    useHead({
+      // Preload to ensure gtag.js is loaded as soon as possible.
+      link: [
+        {
+          rel: 'preload',
+          as: 'script',
+          href: `https://www.googletagmanager.com/gtag/js?id=${gtagId}`,
+        },
+      ],
+      script: [
+        {
+          src: `https://www.googletagmanager.com/gtag/js?id=${gtagId}`,
+          async: true,
+        },
+      ],
+    })
+  },
+})
+
+/**
+ * Initialize the Google tag.
+ *
+ * @param {{
+ *   gtagId: string
+ * }} params - Parameters.
+ * @returns {void}
+ */
+function initializeGtag ({
+  gtagId,
+}) {
+  window.dataLayer ||= []
+
+  gtag('js', new Date())
+  gtag('config', gtagId)
+}
+
+/**
+ * Function provided by Google Tag.
+ */
+function gtag () {
+  // Rest parameters does not work. Must use `arguments`.
+  // eslint-disable-next-line prefer-rest-params
+  window.dataLayer?.push(arguments)
+}

--- a/plugins/001.gtag.client.js
+++ b/plugins/001.gtag.client.js
@@ -7,6 +7,11 @@ import {
 export default defineNuxtPlugin({
   parallel: true,
   setup () {
+    // Should only enable Google Tag in production.
+    if (import.meta.env.MODE !== 'production') {
+      return
+    }
+
     const runtimeConfig = useRuntimeConfig()
     const gtagId = runtimeConfig.public.GTAG_ID
 

--- a/types/window.d.ts
+++ b/types/window.d.ts
@@ -6,6 +6,9 @@ declare global {
   interface Window extends KeplrWindow {
     // TODO: Find type for phantom. Might need a library.
     phantom?: any;
+
+    // For Google Tag. Don't know the exact type.
+    dataLayer?: Array<any>
   }
 }
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2507

# How

* Add Google tag for Analytics through a client plugin.
* It only runs on the client.
* It only runs during production to reduce noise in our analytics.

# Screenshots

![image](https://github.com/user-attachments/assets/883d921e-da9f-4060-b732-916b09bb8100)

