### PR TITLE
Add intercardinal positions for AppTooltip

### DIFF
--- a/app/vue/contexts/AppTooltipContext.js
+++ b/app/vue/contexts/AppTooltipContext.js
@@ -86,8 +86,12 @@ export default class AppTooltipContext extends BaseFuroContext {
 
 /**
  * @typedef {'top'
+ *   | 'top-start'
+ *   | 'top-end'
  *   | 'right'
  *   | 'bottom'
+ *   | 'bottom-start'
+ *   | 'bottom-end'
  *   | 'left'
  * } TooltipPosition
  */

--- a/components/units/AppTooltip.vue
+++ b/components/units/AppTooltip.vue
@@ -11,6 +11,18 @@ export default defineComponent({
       type: /** @type {import('vue').PropType<import('~/app/vue/contexts/AppTooltipContext').TooltipPosition>} */ (String),
       required: false,
       default: 'top',
+      /** @type {(value: string) => boolean} */
+      validator: value => [
+        'top',
+        'top-start',
+        'top-end',
+        'right',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'left',
+      ]
+        .includes(value),
     },
     message: {
       type: String,

--- a/components/units/AppTooltip.vue
+++ b/components/units/AppTooltip.vue
@@ -149,6 +149,38 @@ export default defineComponent({
   );
 }
 
+.unit-tooltip.top-start > .message {
+  bottom: calc(100% + 0.75rem);
+  right: 0;
+}
+
+.unit-tooltip.top-start > .message::before {
+  top: 100%;
+  right: 0;
+
+  clip-path: polygon(
+    0% 0%,
+    50% 100%,
+    50% 0%
+  );
+}
+
+.unit-tooltip.top-end > .message {
+  bottom: calc(100% + 0.75rem);
+  left: 0;
+}
+
+.unit-tooltip.top-end > .message::before {
+  top: 100%;
+  left: 0;
+
+  clip-path: polygon(
+    50% 0%,
+    50% 100%,
+    100% 0%
+  );
+}
+
 .unit-tooltip.right > .message {
   left: calc(100% + 0.75rem);
 }
@@ -173,6 +205,38 @@ export default defineComponent({
   clip-path: polygon(
     0% 100%,
     50% 0%,
+    100% 100%
+  );
+}
+
+.unit-tooltip.bottom-start > .message {
+  top: calc(100% + 0.75rem);
+  right: 0;
+}
+
+.unit-tooltip.bottom-start > .message::before {
+  bottom: 100%;
+  right: 0;
+
+  clip-path: polygon(
+    0% 100%,
+    50% 0%,
+    50% 100%
+  );
+}
+
+.unit-tooltip.bottom-end > .message {
+  top: calc(100% + 0.75rem);
+  left: 0;
+}
+
+.unit-tooltip.bottom-end > .message::before {
+  bottom: 100%;
+  left: 0;
+
+  clip-path: polygon(
+    50% 0%,
+    50% 100%,
     100% 100%
   );
 }


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2591

# How

* Add intercardinal positions for AppTooltip.
* This is a workaround for the overflowing issue of pop-up elements. Even though the pop-ups are implemented with `position: absolute`, they still contribute to the scroll flow of the parent container, which causes the behavior in the below screencast to occur.

https://github.com/user-attachments/assets/a62571c6-4ab2-4a9d-b3c9-129a2133669a

* A better option would be using `position: fixed` and then calculate the position with JavaScript. However, we also need to teleport the element to an outside div. Let's discuss it later.

# Screenshots

Tooltips that use `top-start` and `bottom-start` position:

![Screenshot From 2025-04-24 17-13-50](https://github.com/user-attachments/assets/e108f50b-2be9-415d-bb7a-1f37b766e650)

![Screenshot From 2025-04-24 17-13-37](https://github.com/user-attachments/assets/c9a4b2e3-2486-46d2-9c99-99b382c982bf)

