### PR TITLE
Add competition edit button to competition details page

### DIFF
--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -129,6 +129,15 @@ export default class SectionLeagueContext extends BaseFuroContext {
   }
 
   /**
+   * get: competitionId
+   *
+   * @returns {PropsType['competitionId']}
+   */
+  get competitionId () {
+    return this.props.competitionId
+  }
+
+  /**
    * get: competitionStatusId
    *
    * @returns {PropsType['competitionStatusId']}
@@ -909,6 +918,17 @@ export default class SectionLeagueContext extends BaseFuroContext {
       ?.scheduledDatetime
       ?? null
   }
+
+  /**
+   * Generate URL of competition edit page.
+   *
+   * @returns {string}
+   */
+  generateCompetitionEditUrl () {
+    return this.competitionId === null
+      ? ''
+      : `/competitions/${this.competitionId}/edit`
+  }
 }
 
 /**
@@ -929,6 +949,7 @@ export default class SectionLeagueContext extends BaseFuroContext {
  * @typedef {{
  *   competition: CompetitionEntity | null
  *   participantStatusId: number | null
+ *   competitionId: number | null
  *   competitionStatusId: number | null
  *   enrolledParticipantsNumber: number | null
  *   isHostOfCompetition: boolean

--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -649,6 +649,17 @@ export default class SectionLeagueContext extends BaseFuroContext {
   }
 
   /**
+   * Generate CSS classes for competition edit button.
+   *
+   * @returns {import('vue').HTMLAttributes['class']}
+   */
+  generateCompetitionEditButtonClasses () {
+    return {
+      hidden: !this.isHostOfCompetition,
+    }
+  }
+
+  /**
    * Generate description expansion button label.
    *
    * @returns {string}

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -176,6 +176,7 @@
   --color-text-participant-status-disqualified: var(--palette-red);
   --color-text-participant-status-canceled: var(--color-text-tertiary);
 
+  --color-text-button-highlight: var(--palette-purple);
   --color-text-button-highlight-hover: var(--palette-purple-lighter);
 
   /* Border Colors */

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -57,6 +57,13 @@ export default defineComponent({
       ],
       required: true,
     },
+    competitionId: {
+      type: [
+        Number,
+        null,
+      ],
+      required: true,
+    },
     competitionStatusId: {
       type: [
         Number,

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -256,6 +256,15 @@ export default defineComponent({
           >
 
           <div class="buttons">
+            <NuxtLink :to="context.generateCompetitionEditUrl()"
+              class="link edit"
+              :class="context.generateCompetitionEditButtonClasses()"
+            >
+              <Icon name="heroicons:pencil-square"
+                size="1.25rem"
+              />
+            </NuxtLink>
+
             <!-- TODO: Implement share feature. -->
             <!-- <button class="button">
               <Icon name="heroicons:share"
@@ -644,6 +653,7 @@ export default defineComponent({
 
 .unit-meta > .actions > .buttons {
   display: flex;
+  align-items: center;
   gap: 1.5rem;
 }
 
@@ -661,6 +671,24 @@ export default defineComponent({
 
 .unit-meta > .actions > .buttons > .button:hover {
   color: var(--color-text-secondary);
+}
+
+.unit-meta > .actions > .buttons > .link.edit {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
+  color: var(--color-text-button-highlight);
+
+  transition: color 250ms var(--transition-timing-base);
+}
+
+.unit-meta > .actions > .buttons > .link.edit:hover {
+  color: var(--color-text-button-highlight-hover);
+}
+
+.unit-meta > .actions > .buttons > .link.edit.hidden {
+  display: none;
 }
 
 .unit-statistics {

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
@@ -1,0 +1,12 @@
+import {
+  BaseFuroContext,
+} from '@openreachtech/furo-nuxt'
+
+/**
+ * CompetitionDetailsEditPageContext
+ *
+ * @extends {BaseFuroContext<null, {}, null>}
+ */
+export default class CompetitionDetailsEditPageContext extends BaseFuroContext {
+
+}

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -1,0 +1,31 @@
+<script>
+import {
+  defineComponent,
+} from 'vue'
+
+import CompetitionDetailsEditPageContext from './CompetitionDetailsEditPageContext'
+
+export default defineComponent({
+  setup (
+    props,
+    componentContext
+  ) {
+    const args = {
+      props,
+      componentContext,
+    }
+    const context = CompetitionDetailsEditPageContext.create(args)
+      .setupComponent()
+
+    return {
+      context,
+    }
+  },
+})
+</script>
+
+<template>
+  <div class="unit-page">
+    Edit
+  </div>
+</template>

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -156,6 +156,7 @@ export default defineComponent({
       :participant-status-id="context.participantStatusId"
       :is-host-of-competition="context.isHostOfCompetition()"
       :is-competition-full="context.isCompetitionFull()"
+      :competition-id="context.extractCompetitionId()"
       :competition-status-id="context.competitionStatusId"
       :enrolled-participants-number="context.enrolledParticipantsNumber"
       @show-cancelation-dialog="context.showDialog({


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2648

# How

* Add competition edit button to competition details page.
* The button simply navigates the user to the edit page.

# Screenshots

* New button is the pencil.

![image](https://github.com/user-attachments/assets/282bfbb4-8bcb-4b25-b857-68b19edb5f71)

