### PR TITLE
Fix incorrect watcher sources for competitions query

### DIFF
--- a/app/vue/contexts/CompetitionsPageContext.js
+++ b/app/vue/contexts/CompetitionsPageContext.js
@@ -105,7 +105,7 @@ export default class CompetitionsPageContext extends BaseFuroContext {
     this.watch(
       [
         () => this.extractCurrentPage(),
-        () => this.extractActiveCompetitionsFilters(),
+        () => this.extractQueryStatusId(),
       ],
       async () => {
         await this.fetchCompetitions()
@@ -280,17 +280,6 @@ export default class CompetitionsPageContext extends BaseFuroContext {
         ],
       },
     ]
-  }
-
-  /**
-   * Extract active filters.
-   *
-   * @returns {Array<string>}
-   */
-  extractActiveCompetitionsFilters () {
-    return this.competitionsFilters
-      .map(filter => filter.name)
-      .filter(filter => this.route.query[filter])
   }
 
   /**


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2665

# How

* Currently I created an array of possible filters and pass them as watcher sources for the competitions query.
* The problem is that the array structure was wrong, so the fetch logic is invoked multiple times with different values.
* I tried to change the array structure to be actually correct, but it still didn't work as expected.
* I then decided to explicitly set the watcher sources in this PR. Perhaps it's better this way. 
