### PR TITLE
Add the ability to pass initial value when editing competition basic details

### DIFF
--- a/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
@@ -2,6 +2,8 @@ import {
   BaseFuroContext,
 } from '@openreachtech/furo-nuxt'
 
+const FALLBACK_COMPETITION_IMAGE_URL = '/img/badges/league-badge-placeholder.png'
+
 /**
  * AddCompetitionFormStepDetailsContext
  *
@@ -109,6 +111,36 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
    */
   get initialCompetitionImageUrl () {
     return this.props.initialCompetitionImageUrl
+  }
+
+  /**
+   * get: imageSource
+   *
+   * @returns {string | null}
+   */
+  get imageSource () {
+    return this.imageSourceRef.value
+  }
+
+  /**
+   * Generate competition image URL.
+   *
+   * @returns {string}
+   */
+  generateCompetitionImageUrl () {
+    if (
+      this.initialCompetitionImageUrl === null
+      && this.imageSource === null
+    ) {
+      return FALLBACK_COMPETITION_IMAGE_URL
+    }
+
+    if (this.imageSource !== null) {
+      return this.imageSource
+    }
+
+    return this.initialCompetitionImageUrl
+      ?? FALLBACK_COMPETITION_IMAGE_URL
   }
 
   /**
@@ -233,7 +265,7 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
 /**
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<PropsType> & {
  *   uploadInputShallowRef: import('vue').ShallowRef<HTMLInputElement | null>
- *   imageSourceRef: import('vue').Ref<string>
+ *   imageSourceRef: import('vue').Ref<string | null>
  *   imageIdRef: import('vue').Ref<number | null>
  *   statusReactive: StatusReactive
  *   graphqlClientHash: Record<GraphqlClientHashKeys, GraphqlClient>

--- a/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
@@ -76,6 +76,42 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
   }
 
   /**
+   * get: initialFormValueHash
+   *
+   * @returns {PropsType['initialFormValueHash']}
+   */
+  get initialFormValueHash () {
+    return this.props.initialFormValueHash
+  }
+
+  /**
+   * get: initialTitle
+   *
+   * @returns {string | null}
+   */
+  get initialTitle () {
+    return this.initialFormValueHash.title
+  }
+
+  /**
+   * get: initialDescription
+   *
+   * @returns {string | null}
+   */
+  get initialDescription () {
+    return this.initialFormValueHash.description
+  }
+
+  /**
+   * get: initialCompetitionImageUrl
+   *
+   * @returns {PropsType['initialCompetitionImageUrl']}
+   */
+  get initialCompetitionImageUrl () {
+    return this.props.initialCompetitionImageUrl
+  }
+
+  /**
    * get: isUploadingImage
    *
    * @returns {boolean}
@@ -225,5 +261,13 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
 /**
  * @typedef {{
  *   validationMessage: furo.ValidatorHashType['message']
+ *   initialFormValueHash: Record<FormInputFieldNames, string | null>
+ *   initialCompetitionImageUrl: string | null
  * }} PropsType
+ */
+
+/**
+ * @typedef {'title'
+ *   | 'description'
+ * } FormInputFieldNames
  */

--- a/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
@@ -134,19 +134,15 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
    * @returns {string}
    */
   generateCompetitionImageUrl () {
-    if (
-      this.initialCompetitionImageUrl === null
-      && this.imageSource === null
-    ) {
-      return FALLBACK_COMPETITION_IMAGE_URL
-    }
-
-    if (this.imageSource !== null) {
+    if (this.imageSource) {
       return this.imageSource
     }
 
-    return this.initialCompetitionImageUrl
-      ?? FALLBACK_COMPETITION_IMAGE_URL
+    if (this.initialCompetitionImageUrl) {
+      return this.initialCompetitionImageUrl
+    }
+
+    return FALLBACK_COMPETITION_IMAGE_URL
   }
 
   /**

--- a/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
@@ -107,10 +107,11 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
   /**
    * get: initialCompetitionImageUrl
    *
-   * @returns {PropsType['initialCompetitionImageUrl']}
+   * @returns {string | null}
    */
   get initialCompetitionImageUrl () {
-    return this.props.initialCompetitionImageUrl
+    return this.initialFormValueHash.competitionImageUrl
+      ?? null
   }
 
   /**
@@ -293,13 +294,10 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
 /**
  * @typedef {{
  *   validationMessage: furo.ValidatorHashType['message']
- *   initialFormValueHash: Record<FormInputFieldNames, string | null>
- *   initialCompetitionImageUrl: string | null
+ *   initialFormValueHash: {
+ *     title: string | null
+ *     description: string | null
+ *     competitionImageUrl?: string | null
+ *   }
  * }} PropsType
- */
-
-/**
- * @typedef {'title'
- *   | 'description'
- * } FormInputFieldNames
  */

--- a/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
@@ -92,7 +92,9 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
    * @returns {string | null}
    */
   get initialTitle () {
-    return this.initialFormValueHash.title
+    return this.initialFormValueHash
+      ?.title
+      ?? null
   }
 
   /**
@@ -101,7 +103,9 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
    * @returns {string | null}
    */
   get initialDescription () {
-    return this.initialFormValueHash.description
+    return this.initialFormValueHash
+      ?.description
+      ?? null
   }
 
   /**
@@ -110,7 +114,8 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
    * @returns {string | null}
    */
   get initialCompetitionImageUrl () {
-    return this.initialFormValueHash.competitionImageUrl
+    return this.initialFormValueHash
+      ?.competitionImageUrl
       ?? null
   }
 

--- a/components/competition-add/AddCompetitionFormStepDetails.vue
+++ b/components/competition-add/AddCompetitionFormStepDetails.vue
@@ -44,14 +44,6 @@ export default defineComponent({
       required: false,
       default: null,
     },
-    initialCompetitionImageUrl: {
-      type: [
-        String,
-        null,
-      ],
-      required: false,
-      default: null,
-    },
   },
 
   setup (

--- a/components/competition-add/AddCompetitionFormStepDetails.vue
+++ b/components/competition-add/AddCompetitionFormStepDetails.vue
@@ -35,6 +35,23 @@ export default defineComponent({
       type: Object,
       required: true,
     },
+    initialFormValueHash: {
+      /** @type {import('vue').PropType<import('~/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext').PropsType['initialFormValueHash']>} */
+      type: [
+        Object,
+        null,
+      ],
+      required: false,
+      default: null,
+    },
+    initialCompetitionImageUrl: {
+      type: [
+        String,
+        null,
+      ],
+      required: false,
+      default: null,
+    },
   },
 
   setup (

--- a/components/competition-add/AddCompetitionFormStepDetails.vue
+++ b/components/competition-add/AddCompetitionFormStepDetails.vue
@@ -60,8 +60,8 @@ export default defineComponent({
   ) {
     /** @type {import('vue').ShallowRef<HTMLInputElement | null>} */
     const uploadInputShallowRef = shallowRef(null)
-    /** @type {import('vue').Ref<string>} */
-    const imageSourceRef = ref('/img/badges/league-badge-placeholder.png')
+    /** @type {import('vue').Ref<string | null>} */
+    const imageSourceRef = ref(null)
     /** @type {import('vue').Ref<number | null>} */
     const imageIdRef = ref(null)
     /** @type {import('~/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext').StatusReactive} */
@@ -160,7 +160,7 @@ export default defineComponent({
           })"
         >
 
-        <img :src="context.imageSourceRef.value"
+        <img :src="context.generateCompetitionImageUrl()"
           alt="League badge"
           class="image"
         >

--- a/components/competition-add/AddCompetitionFormStepDetails.vue
+++ b/components/competition-add/AddCompetitionFormStepDetails.vue
@@ -111,6 +111,7 @@ export default defineComponent({
       </span>
 
       <AppInput name="title"
+        :value="context.initialTitle"
         placeholder="Give your league a name (max 30 characters)"
         :has-error="Boolean(context.validationMessage.title)"
         :error-message="context.validationMessage.title"
@@ -124,6 +125,7 @@ export default defineComponent({
 
       <AppTextarea name="description"
         rows="10"
+        :value="context.initialDescription"
         placeholder="Describe your league (max 250 characters)"
         :has-error="Boolean(context.validationMessage.description)"
         :error-message="context.validationMessage.description"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2707

# How

* Allow to set initial value of input fields through props when editing competition basic details.
* This is required for the competition edit feature.

# Screenshots

```vue
<AddCompetitionFormStepDetails
  :initial-form-value-hash="{
    title: 'blue',
    description: 'This is the default description',
  }"
/>
```

![image](https://github.com/user-attachments/assets/c956077b-a29a-4367-8719-6c70e2610258)

