### PR TITLE
Change position of “Continue” button when hosting a competition

### DIFF
--- a/app/vue/contexts/AddCompetitionPageContext.js
+++ b/app/vue/contexts/AddCompetitionPageContext.js
@@ -99,6 +99,59 @@ export default class AddCompetitionPageContext extends BaseFuroContext {
   }
 
   /**
+   * get: steps
+   *
+   * @returns {Array<Step>}
+   */
+  get steps () {
+    return [
+      {
+        step: 1,
+        title: 'Details',
+      },
+      {
+        step: 2,
+        title: 'Timeline',
+      },
+      {
+        step: 3,
+        title: 'Participation',
+      },
+      {
+        step: 4,
+        title: 'Rank & Prize',
+      },
+    ]
+  }
+
+  /**
+   * get: currentStep
+   *
+   * @returns {number}
+   */
+  get currentStep () {
+    return this.currentStepRef.value
+  }
+
+  /**
+   * Check if is first step.
+   *
+   * @returns {boolean} `true` if the current step is the first step.
+   */
+  isFirstStep () {
+    return this.currentStep === 1
+  }
+
+  /**
+   * Check if is last step.
+   *
+   * @returns {boolean} `true` if the current step is the last step.
+   */
+  isLastStep () {
+    return this.currentStep === this.steps.length
+  }
+
+  /**
    * get: addCompetitionFormClerk
    *
    * @returns {AddCompetitionPageContextParams['formClerkHash']['addCompetition']}
@@ -182,6 +235,74 @@ export default class AddCompetitionPageContext extends BaseFuroContext {
   }
 
   /**
+   * Go to previous step.
+   *
+   * @returns {void}
+   */
+  goToPreviousStep () {
+    if (this.isFirstStep()) {
+      return
+    }
+
+    this.currentStepRef.value = this.currentStep - 1
+  }
+
+  /**
+   * Go to next step.
+   *
+   * @param {{
+   *   mouseEvent: MouseEvent
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  goToNextStep ({
+    mouseEvent,
+  }) {
+    if (this.isLastStep()) {
+      return
+    }
+
+    // Prevent default event before last step because `this.generateActionButtonType()`
+    // runs before the the event is invoked, which causes the form to submit before last step.
+    mouseEvent.preventDefault()
+
+    this.goToStep({
+      step: this.currentStep + 1,
+    })
+  }
+
+  /**
+   * Generate next-step button label.
+   *
+   * @returns {string}
+   */
+  generateNextStepButtonLabel () {
+    return this.isLastStep()
+      ? 'Host New League'
+      : 'Save & Continue'
+  }
+
+  /**
+   * Generate next-step button type.
+   *
+   * @returns {'submit' | 'button'}
+   */
+  generateNextStepButtonType () {
+    return this.isLastStep()
+      ? 'submit'
+      : 'button'
+  }
+
+  /**
+   * Wheter to disable previous-step button or not.
+   *
+   * @returns {boolean}
+   */
+  shouldDisablePreviousStepButton () {
+    return this.isFirstStep()
+  }
+
+  /**
    * Generate CSS classes for step element.
    *
    * @param {{
@@ -238,4 +359,11 @@ export default class AddCompetitionPageContext extends BaseFuroContext {
  * @typedef {{
  *   isLoading: boolean
  * }} StatusReactive
+ */
+
+/**
+ * @typedef {{
+ *   step: number
+ *   title: string
+ * }} Step
  */

--- a/app/vue/contexts/competition/AddCompetitionFormStepsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepsContext.js
@@ -18,6 +18,15 @@ export default class AddCompetitionFormStepsContext extends BaseFuroContext {
   }
 
   /**
+   * get: steps
+   *
+   * @returns {PropsType['steps']}
+   */
+  get steps () {
+    return this.props.steps
+  }
+
+  /**
    * get: currentStep
    *
    * @returns {PropsType['currentStep']}
@@ -187,6 +196,7 @@ export default class AddCompetitionFormStepsContext extends BaseFuroContext {
 
 /**
  * @typedef {{
+ *   steps: Array<import('~/app/vue/contexts/AddCompetitionPageContext').Step>
  *   currentStep: number
  *   errorMessageHash: Record<string, string | null> | null
  * }} PropsType

--- a/app/vue/contexts/competition/AddCompetitionFormStepsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepsContext.js
@@ -9,7 +9,7 @@ import {
 /**
  * AddCompetitionFormStepsContext
  *
- * @extends {BaseFuroContext<(typeof EVENT_NAME)[keyof typeof EVENT_NAME]>}
+ * @extends {BaseFuroContext<null, PropsType, (typeof EVENT_NAME)[keyof typeof EVENT_NAME]>}
  */
 export default class AddCompetitionFormStepsContext extends BaseFuroContext {
   /** @override */
@@ -20,7 +20,7 @@ export default class AddCompetitionFormStepsContext extends BaseFuroContext {
   /**
    * get: currentStep
    *
-   * @returns {number}
+   * @returns {PropsType['currentStep']}
    */
   get currentStep () {
     return this.props.currentStep
@@ -29,7 +29,7 @@ export default class AddCompetitionFormStepsContext extends BaseFuroContext {
   /**
    * get: errorMessageHash
    *
-   * @returns {Record<string, string | null>}
+   * @returns {PropsType['errorMessageHash']}
    */
   get errorMessageHash () {
     return this.props.errorMessageHash
@@ -41,7 +41,9 @@ export default class AddCompetitionFormStepsContext extends BaseFuroContext {
    * @returns {string | null}
    */
   get addCompetitionErrorMessage () {
-    return this.errorMessageHash.addCompetition
+    return this.errorMessageHash
+      ?.addCompetition
+      ?? null
   }
 
   /**
@@ -181,4 +183,11 @@ export default class AddCompetitionFormStepsContext extends BaseFuroContext {
  *   step: number
  *   title: string
  * }} Step
+ */
+
+/**
+ * @typedef {{
+ *   currentStep: number
+ *   errorMessageHash: Record<string, string | null> | null
+ * }} PropsType
  */

--- a/app/vue/contexts/competition/AddCompetitionFormStepsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepsContext.js
@@ -86,61 +86,6 @@ export default class AddCompetitionFormStepsContext extends BaseFuroContext {
   }
 
   /**
-   * Check if is last step.
-   *
-   * @returns {boolean} `true` if the current step is the last step.
-   */
-  isLastStep () {
-    return this.currentStep === this.generateSteps().length
-  }
-
-  /**
-   * Go to next step.
-   *
-   * @param {{
-   *   mouseEvent: MouseEvent
-   * }} params - Parameters.
-   * @returns {void}
-   */
-  nextStep ({
-    mouseEvent,
-  }) {
-    if (this.isLastStep()) {
-      return
-    }
-
-    // Prevent default event before last step because `this.generateActionButtonType()`
-    // runs before the the event is invoked, which causes the form to submit before last step.
-    mouseEvent.preventDefault()
-
-    this.goToStep({
-      step: this.currentStep + 1,
-    })
-  }
-
-  /**
-   * Generate action button label.
-   *
-   * @returns {string}
-   */
-  generateActionButtonLabel () {
-    return this.isLastStep()
-      ? 'Host New League'
-      : 'Next'
-  }
-
-  /**
-   * Generate action button type.
-   *
-   * @returns {'submit' | 'button'}
-   */
-  generateActionButtonType () {
-    return this.isLastStep()
-      ? 'submit'
-      : 'button'
-  }
-
-  /**
    * Generate aria-current.
    *
    * @param {{
@@ -158,32 +103,6 @@ export default class AddCompetitionFormStepsContext extends BaseFuroContext {
     return isCurrentStep
       ? 'step'
       : 'false'
-  }
-
-  /**
-   * Generate steps.
-   *
-   * @returns {Array<Step>}
-   */
-  generateSteps () {
-    return [
-      {
-        step: 1,
-        title: 'Details',
-      },
-      {
-        step: 2,
-        title: 'Timeline',
-      },
-      {
-        step: 3,
-        title: 'Participation',
-      },
-      {
-        step: 4,
-        title: 'Rank & Prize',
-      },
-    ]
   }
 }
 

--- a/components/competition-add/AddCompetitionFormSteps.vue
+++ b/components/competition-add/AddCompetitionFormSteps.vue
@@ -7,7 +7,6 @@ import {
   Icon,
 } from '#components'
 
-import AppButton from '~/components/units/AppButton.vue'
 import AppMessage from '~/components/units/AppMessage.vue'
 
 import AddCompetitionFormStepsContext from '~/app/vue/contexts/competition/AddCompetitionFormStepsContext'
@@ -20,7 +19,6 @@ export const EVENT_NAME = {
 export default defineComponent({
   components: {
     Icon,
-    AppButton,
     AppMessage,
   },
 
@@ -117,17 +115,6 @@ export default defineComponent({
     >
       {{ context.addCompetitionErrorMessage }}
     </AppMessage>
-
-    <div class="unit-actions">
-      <AppButton class="button"
-        :type="context.generateActionButtonType()"
-        @click="context.nextStep({
-          mouseEvent: $event,
-        })"
-      >
-        {{ context.generateActionButtonLabel() }}
-      </AppButton>
-    </div>
   </div>
 </template>
 
@@ -350,19 +337,5 @@ export default defineComponent({
 .unit-guide > .note {
   font-size: var(--font-size-small);
   color: var(--color-text-tertiary);
-}
-
-.unit-actions {
-  display: none;
-  flex-direction: column;
-  gap: 0.75rem;
-
-  @media (48rem < width) {
-    display: flex;
-  }
-}
-
-.unit-actions > .button {
-  justify-content: center;
 }
 </style>

--- a/components/competition-add/AddCompetitionFormSteps.vue
+++ b/components/competition-add/AddCompetitionFormSteps.vue
@@ -23,6 +23,15 @@ export default defineComponent({
   },
 
   props: {
+    steps: {
+      /**
+       * @type {import('vue').PropType<
+       *   import('~/app/vue/contexts/competition/AddCompetitionFormStepsContext').PropsType['steps']
+       * >}
+       */
+      type: Array,
+      required: true,
+    },
     currentStep: {
       type: Number,
       required: true,
@@ -65,7 +74,7 @@ export default defineComponent({
 <template>
   <div class="unit-container">
     <div class="steps">
-      <div v-for="it of context.generateSteps()"
+      <div v-for="it of context.steps"
         :key="it.step"
         class="unit-step"
         :aria-current="context.generateAriaCurrent({

--- a/components/competition-add/AddCompetitionFormSteps.vue
+++ b/components/competition-add/AddCompetitionFormSteps.vue
@@ -28,7 +28,11 @@ export default defineComponent({
       required: true,
     },
     errorMessageHash: {
-      /** @type {import('vue').PropType<Record<string, string | null> | null>} */
+      /**
+       * @type {import('vue').PropType<
+       *   import('~/app/vue/contexts/competition/AddCompetitionFormStepsContext').PropsType['errorMessageHash']
+       * >}
+       */
       type: [
         Object,
         null,

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -135,6 +135,7 @@ export default defineComponent({
         </div>
 
         <AddCompetitionFormSteps :current-step="context.currentStepRef.value"
+          :steps="context.steps"
           :error-message-hash="context.errorMessageHashReactive"
           @go-to-step="context.goToStep($event)"
         />

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -9,6 +9,7 @@ import {
   Icon,
 } from '#components'
 
+import AppButton from '~/components/units/AppButton.vue'
 import AddCompetitionFormSteps from '~/components/competition-add/AddCompetitionFormSteps.vue'
 import AddCompetitionFormStepDetails from '~/components/competition-add/AddCompetitionFormStepDetails.vue'
 import AddCompetitionFormStepTimeline from '~/components/competition-add/AddCompetitionFormStepTimeline.vue'
@@ -31,6 +32,7 @@ export default defineComponent({
   components: {
     NuxtLink,
     Icon,
+    AppButton,
     AddCompetitionFormSteps,
     AddCompetitionFormStepDetails,
     AddCompetitionFormStepTimeline,
@@ -110,6 +112,26 @@ export default defineComponent({
           <AddCompetitionFormStepPrize :class="context.generateStepClasses({ step: 4 })"
             :validation-message="context.addCompetitionValidationMessage"
           />
+
+          <div class="unit-actions">
+            <AppButton appearance="outlined"
+              class="button back"
+              type="button"
+              :disabled="context.shouldDisablePreviousStepButton()"
+              @click="context.goToPreviousStep()"
+            >
+              <Icon name="heroicons-outline:chevron-left"
+                size="1rem"
+              />
+            </AppButton>
+            <AppButton :type="context.generateNextStepButtonType"
+              @click="context.goToNextStep({
+                mouseEvent: $event,
+              })"
+            >
+              {{ context.generateNextStepButtonLabel() }}
+            </AppButton>
+          </div>
         </div>
 
         <AddCompetitionFormSteps :current-step="context.currentStepRef.value"
@@ -193,5 +215,18 @@ export default defineComponent({
 
 .unit-form > .steps > .step.hidden {
   display: none;
+}
+
+.unit-actions {
+  margin-block-start: 2.5rem;
+
+  display: flex;
+  justify-content: end;
+  gap: 1rem;
+}
+
+.unit-actions > .button.back {
+  padding-block: 0.625rem;
+  padding-inline: 0.625rem;
 }
 </style>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2716

# How

* Update the UI to match the new design.
* This change requires moving some old logics to page level.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/cc72ca82-1df7-4f6a-a08c-35140471b4ab)

## After 

![image](https://github.com/user-attachments/assets/9597d041-86cc-4aa5-b587-2c4c46e95c4d)
