### PR TITLE
Improve the responsiveness of host/edit competition form

### DIFF
--- a/app/vue/contexts/AddCompetitionPageContext.js
+++ b/app/vue/contexts/AddCompetitionPageContext.js
@@ -314,7 +314,6 @@ export default class AddCompetitionPageContext extends BaseFuroContext {
     step,
   }) {
     return [
-      'step',
       {
         hidden: this.currentStepRef.value !== step,
       },

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -98,19 +98,31 @@ export default defineComponent({
       >
         <div class="steps">
           <div class="content">
-            <AddCompetitionFormStepDetails :class="context.generateStepClasses({ step: 1 })"
+            <AddCompetitionFormStepDetails class="step"
+              :class="context.generateStepClasses({
+                step: 1,
+              })"
               :validation-message="context.addCompetitionValidationMessage"
             />
 
-            <AddCompetitionFormStepTimeline :class="context.generateStepClasses({ step: 2 })"
+            <AddCompetitionFormStepTimeline class="step"
+              :class="context.generateStepClasses({
+                step: 2,
+              })"
               :validation-message="context.addCompetitionValidationMessage"
             />
 
-            <AddCompetitionFormStepParticipation :class="context.generateStepClasses({ step: 3 })"
+            <AddCompetitionFormStepParticipation class="step"
+              :class="context.generateStepClasses({
+                step: 3,
+              })"
               :validation-message="context.addCompetitionValidationMessage"
             />
 
-            <AddCompetitionFormStepPrize :class="context.generateStepClasses({ step: 4 })"
+            <AddCompetitionFormStepPrize class="step"
+              :class="context.generateStepClasses({
+                step: 4,
+              })"
               :validation-message="context.addCompetitionValidationMessage"
             />
           </div>

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -97,21 +97,23 @@ export default defineComponent({
         @submit.prevent="context.submitForm()"
       >
         <div class="steps">
-          <AddCompetitionFormStepDetails :class="context.generateStepClasses({ step: 1 })"
-            :validation-message="context.addCompetitionValidationMessage"
-          />
+          <div class="content">
+            <AddCompetitionFormStepDetails :class="context.generateStepClasses({ step: 1 })"
+              :validation-message="context.addCompetitionValidationMessage"
+            />
 
-          <AddCompetitionFormStepTimeline :class="context.generateStepClasses({ step: 2 })"
-            :validation-message="context.addCompetitionValidationMessage"
-          />
+            <AddCompetitionFormStepTimeline :class="context.generateStepClasses({ step: 2 })"
+              :validation-message="context.addCompetitionValidationMessage"
+            />
 
-          <AddCompetitionFormStepParticipation :class="context.generateStepClasses({ step: 3 })"
-            :validation-message="context.addCompetitionValidationMessage"
-          />
+            <AddCompetitionFormStepParticipation :class="context.generateStepClasses({ step: 3 })"
+              :validation-message="context.addCompetitionValidationMessage"
+            />
 
-          <AddCompetitionFormStepPrize :class="context.generateStepClasses({ step: 4 })"
-            :validation-message="context.addCompetitionValidationMessage"
-          />
+            <AddCompetitionFormStepPrize :class="context.generateStepClasses({ step: 4 })"
+              :validation-message="context.addCompetitionValidationMessage"
+            />
+          </div>
 
           <div class="unit-actions">
             <AppButton appearance="outlined"
@@ -216,8 +218,17 @@ export default defineComponent({
   }
 }
 
-.unit-form > .steps > .step.hidden {
-  display: none;
+.unit-form > .steps > .content {
+  display: grid;
+}
+
+.unit-form > .steps > .content > * {
+  grid-row: 1 / -1;
+  grid-column: 1 / -1;
+}
+
+.unit-form > .steps > .content > .step.hidden {
+  visibility: hidden;
 }
 
 .unit-actions {

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -148,6 +148,8 @@ export default defineComponent({
 .unit-page {
   margin-inline: calc(-1 * var(--size-body-padding-inline-mobile));
 
+  padding-block-end: 12rem;
+
   @media (30rem < width) {
     margin-inline: calc(-1 * var(--size-body-padding-inline-desktop));
   }


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2726

# How

* Add missing bottom padding for the form.
* Use `grid` + `visibility: hidden` to hide each step in order to avoid layout shift.

# Screencasts

## Before

https://github.com/user-attachments/assets/a001b519-a88c-41fe-a324-8ebbc2527a77

## After

https://github.com/user-attachments/assets/50c3e8cc-01da-49ce-9de9-9b978d74c40e


