### PR TITLE
Allow AddCompetitionFormStepPrize to have initial form value hash

### DIFF
--- a/components/competition-add/AddCompetitionFormStepPrize.vue
+++ b/components/competition-add/AddCompetitionFormStepPrize.vue
@@ -50,14 +50,7 @@ export default defineComponent({
     componentContext
   ) {
     /** @type {import('./AddCompetitionFormStepPrizeContext').AddCompetitionFormStepPrizeContextFactoryParams['prizeRulesRef']} */
-    const prizeRulesRef = ref([
-      {
-        rankFrom: 1,
-        rankTo: 1,
-        amount: '0',
-        isRankRange: false,
-      },
-    ])
+    const prizeRulesRef = ref(generateInitialPrizeRules())
 
     const args = {
       props,
@@ -69,6 +62,28 @@ export default defineComponent({
 
     return {
       context,
+    }
+
+    /**
+     * Generate initial prize rules.
+     *
+     * @returns {Array<import('./AddCompetitionFormStepPrizeContext').PrizeRule>}
+     */
+    function generateInitialPrizeRules () {
+      const defaultPrizeRules = [
+        {
+          rankFrom: 1,
+          rankTo: 1,
+          amount: '0',
+          isRankRange: false,
+        },
+      ]
+
+      if (!props.initialFormValueHash) {
+        return defaultPrizeRules
+      }
+
+      return props.initialFormValueHash.prizeRules
     }
   },
 })

--- a/components/competition-add/AddCompetitionFormStepPrize.vue
+++ b/components/competition-add/AddCompetitionFormStepPrize.vue
@@ -30,6 +30,19 @@ export default defineComponent({
       type: Object,
       required: true,
     },
+    initialFormValueHash: {
+      /**
+       * @type {import('vue').PropType<
+       *   import('./AddCompetitionFormStepPrizeContext').PropsType['initialFormValueHash']
+       * >}
+       */
+      type: [
+        Object,
+        null,
+      ],
+      required: false,
+      default: null,
+    },
   },
 
   setup (

--- a/components/competition-add/AddCompetitionFormStepPrizeContext.js
+++ b/components/competition-add/AddCompetitionFormStepPrizeContext.js
@@ -124,6 +124,15 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
   }
 
   /**
+   * get: initialFormValueHash
+   *
+   * @returns {PropsType['initialFormValueHash']}
+   */
+  get initialFormValueHash () {
+    return this.props.initialFormValueHash
+  }
+
+  /**
    * Calculate total prize.
    *
    * @returns {number}
@@ -284,5 +293,12 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
 /**
  * @typedef {{
  *   validationMessage: furo.ValidatorHashType['message']
+ *   initialFormValueHash: InitialFormValueHash | null
  * }} PropsType
+ */
+
+/**
+ * @typedef {{
+ *   prizeRules: Array<PrizeRule>
+ * }} InitialFormValueHash
  */


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2732

# How

* Add a prop and use it to set the initial value of prize rules.
