### PR TITLE
Sync the initial prize rules when prop changes

### DIFF
--- a/components/competition-add/AddCompetitionFormStepPrizeContext.js
+++ b/components/competition-add/AddCompetitionFormStepPrizeContext.js
@@ -115,6 +115,24 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
   }
 
   /**
+   * Setup component.
+   *
+   * @template {X extends AddCompetitionFormStepPrizeContext ? X : never} T, X
+   * @override
+   * @this {T}
+   */
+  setupComponent () {
+    this.watch(
+      () => this.initialPrizeRules,
+      () => {
+        this.syncInitialPrizeRules()
+      }
+    )
+
+    return this
+  }
+
+  /**
    * get: validationMessage
    *
    * @returns {PropsType['validationMessage']}
@@ -130,6 +148,26 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
    */
   get initialFormValueHash () {
     return this.props.initialFormValueHash
+  }
+
+  /**
+   * get: initialPrizeRules
+   *
+   * @returns {Array<PrizeRule>}
+   */
+  get initialPrizeRules () {
+    return this.initialFormValueHash
+      ?.prizeRules
+      ?? []
+  }
+
+  /**
+   * Sync initial prize rules when prop changes.
+   *
+   * @returns {void}
+   */
+  syncInitialPrizeRules () {
+    this.prizeRulesRef.value = this.initialPrizeRules
   }
 
   /**


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2830

# How

* The initial value of competition prize rules is gotten from prop.
* Prop value is gotten from the server through an API call.
* This PR added a watcher so that after the API call, the initial value of prize rules is updated accordingly.

# Screenshots

![image](https://github.com/user-attachments/assets/5a6ff73e-17ee-4bae-97e7-9a394ef53217)

