### PR TITLE
Properly sync the initial value of date picker

### DIFF
--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -68,6 +68,34 @@ export default class AppDatePikcerContext extends BaseFuroContext {
   }
 
   /**
+   * Setup component.
+   *
+   * @template {X extends AppDatePikcerContext ? X : never} T, X
+   * @override
+   * @this {T}
+   * @todo: Fix typo `pikcer` -> `picker`.
+   */
+  setupComponent () {
+    this.watch(
+      () => this.initialDate,
+      () => {
+        this.syncInitialInputValue()
+      }
+    )
+
+    return this
+  }
+
+  /**
+   * get: initialDate
+   *
+   * @returns {Date | string | null}
+   */
+  get initialDate () {
+    return this.props.initialDate
+  }
+
+  /**
    * get: shouldDisablePastDates
    *
    * @returns {boolean} `true` if past dates should be disabled.
@@ -101,6 +129,29 @@ export default class AppDatePikcerContext extends BaseFuroContext {
    */
   get inputValue () {
     return this.inputValueRef.value
+  }
+
+  /**
+   * Sync the initial value of date picker.
+   *
+   * @returns {void}
+   */
+  syncInitialInputValue () {
+    if (this.initialDate === null) {
+      return
+    }
+
+    const dateString = new Date(this.initialDate)
+      .toISOString()
+      .split('T')
+      .at(0)
+      ?? null
+
+    if (!dateString) {
+      return
+    }
+
+    this.inputValueRef.value = dateString
   }
 
   /**


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2829

# How

* The initial value of date picker is gotten from prop.
* Prop value can be gotten from the server through an API call.
* This PR added a watcher so that after the API call, the initial value of date picker is updated accordingly.
