### PR TITLE
Implement logic to edit competition details

### DIFF
--- a/app/domClerk/UpdateCompetitionSchedulesFormElementClerk.js
+++ b/app/domClerk/UpdateCompetitionSchedulesFormElementClerk.js
@@ -30,6 +30,7 @@ export default class UpdateCompetitionSchedulesFormElementClerk extends BaseFilt
             SCHEDULE_CATEGORY.REGISTRATION_END.ID,
             SCHEDULE_CATEGORY.COMPETITION_START.ID,
             SCHEDULE_CATEGORY.COMPETITION_END.ID,
+            SCHEDULE_CATEGORY.PRIZE_DISTRIBUTE.ID,
           ]
 
           return it.length >= 4

--- a/components/competition-add/AddCompetitionFormStepPrize.vue
+++ b/components/competition-add/AddCompetitionFormStepPrize.vue
@@ -43,6 +43,11 @@ export default defineComponent({
       required: false,
       default: null,
     },
+    shouldOmitTotalPrize: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 
   setup (
@@ -239,6 +244,7 @@ export default defineComponent({
         <input type="text"
           name="totalPrize"
           class="input hidden"
+          :disabled="context.shouldOmitTotalPrize"
           :value="context.calculateTotalPrize()"
         >
 

--- a/components/competition-add/AddCompetitionFormStepPrizeContext.js
+++ b/components/competition-add/AddCompetitionFormStepPrizeContext.js
@@ -162,6 +162,15 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
   }
 
   /**
+   * get: shouldOmitTotalPrize
+   *
+   * @returns {PropsType['shouldOmitTotalPrize']}
+   */
+  get shouldOmitTotalPrize () {
+    return this.props.shouldOmitTotalPrize
+  }
+
+  /**
    * Sync initial prize rules when prop changes.
    *
    * @returns {void}
@@ -332,6 +341,7 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
  * @typedef {{
  *   validationMessage: furo.ValidatorHashType['message']
  *   initialFormValueHash: InitialFormValueHash | null
+ *   shouldOmitTotalPrize: boolean
  * }} PropsType
  */
 

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
@@ -21,6 +21,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
     graphqlClientHash,
     formClerkHash,
     statusReactive,
+    updateCompetitionFormShallowRef,
+    updateCompetitionSchedulesFormShallowRef,
+    updateCompetitionLimitsFormShallowRef,
+    updateCompetitionPrizeRulesFormShallowRef,
   }) {
     super({
       props,
@@ -31,6 +35,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
     this.graphqlClientHash = graphqlClientHash
     this.formClerkHash = formClerkHash
     this.statusReactive = statusReactive
+    this.updateCompetitionFormShallowRef = updateCompetitionFormShallowRef
+    this.updateCompetitionSchedulesFormShallowRef = updateCompetitionSchedulesFormShallowRef
+    this.updateCompetitionLimitsFormShallowRef = updateCompetitionLimitsFormShallowRef
+    this.updateCompetitionPrizeRulesFormShallowRef = updateCompetitionPrizeRulesFormShallowRef
   }
 
   /**
@@ -49,6 +57,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
     graphqlClientHash,
     formClerkHash,
     statusReactive,
+    updateCompetitionFormShallowRef,
+    updateCompetitionSchedulesFormShallowRef,
+    updateCompetitionLimitsFormShallowRef,
+    updateCompetitionPrizeRulesFormShallowRef,
   }) {
     return /** @type {InstanceType<T>} */ (
       new this({
@@ -58,6 +70,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
         graphqlClientHash,
         formClerkHash,
         statusReactive,
+        updateCompetitionFormShallowRef,
+        updateCompetitionSchedulesFormShallowRef,
+        updateCompetitionLimitsFormShallowRef,
+        updateCompetitionPrizeRulesFormShallowRef,
       })
     )
   }
@@ -185,6 +201,46 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
     return this.updateCompetitionPrizeRulesValidation
       .message
   }
+
+  /**
+   * get: updateCompetitionFormElement
+   *
+   * @returns {HTMLFormElement | null}
+   */
+  get updateCompetitionFormElement () {
+    return this.updateCompetitionFormShallowRef
+      .value
+  }
+
+  /**
+   * get: updateCompetitionSchedulesFormElement
+   *
+   * @returns {HTMLFormElement | null}
+   */
+  get updateCompetitionSchedulesFormElement () {
+    return this.updateCompetitionSchedulesFormShallowRef
+      .value
+  }
+
+  /**
+   * get: updateCompetitionLimitsFormElement
+   *
+   * @returns {HTMLFormElement | null}
+   */
+  get updateCompetitionLimitsFormElement () {
+    return this.updateCompetitionLimitsFormShallowRef
+      .value
+  }
+
+  /**
+   * get: updateCompetitionPrizeRulesFormElement
+   *
+   * @returns {HTMLFormElement | null}
+   */
+  get updateCompetitionPrizeRulesFormElement () {
+    return this.updateCompetitionPrizeRulesFormShallowRef
+      .value
+  }
 }
 
 /**
@@ -193,6 +249,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
  *   graphqlClientHash: Record<GraphqlClientHashKeys, GraphqlClient>
  *   formClerkHash: Record<FormClerkHashKeys, FormClerk>
  *   statusReactive: StatusReactive
+ *   updateCompetitionFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
+ *   updateCompetitionSchedulesFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
+ *   updateCompetitionLimitsFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
+ *   updateCompetitionPrizeRulesFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
  * }} CompetitionDetailsEditMutationContextParams
  */
 

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
@@ -1,0 +1,110 @@
+import {
+  BaseFuroContext,
+} from '@openreachtech/furo-nuxt'
+
+/**
+ * CompetitionDetailsEditMutationContext
+ *
+ * @extends {BaseFuroContext<null, {}, null>}
+ */
+export default class CompetitionDetailsEditMutationContext extends BaseFuroContext {
+  /**
+   * Constructor
+   *
+   * @param {CompetitionDetailsEditMutationContextParams} params - Parameters of this constructor.
+   */
+  constructor ({
+    props,
+    componentContext,
+
+    route,
+    graphqlClientHash,
+    formClerkHash,
+    statusReactive,
+  }) {
+    super({
+      props,
+      componentContext,
+    })
+
+    this.route = route
+    this.graphqlClientHash = graphqlClientHash
+    this.formClerkHash = formClerkHash
+    this.statusReactive = statusReactive
+  }
+
+  /**
+   * Factory method to create a new instance of this class.
+   *
+   * @template {X extends typeof CompetitionDetailsEditMutationContext ? X : never} T, X
+   * @override
+   * @param {CompetitionDetailsEditMutationContextFactoryParams} params - Parameters of this factory method.
+   * @returns {InstanceType<T>} An instance of this class.
+   * @this {T}
+   */
+  static create ({
+    props,
+    componentContext,
+    route,
+    graphqlClientHash,
+    formClerkHash,
+    statusReactive,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        props,
+        componentContext,
+        route,
+        graphqlClientHash,
+        formClerkHash,
+        statusReactive,
+      })
+    )
+  }
+}
+
+/**
+ * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams & {
+ *   route: ReturnType<import('vue-router').useRoute>
+ *   graphqlClientHash: Record<GraphqlClientHashKeys, GraphqlClient>
+ *   formClerkHash: Record<FormClerkHashKeys, FormClerk>
+ *   statusReactive: StatusReactive
+ * }} CompetitionDetailsEditMutationContextParams
+ */
+
+/**
+ * @typedef {CompetitionDetailsEditMutationContextParams} CompetitionDetailsEditMutationContextFactoryParams
+ */
+
+/**
+ * @typedef {'updateCompetition'
+ *   | 'updateCompetitionSchedules'
+ *   | 'updateCompetitionLimits'
+ *   | 'updateCompetitionPrizeRules'
+ * } GraphqlClientHashKeys
+ */
+
+/**
+ * @typedef {'updateCompetition'
+ *   | 'updateCompetitionSchedules'
+ *   | 'updateCompetitionLimits'
+ *   | 'updateCompetitionPrizeRules'
+ * } FormClerkHashKeys
+ */
+
+/**
+ * @typedef {ReturnType<import('@openreachtech/furo-nuxt').useGraphqlClient>} GraphqlClient
+ */
+
+/**
+ * @typedef {ReturnType<import('~/composables/useAppFormClerk').default>} FormClerk
+ */
+
+/**
+ * @typedef {{
+ *   isUpdatingCompetition: boolean
+ *   isUpdatingCompetitionSchedules: boolean
+ *   isUpdatingCompetitionLimits: boolean
+ *   isUpdatingCompetitionPrizeRules: boolean
+ * }} StatusReactive
+ */

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
@@ -61,6 +61,130 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
       })
     )
   }
+
+  /**
+   * get: updateCompetitionFormClerk
+   *
+   * @returns {FormClerk}
+   */
+  get updateCompetitionFormClerk () {
+    return this.formClerkHash
+      .updateCompetition
+  }
+
+  /**
+   * get: updateCompetitionValidation
+   *
+   * @returns {furo.ValidatorHashType}
+   */
+  get updateCompetitionValidation () {
+    return this.updateCompetitionFormClerk
+      .validationRef
+      .value
+  }
+
+  /**
+   * get: updateCompetitionValidationMessage
+   *
+   * @returns {furo.ValidatorHashType['message']}
+   */
+  get updateCompetitionValidationMessage () {
+    return this.updateCompetitionValidation
+      .message
+  }
+
+  /**
+   * get: updateCompetitionSchedulesFormClerk
+   *
+   * @returns {FormClerk}
+   */
+  get updateCompetitionSchedulesFormClerk () {
+    return this.formClerkHash
+      .updateCompetitionSchedules
+  }
+
+  /**
+   * get: updateCompetitionSchedulesValidation
+   *
+   * @returns {furo.ValidatorHashType}
+   */
+  get updateCompetitionSchedulesValidation () {
+    return this.updateCompetitionSchedulesFormClerk
+      .validationRef
+      .value
+  }
+
+  /**
+   * get: updateCompetitionSchedulesValidationMessage
+   *
+   * @returns {furo.ValidatorHashType['message']}
+   */
+  get updateCompetitionSchedulesValidationMessage () {
+    return this.updateCompetitionSchedulesValidation
+      .message
+  }
+
+  /**
+   * get: updateCompetitionLimitsFormClerk
+   *
+   * @returns {FormClerk}
+   */
+  get updateCompetitionLimitsFormClerk () {
+    return this.formClerkHash
+      .updateCompetitionLimits
+  }
+
+  /**
+   * get: updateCompetitionLimitsValidation
+   *
+   * @returns {furo.ValidatorHashType}
+   */
+  get updateCompetitionLimitsValidation () {
+    return this.updateCompetitionLimitsFormClerk
+      .validationRef
+      .value
+  }
+
+  /**
+   * get: updateCompetitionLimitsValidationMessage
+   *
+   * @returns {furo.ValidatorHashType['message']}
+   */
+  get updateCompetitionLimitsValidationMessage () {
+    return this.updateCompetitionLimitsValidation
+      .message
+  }
+
+  /**
+   * get: updateCompetitionPrizeRulesFormClerk
+   *
+   * @returns {FormClerk}
+   */
+  get updateCompetitionPrizeRulesFormClerk () {
+    return this.formClerkHash
+      .updateCompetitionPrizeRules
+  }
+
+  /**
+   * get: updateCompetitionPrizeRulesValidation
+   *
+   * @returns {furo.ValidatorHashType}
+   */
+  get updateCompetitionPrizeRulesValidation () {
+    return this.updateCompetitionPrizeRulesFormClerk
+      .validationRef
+      .value
+  }
+
+  /**
+   * get: updateCompetitionPrizeRulesValidationMessage
+   *
+   * @returns {furo.ValidatorHashType['message']}
+   */
+  get updateCompetitionPrizeRulesValidationMessage () {
+    return this.updateCompetitionPrizeRulesValidation
+      .message
+  }
 }
 
 /**

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
@@ -241,6 +241,198 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
     return this.updateCompetitionPrizeRulesFormShallowRef
       .value
   }
+
+  /**
+   * Extract competition id from route params.
+   *
+   * @returns {number | null}
+   */
+  extractCompetitionIdFromRoute () {
+    const competitionIdParam = Array.isArray(this.route.params.competitionId)
+      ? this.route.params.competitionId[0]
+      : this.route.params.competitionId
+    const competitionId = Number(competitionIdParam)
+
+    return isNaN(competitionId)
+      ? null
+      : competitionId
+  }
+
+  /**
+   * Submit form `updateCompetition`.
+   *
+   * @returns {Promise<void>}
+   */
+  async submitFormUpdateCompetition () {
+    if (!this.updateCompetitionFormElement) {
+      return
+    }
+
+    await this.updateCompetitionFormClerk
+      .submitForm({
+        formElement: this.updateCompetitionFormElement,
+        hooks: this.updateCompetitionLauncherHooks,
+      })
+  }
+
+  /**
+   * get: updateCompetitionLauncherHooks
+   *
+   * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
+   */
+  get updateCompetitionLauncherHooks () {
+    return {
+      beforeRequest: async payload => {
+        this.statusReactive.isUpdatingCompetition = true
+
+        return false
+      },
+      afterRequest: async capsule => {
+        this.statusReactive.isUpdatingCompetition = false
+      },
+    }
+  }
+
+  /**
+   * get: isUpdatingCompetition
+   *
+   * @returns {boolean}
+   */
+  get isUpdatingCompetition () {
+    return this.statusReactive.isUpdatingCompetition
+  }
+
+  /**
+   * Submit form `updateCompetitionSchedules`.
+   *
+   * @returns {Promise<void>}
+   */
+  async submitFormUpdateCompetitionSchedules () {
+    if (!this.updateCompetitionSchedulesFormElement) {
+      return
+    }
+
+    await this.updateCompetitionSchedulesFormClerk
+      .submitForm({
+        formElement: this.updateCompetitionSchedulesFormElement,
+        hooks: this.updateCompetitionSchedulesLauncherHooks,
+      })
+  }
+
+  /**
+   * get: updateCompetitionSchedulesLauncherHooks
+   *
+   * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
+   */
+  get updateCompetitionSchedulesLauncherHooks () {
+    return {
+      beforeRequest: async payload => {
+        this.statusReactive.isUpdatingCompetitionSchedules = true
+
+        return false
+      },
+      afterRequest: async capsule => {
+        this.statusReactive.isUpdatingCompetitionSchedules = false
+      },
+    }
+  }
+
+  /**
+   * get: isUpdatingCompetitionSchedules
+   *
+   * @returns {boolean}
+   */
+  get isUpdatingCompetitionSchedules () {
+    return this.statusReactive.isUpdatingCompetitionSchedules
+  }
+
+  /**
+   * Submit form `updateCompetitionLimits`.
+   *
+   * @returns {Promise<void>}
+   */
+  async submitFormUpdateCompetitionLimits () {
+    if (!this.updateCompetitionLimitsFormElement) {
+      return
+    }
+
+    await this.updateCompetitionLimitsFormClerk
+      .submitForm({
+        formElement: this.updateCompetitionLimitsFormElement,
+        hooks: this.updateCompetitionLimitsLauncherHooks,
+      })
+  }
+
+  /**
+   * get: updateCompetitionLimitsLauncherHooks
+   *
+   * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
+   */
+  get updateCompetitionLimitsLauncherHooks () {
+    return {
+      beforeRequest: async payload => {
+        this.statusReactive.isUpdatingCompetitionLimits = true
+
+        return false
+      },
+      afterRequest: async capsule => {
+        this.statusReactive.isUpdatingCompetitionLimits = false
+      },
+    }
+  }
+
+  /**
+   * get: isUpdatingCompetitionLimits
+   *
+   * @returns {boolean}
+   */
+  get isUpdatingCompetitionLimits () {
+    return this.statusReactive.isUpdatingCompetitionLimits
+  }
+
+  /**
+   * Submit form `updateCompetitionPrizeRules`.
+   *
+   * @returns {Promise<void>}
+   */
+  async submitFormUpdateCompetitionPrizeRules () {
+    if (!this.updateCompetitionPrizeRulesFormElement) {
+      return
+    }
+
+    await this.updateCompetitionPrizeRulesFormClerk
+      .submitForm({
+        formElement: this.updateCompetitionPrizeRulesFormElement,
+        hooks: this.updateCompetitionPrizeRulesLauncherHooks,
+      })
+  }
+
+  /**
+   * get: updateCompetitionPrizeRulesLauncherHooks
+   *
+   * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
+   */
+  get updateCompetitionPrizeRulesLauncherHooks () {
+    return {
+      beforeRequest: async payload => {
+        this.statusReactive.isUpdatingCompetitionPrizeRules = true
+
+        return false
+      },
+      afterRequest: async capsule => {
+        this.statusReactive.isUpdatingCompetitionPrizeRules = false
+      },
+    }
+  }
+
+  /**
+   * get: isUpdatingCompetitionPrizeRules
+   *
+   * @returns {boolean}
+   */
+  get isUpdatingCompetitionPrizeRules () {
+    return this.statusReactive.isUpdatingCompetitionPrizeRules
+  }
 }
 
 /**

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
@@ -179,6 +179,20 @@ export default class CompetitionDetailsEditPageContext extends BaseFuroContext {
   }
 
   /**
+   * Go to step.
+   *
+   * @param {{
+   *   step: number
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  goToStep ({
+    step,
+  }) {
+    this.currentStepRef.value = step
+  }
+
+  /**
    * Generate competition details URL.
    *
    * @returns {string}

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
@@ -20,7 +20,6 @@ export default class CompetitionDetailsEditPageContext extends BaseFuroContext {
     route,
     fetcherHash,
     currentStepRef,
-    editCompetitionFormShallowRef,
   }) {
     super({
       props,
@@ -30,7 +29,6 @@ export default class CompetitionDetailsEditPageContext extends BaseFuroContext {
     this.route = route
     this.fetcherHash = fetcherHash
     this.currentStepRef = currentStepRef
-    this.editCompetitionFormShallowRef = editCompetitionFormShallowRef
   }
 
   /**
@@ -48,7 +46,6 @@ export default class CompetitionDetailsEditPageContext extends BaseFuroContext {
     route,
     fetcherHash,
     currentStepRef,
-    editCompetitionFormShallowRef,
   }) {
     return /** @type {InstanceType<T>} */ (
       new this({
@@ -57,7 +54,6 @@ export default class CompetitionDetailsEditPageContext extends BaseFuroContext {
         route,
         fetcherHash,
         currentStepRef,
-        editCompetitionFormShallowRef,
       })
     )
   }
@@ -248,7 +244,6 @@ export default class CompetitionDetailsEditPageContext extends BaseFuroContext {
  *     competitionDetailsEdit: import('./CompetitionDetailsEditFetcher').default
  *   }
  *   currentStepRef: import('vue').Ref<number>
- *   editCompetitionFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
  * }} CompetitionDetailsEditPageContextParams
  */
 

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -25,12 +25,23 @@ import {
 import {
   useGraphqlClient,
 } from '@openreachtech/furo-nuxt'
+import useAppFormClerk from '~/composables/useAppFormClerk'
 
 import CompetitionQueryGraphqlLauncher from '~/app/graphql/client/queries/competition/CompetitionQueryGraphqlLauncher'
+import UpdateCompetitionMutationGraphqlLauncher from '~/app/graphql/client/mutations/updateCompetition/UpdateCompetitionMutationGraphqlLauncher'
+import UpdateCompetitionSchedulesMutationGraphqlLauncher from '~/app/graphql/client/mutations/updateCompetitionSchedules/UpdateCompetitionSchedulesMutationGraphqlLauncher'
+import UpdateCompetitionLimitsMutationGraphqlLauncher from '~/app/graphql/client/mutations/updateCompetitionLimits/UpdateCompetitionLimitsMutationGraphqlLauncher'
+import UpdateCompetitionPrizeRulesMutationGraphqlLauncher from '~/app/graphql/client/mutations/updateCompetitionPrizeRules/UpdateCompetitionPrizeRulesMutationGraphqlLauncher'
+
+import UpdateCompetitionFormElementClerk from '~/app/domClerk/UpdateCompetitionFormElementClerk'
+import UpdateCompetitionSchedulesFormElementClerk from '~/app/domClerk/UpdateCompetitionSchedulesFormElementClerk'
+import UpdateCompetitionLimitsFormElementClerk from '~/app/domClerk/UpdateCompetitionLimitsFormElementClerk'
+import UpdateCompetitionPrizeRulesFormElementClerk from '~/app/domClerk/UpdateCompetitionPrizeRulesFormElementClerk'
 
 import CompetitionDetailsEditFetcher from './CompetitionDetailsEditFetcher'
 
 import CompetitionDetailsEditPageContext from './CompetitionDetailsEditPageContext'
+import CompetitionDetailsEditMutationContext from './CompetitionDetailsEditMutationContext'
 
 export default defineComponent({
   components: {
@@ -55,6 +66,10 @@ export default defineComponent({
     const editCompetitionFormShallowRef = shallowRef(null)
     const statusReactive = reactive({
       isLoadingInitialValue: true,
+      isUpdatingCompetition: false,
+      isUpdatingCompetitionSchedules: false,
+      isUpdatingCompetitionLimits: false,
+      isUpdatingCompetitionPrizeRules: false,
     })
 
     const competitionGraphqlClient = useGraphqlClient(CompetitionQueryGraphqlLauncher)
@@ -80,8 +95,51 @@ export default defineComponent({
     const context = CompetitionDetailsEditPageContext.create(args)
       .setupComponent()
 
+    const updateCompetitionGraphqlClient = useGraphqlClient(UpdateCompetitionMutationGraphqlLauncher)
+    const updateCompetitionFormClerk = useAppFormClerk({
+      FormElementClerk: UpdateCompetitionFormElementClerk,
+      invokeRequestWithFormValueHash: updateCompetitionGraphqlClient.invokeRequestWithFormValueHash,
+    })
+    const updateCompetitionSchedulesGraphqlClient = useGraphqlClient(UpdateCompetitionSchedulesMutationGraphqlLauncher)
+    const updateCompetitionSchedulesFormClerk = useAppFormClerk({
+      FormElementClerk: UpdateCompetitionSchedulesFormElementClerk,
+      invokeRequestWithFormValueHash: updateCompetitionSchedulesGraphqlClient.invokeRequestWithFormValueHash,
+    })
+    const updateCompetitionLimitsGraphqlClient = useGraphqlClient(UpdateCompetitionLimitsMutationGraphqlLauncher)
+    const updateCompetitionLimitsFormClerk = useAppFormClerk({
+      FormElementClerk: UpdateCompetitionLimitsFormElementClerk,
+      invokeRequestWithFormValueHash: updateCompetitionLimitsGraphqlClient.invokeRequestWithFormValueHash,
+    })
+    const updateCompetitionPrizeRulesGraphqlClient = useGraphqlClient(UpdateCompetitionPrizeRulesMutationGraphqlLauncher)
+    const updateCompetitionPrizeRulesFormClerk = useAppFormClerk({
+      FormElementClerk: UpdateCompetitionPrizeRulesFormElementClerk,
+      invokeRequestWithFormValueHash: updateCompetitionPrizeRulesGraphqlClient.invokeRequestWithFormValueHash,
+    })
+
+    const mutationArgs = {
+      props,
+      componentContext,
+      route,
+      graphqlClientHash: {
+        updateCompetition: updateCompetitionGraphqlClient,
+        updateCompetitionSchedules: updateCompetitionSchedulesGraphqlClient,
+        updateCompetitionLimits: updateCompetitionLimitsGraphqlClient,
+        updateCompetitionPrizeRules: updateCompetitionPrizeRulesGraphqlClient,
+      },
+      formClerkHash: {
+        updateCompetition: updateCompetitionFormClerk,
+        updateCompetitionSchedules: updateCompetitionSchedulesFormClerk,
+        updateCompetitionLimits: updateCompetitionLimitsFormClerk,
+        updateCompetitionPrizeRules: updateCompetitionPrizeRulesFormClerk,
+      },
+      statusReactive,
+    }
+    const mutationContext = CompetitionDetailsEditMutationContext.create(mutationArgs)
+      .setupComponent()
+
     return {
       context,
+      mutationContext,
     }
   },
 })

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -161,7 +161,7 @@ export default defineComponent({
       </span>
     </div>
 
-    <form class="unit-form">
+    <div class="unit-form-container">
       <div class="steps">
         <div class="content">
           <AddCompetitionFormStepDetails class="step"
@@ -208,7 +208,7 @@ export default defineComponent({
         :steps="context.steps"
         @go-to-step="context.goToStep($event)"
       />
-    </form>
+    </div>
   </div>
 </template>
 
@@ -250,7 +250,7 @@ export default defineComponent({
   line-height: var(--size-line-height-large);
 }
 
-.unit-form {
+.unit-form-container {
   margin-block-start: 2.25rem;
 
   display: flex;
@@ -264,7 +264,7 @@ export default defineComponent({
   }
 }
 
-.unit-form > .steps {
+.unit-form-container > .steps {
   border-radius: 1.25rem;
 
   padding-block: 1.25rem;
@@ -281,20 +281,20 @@ export default defineComponent({
   }
 }
 
-.unit-form > .steps > .content {
+.unit-form-container > .steps > .content {
   display: grid;
 }
 
-.unit-form > .steps > .content > * {
+.unit-form-container > .steps > .content > * {
   grid-row: 1 / -1;
   grid-column: 1 / -1;
 }
 
-.unit-form > .steps > .content > .step.hidden {
+.unit-form-container > .steps > .content > .step.hidden {
   visibility: hidden;
 }
 
-.unit-form > .steps > .actions {
+.unit-form-container > .steps > .actions {
   margin-block-start: 2.5rem;
 
   display: flex;
@@ -302,7 +302,7 @@ export default defineComponent({
   gap: 1rem;
 }
 
-.unit-form > .steps > .actions > .button.back {
+.unit-form-container > .steps > .actions > .button.back {
   padding-block: 0.625rem;
   padding-inline: 0.625rem;
 }

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -178,6 +178,7 @@ export default defineComponent({
           :class="context.generateStepClasses({
             step: 1,
           })"
+          @submit.prevent="mutationContext.submitFormUpdateCompetition()"
         >
           <AddCompetitionFormStepDetails :validation-message="mutationContext.updateCompetitionValidationMessage"
             :initial-form-value-hash="context.generateStepDetailsInitialValueHash()"
@@ -185,6 +186,7 @@ export default defineComponent({
           />
           <AppButton type="submit"
             class="button submit"
+            :is-loading="mutationContext.isUpdatingCompetition"
           >
             Save changes
           </AppButton>
@@ -195,6 +197,7 @@ export default defineComponent({
           :class="context.generateStepClasses({
             step: 2,
           })"
+          @submit.prevent="mutationContext.submitFormUpdateCompetitionSchedules()"
         >
           <AddCompetitionFormStepTimeline :validation-message="mutationContext.updateCompetitionSchedulesValidationMessage"
             :initial-form-value-hash="context.generateStepTimelineInitialValueHash()"
@@ -202,6 +205,7 @@ export default defineComponent({
           />
           <AppButton type="submit"
             class="button submit"
+            :is-loading="mutationContext.isUpdatingCompetitionSchedules"
           >
             Save changes
           </AppButton>
@@ -212,6 +216,7 @@ export default defineComponent({
           :class="context.generateStepClasses({
             step: 3,
           })"
+          @submit.prevent="mutationContext.submitFormUpdateCompetitionLimits()"
         >
           <AddCompetitionFormStepParticipation :validation-message="mutationContext.updateCompetitionLimitsValidationMessage"
             :initial-form-value-hash="context.generateStepParticipationInitialValueHash()"
@@ -219,6 +224,7 @@ export default defineComponent({
           />
           <AppButton type="submit"
             class="button submit"
+            :is-loading="mutationContext.isUpdatingCompetitionLimits"
           >
             Save changes
           </AppButton>
@@ -229,6 +235,7 @@ export default defineComponent({
           :class="context.generateStepClasses({
             step: 4,
           })"
+          @submit.prevent="mutationContext.submitFormUpdateCompetitionPrizeRules()"
         >
           <AddCompetitionFormStepPrize :validation-message="mutationContext.updateCompetitionPrizeRulesValidationMessage"
             :initial-form-value-hash="context.generateStepPrizeInitialValueHash()"
@@ -236,6 +243,7 @@ export default defineComponent({
           />
           <AppButton type="submit"
             class="button submit"
+            :is-loading="mutationContext.isUpdatingCompetitionPrizeRules"
           >
             Save changes
           </AppButton>

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -163,45 +163,69 @@ export default defineComponent({
 
     <div class="unit-form-container">
       <div class="steps">
-        <div class="content">
-          <AddCompetitionFormStepDetails class="step"
-            :class="context.generateStepClasses({
-              step: 1,
-            })"
-            :validation-message="mutationContext.updateCompetitionValidationMessage"
+        <form class="unit-form step"
+          :class="context.generateStepClasses({
+            step: 1,
+          })"
+        >
+          <AddCompetitionFormStepDetails :validation-message="mutationContext.updateCompetitionValidationMessage"
             :initial-form-value-hash="context.generateStepDetailsInitialValueHash()"
+            class="controls"
           />
-
-          <AddCompetitionFormStepTimeline class="step"
-            :class="context.generateStepClasses({
-              step: 2,
-            })"
-            :validation-message="mutationContext.updateCompetitionSchedulesValidationMessage"
-            :initial-form-value-hash="context.generateStepTimelineInitialValueHash()"
-          />
-
-          <AddCompetitionFormStepParticipation class="step"
-            :class="context.generateStepClasses({
-              step: 3,
-            })"
-            :validation-message="mutationContext.updateCompetitionLimitsValidationMessage"
-            :initial-form-value-hash="context.generateStepParticipationInitialValueHash()"
-          />
-
-          <AddCompetitionFormStepPrize class="step"
-            :class="context.generateStepClasses({
-              step: 4,
-            })"
-            :validation-message="mutationContext.updateCompetitionPrizeRulesValidationMessage"
-            :initial-form-value-hash="context.generateStepPrizeInitialValueHash()"
-          />
-        </div>
-
-        <div class="actions">
-          <AppButton>
+          <AppButton type="submit"
+            class="button submit"
+          >
             Save changes
           </AppButton>
-        </div>
+        </form>
+
+        <form class="unit-form step"
+          :class="context.generateStepClasses({
+            step: 2,
+          })"
+        >
+          <AddCompetitionFormStepTimeline :validation-message="mutationContext.updateCompetitionSchedulesValidationMessage"
+            :initial-form-value-hash="context.generateStepTimelineInitialValueHash()"
+            class="controls"
+          />
+          <AppButton type="submit"
+            class="button submit"
+          >
+            Save changes
+          </AppButton>
+        </form>
+
+        <form class="unit-form step"
+          :class="context.generateStepClasses({
+            step: 3,
+          })"
+        >
+          <AddCompetitionFormStepParticipation :validation-message="mutationContext.updateCompetitionLimitsValidationMessage"
+            :initial-form-value-hash="context.generateStepParticipationInitialValueHash()"
+            class="controls"
+          />
+          <AppButton type="submit"
+            class="button submit"
+          >
+            Save changes
+          </AppButton>
+        </form>
+
+        <form class="unit-form step"
+          :class="context.generateStepClasses({
+            step: 4,
+          })"
+        >
+          <AddCompetitionFormStepPrize :validation-message="mutationContext.updateCompetitionPrizeRulesValidationMessage"
+            :initial-form-value-hash="context.generateStepPrizeInitialValueHash()"
+            class="controls"
+          />
+          <AppButton type="submit"
+            class="button submit"
+          >
+            Save changes
+          </AppButton>
+        </form>
       </div>
 
       <AddCompetitionFormSteps :current-step="context.currentStep"
@@ -265,6 +289,8 @@ export default defineComponent({
 }
 
 .unit-form-container > .steps {
+  display: grid;
+
   border-radius: 1.25rem;
 
   padding-block: 1.25rem;
@@ -281,29 +307,28 @@ export default defineComponent({
   }
 }
 
-.unit-form-container > .steps > .content {
-  display: grid;
-}
-
-.unit-form-container > .steps > .content > * {
+.unit-form-container > .steps > * {
   grid-row: 1 / -1;
   grid-column: 1 / -1;
 }
 
-.unit-form-container > .steps > .content > .step.hidden {
+.unit-form-container > .steps > .step.hidden {
   visibility: hidden;
 }
 
-.unit-form-container > .steps > .actions {
-  margin-block-start: 2.5rem;
-
+.unit-form {
   display: flex;
-  justify-content: end;
-  gap: 1rem;
+  flex-direction: column;
+  min-width: 0;
 }
 
-.unit-form-container > .steps > .actions > .button.back {
-  padding-block: 0.625rem;
-  padding-inline: 0.625rem;
+.unit-form > .controls {
+  flex: 1;
+}
+
+.unit-form > .button.submit {
+  margin-block-start: 2.5rem;
+
+  align-self: end;
 }
 </style>

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -168,7 +168,7 @@ export default defineComponent({
             :class="context.generateStepClasses({
               step: 1,
             })"
-            :validation-message="{}"
+            :validation-message="mutationContext.updateCompetitionValidationMessage"
             :initial-form-value-hash="context.generateStepDetailsInitialValueHash()"
           />
 
@@ -176,7 +176,7 @@ export default defineComponent({
             :class="context.generateStepClasses({
               step: 2,
             })"
-            :validation-message="{}"
+            :validation-message="mutationContext.updateCompetitionSchedulesValidationMessage"
             :initial-form-value-hash="context.generateStepTimelineInitialValueHash()"
           />
 
@@ -184,7 +184,7 @@ export default defineComponent({
             :class="context.generateStepClasses({
               step: 3,
             })"
-            :validation-message="{}"
+            :validation-message="mutationContext.updateCompetitionLimitsValidationMessage"
             :initial-form-value-hash="context.generateStepParticipationInitialValueHash()"
           />
 
@@ -192,7 +192,7 @@ export default defineComponent({
             :class="context.generateStepClasses({
               step: 4,
             })"
-            :validation-message="{}"
+            :validation-message="mutationContext.updateCompetitionPrizeRulesValidationMessage"
             :initial-form-value-hash="context.generateStepPrizeInitialValueHash()"
           />
         </div>

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -259,6 +259,7 @@ export default defineComponent({
           >
           <AddCompetitionFormStepPrize :validation-message="mutationContext.updateCompetitionPrizeRulesValidationMessage"
             :initial-form-value-hash="context.generateStepPrizeInitialValueHash()"
+            should-omit-total-prize
             class="controls"
           />
           <AppButton type="submit"

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -198,14 +198,6 @@ export default defineComponent({
         </div>
 
         <div class="actions">
-          <AppButton appearance="outlined"
-            class="button back"
-            type="button"
-          >
-            <Icon name="heroicons-outline:chevron-left"
-              size="1rem"
-            />
-          </AppButton>
           <AppButton>
             Save changes
           </AppButton>

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -62,8 +62,6 @@ export default defineComponent({
     const route = useRoute()
 
     const currentStepRef = ref(1)
-    /** @type {import('vue').ShallowRef<HTMLFormElement | null>} */
-    const editCompetitionFormShallowRef = shallowRef(null)
     const statusReactive = reactive({
       isLoadingInitialValue: true,
       isUpdatingCompetition: false,
@@ -90,10 +88,18 @@ export default defineComponent({
         competitionDetailsEdit: competitionDetailsEditFetcher,
       },
       currentStepRef,
-      editCompetitionFormShallowRef,
     }
     const context = CompetitionDetailsEditPageContext.create(args)
       .setupComponent()
+
+    /** @type {import('vue').ShallowRef<HTMLFormElement | null>} */
+    const updateCompetitionFormShallowRef = shallowRef(null)
+    /** @type {import('vue').ShallowRef<HTMLFormElement | null>} */
+    const updateCompetitionSchedulesFormShallowRef = shallowRef(null)
+    /** @type {import('vue').ShallowRef<HTMLFormElement | null>} */
+    const updateCompetitionLimitsFormShallowRef = shallowRef(null)
+    /** @type {import('vue').ShallowRef<HTMLFormElement | null>} */
+    const updateCompetitionPrizeRulesFormShallowRef = shallowRef(null)
 
     const updateCompetitionGraphqlClient = useGraphqlClient(UpdateCompetitionMutationGraphqlLauncher)
     const updateCompetitionFormClerk = useAppFormClerk({
@@ -132,6 +138,10 @@ export default defineComponent({
         updateCompetitionLimits: updateCompetitionLimitsFormClerk,
         updateCompetitionPrizeRules: updateCompetitionPrizeRulesFormClerk,
       },
+      updateCompetitionFormShallowRef,
+      updateCompetitionSchedulesFormShallowRef,
+      updateCompetitionLimitsFormShallowRef,
+      updateCompetitionPrizeRulesFormShallowRef,
       statusReactive,
     }
     const mutationContext = CompetitionDetailsEditMutationContext.create(mutationArgs)
@@ -163,7 +173,8 @@ export default defineComponent({
 
     <div class="unit-form-container">
       <div class="steps">
-        <form class="unit-form step"
+        <form :ref="mutationContext.updateCompetitionFormShallowRef"
+          class="unit-form step"
           :class="context.generateStepClasses({
             step: 1,
           })"
@@ -179,7 +190,8 @@ export default defineComponent({
           </AppButton>
         </form>
 
-        <form class="unit-form step"
+        <form :ref="mutationContext.updateCompetitionSchedulesFormShallowRef"
+          class="unit-form step"
           :class="context.generateStepClasses({
             step: 2,
           })"
@@ -195,7 +207,8 @@ export default defineComponent({
           </AppButton>
         </form>
 
-        <form class="unit-form step"
+        <form :ref="mutationContext.updateCompetitionLimitsFormShallowRef"
+          class="unit-form step"
           :class="context.generateStepClasses({
             step: 3,
           })"
@@ -211,7 +224,8 @@ export default defineComponent({
           </AppButton>
         </form>
 
-        <form class="unit-form step"
+        <form :ref="mutationContext.updateCompetitionPrizeRulesFormShallowRef"
+          class="unit-form step"
           :class="context.generateStepClasses({
             step: 4,
           })"

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -214,6 +214,7 @@ export default defineComponent({
 
       <AddCompetitionFormSteps :current-step="context.currentStep"
         :steps="context.steps"
+        @go-to-step="context.goToStep($event)"
       />
     </form>
   </div>

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -180,6 +180,11 @@ export default defineComponent({
           })"
           @submit.prevent="mutationContext.submitFormUpdateCompetition()"
         >
+          <input type="number"
+            class="input hidden"
+            name="competitionId"
+            :value="mutationContext.extractCompetitionIdFromRoute()"
+          >
           <AddCompetitionFormStepDetails :validation-message="mutationContext.updateCompetitionValidationMessage"
             :initial-form-value-hash="context.generateStepDetailsInitialValueHash()"
             class="controls"
@@ -199,6 +204,11 @@ export default defineComponent({
           })"
           @submit.prevent="mutationContext.submitFormUpdateCompetitionSchedules()"
         >
+          <input type="number"
+            class="input hidden"
+            name="competitionId"
+            :value="mutationContext.extractCompetitionIdFromRoute()"
+          >
           <AddCompetitionFormStepTimeline :validation-message="mutationContext.updateCompetitionSchedulesValidationMessage"
             :initial-form-value-hash="context.generateStepTimelineInitialValueHash()"
             class="controls"
@@ -218,6 +228,11 @@ export default defineComponent({
           })"
           @submit.prevent="mutationContext.submitFormUpdateCompetitionLimits()"
         >
+          <input type="number"
+            class="input hidden"
+            name="competitionId"
+            :value="mutationContext.extractCompetitionIdFromRoute()"
+          >
           <AddCompetitionFormStepParticipation :validation-message="mutationContext.updateCompetitionLimitsValidationMessage"
             :initial-form-value-hash="context.generateStepParticipationInitialValueHash()"
             class="controls"
@@ -237,6 +252,11 @@ export default defineComponent({
           })"
           @submit.prevent="mutationContext.submitFormUpdateCompetitionPrizeRules()"
         >
+          <input type="number"
+            class="input hidden"
+            name="competitionId"
+            :value="mutationContext.extractCompetitionIdFromRoute()"
+          >
           <AddCompetitionFormStepPrize :validation-message="mutationContext.updateCompetitionPrizeRulesValidationMessage"
             :initial-form-value-hash="context.generateStepPrizeInitialValueHash()"
             class="controls"
@@ -342,6 +362,10 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   min-width: 0;
+}
+
+.unit-form > .input.hidden {
+  display: none;
 }
 
 .unit-form > .controls {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2813

# How

* Create mutation context for competition details edit page.
* Refactor the form structure to allow to invoke mutation every step.
* Remove prev-button. The design does not include it in the edit page.
