### PR TITLE
Sync initial value of date picker and prize rules only once

### DIFF
--- a/components/competition-add/AddCompetitionFormStepPrizeContext.js
+++ b/components/competition-add/AddCompetitionFormStepPrizeContext.js
@@ -126,6 +126,9 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
       () => this.initialPrizeRules,
       () => {
         this.syncInitialPrizeRules()
+      },
+      {
+        once: true,
       }
     )
 

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -80,6 +80,9 @@ export default class AppDatePikcerContext extends BaseFuroContext {
       () => this.initialDate,
       () => {
         this.syncInitialInputValue()
+      },
+      {
+        once: true,
       }
     )
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2832

# How

* Sync initial value of date picker and prize rules only once, after the API call was a success.
