### PR TITLE
Sync prize rules only if its length changed

### DIFF
--- a/components/competition-add/AddCompetitionFormStepPrizeContext.js
+++ b/components/competition-add/AddCompetitionFormStepPrizeContext.js
@@ -123,7 +123,8 @@ export default class AddCompetitionFormStepPrizeContext extends BaseFuroContext 
    */
   setupComponent () {
     this.watch(
-      () => this.initialPrizeRules,
+      // This array always starts empty. We only invoke one-time watcher if it is no longer empty.
+      () => this.initialPrizeRules.length,
       () => {
         this.syncInitialPrizeRules()
       },


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2859

# How

* Vue's watcher compares new value and old value with `===`. This means two arrays will always be different from each other. We only want to invoke the one time `watcher` is the actual data has been fetched.
* This PR used the array's length as the watcher source to ensure the sync function is only called once the actual data has been fetched.
* `JSON.stringify()` has also been considered but not chosen because of some caveats.
