### PR TITLE
Implement a page to control self-hosted competitions

### DIFF
--- a/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlPayload.js
@@ -54,6 +54,7 @@ export default class CompetitionsQueryGraphqlPayload extends BaseAppGraphqlPaylo
  *   input: {
  *     title?: string
  *     statusId?: number
+ *     hostAddress?: string
  *     pagination: {
  *       limit: number
  *       offset: number

--- a/app/vue/contexts/CompetitionsPageContext.js
+++ b/app/vue/contexts/CompetitionsPageContext.js
@@ -128,7 +128,7 @@ export default class CompetitionsPageContext extends BaseFuroContext {
     title,
     statusId,
   } = {}) {
-    const replacementQuery = this.buileTitleReplacementQuery({
+    const replacementQuery = this.buildTitleReplacementQuery({
       title,
     })
 
@@ -166,7 +166,7 @@ export default class CompetitionsPageContext extends BaseFuroContext {
    * }} params - Parameters.
    * @returns {import('vue-router').LocationQuery}
    */
-  buileTitleReplacementQuery ({
+  buildTitleReplacementQuery ({
     title,
   }) {
     const {

--- a/pages/hosted-arenas/HostedArenasFetcher.js
+++ b/pages/hosted-arenas/HostedArenasFetcher.js
@@ -1,0 +1,231 @@
+import {
+  PAGINATION,
+} from '~/app/constants'
+
+export default class HostedArenasFetcher {
+  /**
+   * Constructor of this class.
+   *
+   * @param {HostedArenasFetcherParams} params - Parameters.
+   */
+  constructor ({
+    route,
+    walletStore,
+    graphqlClientHash,
+    statusReactive,
+  }) {
+    this.route = route
+    this.walletStore = walletStore
+    this.graphqlClientHash = graphqlClientHash
+    this.statusReactive = statusReactive
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof HostedArenasFetcher ? X : never} T, X
+   * @param {HostedArenasFetcherFactoryParams} params - Parameters.
+   * @returns {InstanceType<T>}
+   * @this {T}
+   */
+  static create ({
+    route,
+    walletStore,
+    graphqlClientHash,
+    statusReactive,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        route,
+        walletStore,
+        graphqlClientHash,
+        statusReactive,
+      })
+    )
+  }
+
+  /**
+   * get: competitionsCapsule
+   *
+   * @returns {import('~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule').default}
+   */
+  get competitionsCapsule () {
+    return this.graphqlClientHash
+      .competitions
+      .capsuleRef
+      .value
+  }
+
+  /**
+   * get: localWalletAddress
+   *
+   * @returns {string | null}
+   */
+  get localWalletAddress () {
+    return this.walletStore
+      .walletStoreRef
+      .value
+      .localWallet
+      .address
+  }
+
+  /**
+   * Fetch `competitions` on event.
+   *
+   * @returns {Promise<void>}
+   */
+  async fetchCompetitionsOnEvent () {
+    const title = this.extractTitleFromRoute()
+    const statusId = this.extractStatusIdFromRoute()
+    const pagination = this.generatePagination()
+
+    await this.graphqlClientHash
+      .competitions
+      .invokeRequestOnEvent({
+        variables: {
+          input: {
+            title,
+            statusId,
+            hostAddress: this.localWalletAddress,
+            pagination,
+          },
+        },
+      })
+  }
+
+  /**
+   * Fetch `competitions` on mounted.
+   *
+   * @returns {void}
+   */
+  fetchCompetitionsOnMounted () {
+    const title = this.extractTitleFromRoute()
+    const statusId = this.extractStatusIdFromRoute()
+    const pagination = this.generatePagination()
+
+    this.graphqlClientHash
+      .competitions
+      .invokeRequestOnMounted({
+        variables: {
+          input: {
+            title,
+            statusId,
+            hostAddress: this.localWalletAddress,
+            pagination,
+          },
+        },
+      })
+  }
+
+  /**
+   * get: competitionsLauncherHooks
+   *
+   * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
+   */
+  get competitionsLauncherHooks () {
+    return {
+      beforeRequest: async payload => {
+        this.statusReactive.isLoadingCompetitions = true
+
+        return false
+      },
+      afterRequest: async capsule => {
+        this.statusReactive.isLoadingCompetitions = false
+      },
+    }
+  }
+
+  /**
+   * Extract title from route.
+   *
+   * @returns {string | null}
+   */
+  extractTitleFromRoute () {
+    const queryTitle = Array.isArray(this.route.query.title)
+      ? this.route.query.title[0]
+      : this.route.query.title
+
+    return queryTitle
+      ?? null
+  }
+
+  /**
+   * Extract status id from route.
+   *
+   * @returns {number | null}
+   */
+  extractStatusIdFromRoute () {
+    const queryStatusId = Array.isArray(this.route.query.statusId)
+      ? this.route.query.statusId[0]
+      : this.route.query.statusId
+
+    const statusId = Number(queryStatusId)
+    if (isNaN(statusId)) {
+      return null
+    }
+
+    return statusId
+  }
+
+  /**
+   * Generate pagination.
+   *
+   * @returns {Pagination}
+   */
+  generatePagination () {
+    const currentPage = this.extractCurrentPageFromRoute()
+
+    return {
+      limit: PAGINATION.LIMIT,
+      offset: (currentPage - 1) * PAGINATION.LIMIT,
+    }
+  }
+
+  /**
+   * Extract current page from route.
+   *
+   * @returns {number}.
+   */
+  extractCurrentPageFromRoute () {
+    const currentPageQuery = Array.isArray(this.route.query.page)
+      ? this.route.query.page[0]
+      : this.route.query.page
+    const currentPage = Number(currentPageQuery)
+
+    return isNaN(currentPage)
+      ? 1
+      : currentPage
+  }
+}
+
+/**
+ * @typedef {{
+ *   route: ReturnType<import('vue-router').useRoute>
+ *   walletStore: ReturnType<import('~/stores/wallet').default>
+ *   graphqlClientHash: {
+ *     competitions: GraphqlClient
+ *   }
+ *   statusReactive: import('vue').Reactive<{
+ *     isLoadingCompetitions: boolean
+ *   }>
+ * }} HostedArenasFetcherParams
+ */
+
+/**
+ * @typedef {HostedArenasFetcherParams} HostedArenasFetcherFactoryParams
+ */
+
+/**
+ * @typedef {ReturnType<import('@openreachtech/furo-nuxt').useGraphqlClient>} GraphqlClient
+ */
+
+/**
+ * @typedef {{
+ *   limit: number
+ *   offset: number
+ *   sort?: {
+ *     targetColumn: string
+ *     orderBy: string
+ *   }
+ * }} Pagination
+ */

--- a/pages/hosted-arenas/HostedArenasPageContext.js
+++ b/pages/hosted-arenas/HostedArenasPageContext.js
@@ -73,7 +73,66 @@ export default class HostedArenasPageContext extends BaseFuroContext {
   setupComponent () {
     this.hostedArenasFetcher.fetchCompetitionsOnMounted()
 
+    this.watch(
+      [
+        () => this.extractTitleFromRoute(),
+        () => this.extractStatusIdFromRoute(),
+        () => this.extractCurrentPageFromRoute(),
+      ],
+      async () => {
+        await this.hostedArenasFetcher.fetchCompetitionsOnEvent()
+      }
+    )
+
     return this
+  }
+
+  /**
+   * Extract title from route.
+   *
+   * @returns {string | null}
+   */
+  extractTitleFromRoute () {
+    const queryTitle = Array.isArray(this.route.query.title)
+      ? this.route.query.title[0]
+      : this.route.query.title
+
+    return queryTitle
+      ?? null
+  }
+
+  /**
+   * Extract status id from route.
+   *
+   * @returns {number | null}
+   */
+  extractStatusIdFromRoute () {
+    const queryStatusId = Array.isArray(this.route.query.statusId)
+      ? this.route.query.statusId[0]
+      : this.route.query.statusId
+
+    const statusId = Number(queryStatusId)
+    if (isNaN(statusId)) {
+      return null
+    }
+
+    return statusId
+  }
+
+  /**
+   * Extract current page from route.
+   *
+   * @returns {number}.
+   */
+  extractCurrentPageFromRoute () {
+    const currentPageQuery = Array.isArray(this.route.query.page)
+      ? this.route.query.page[0]
+      : this.route.query.page
+    const currentPage = Number(currentPageQuery)
+
+    return isNaN(currentPage)
+      ? 1
+      : currentPage
   }
 }
 

--- a/pages/hosted-arenas/HostedArenasPageContext.js
+++ b/pages/hosted-arenas/HostedArenasPageContext.js
@@ -8,5 +8,84 @@ import {
  * @extends {BaseFuroContext<null, {}, null>}
  */
 export default class HostedArenasPageContext extends BaseFuroContext {
+  /**
+   * Constructor
+   *
+   * @param {HostedArenasPageContextParams} params - Parameters of this constructor.
+   */
+  constructor ({
+    props,
+    componentContext,
 
+    route,
+    fetcherHash,
+  }) {
+    super({
+      props,
+      componentContext,
+    })
+
+    this.route = route
+    this.fetcherHash = fetcherHash
+  }
+
+  /**
+   * Factory method to create a new instance of this class.
+   *
+   * @template {X extends typeof HostedArenasPageContext ? X : never} T, X
+   * @override
+   * @param {HostedArenasPageContextFactoryParams} params - Parameters of this factory method.
+   * @returns {InstanceType<T>} An instance of this class.
+   * @this {T}
+   */
+  static create ({
+    props,
+    componentContext,
+    route,
+    fetcherHash,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        props,
+        componentContext,
+        route,
+        fetcherHash,
+      })
+    )
+  }
+
+  /**
+   * get: hostedArenasFetcher
+   *
+   * @returns {import('./HostedArenasFetcher').default}
+   */
+  get hostedArenasFetcher () {
+    return this.fetcherHash.hostedArenas
+  }
+
+  /**
+   * Setup component.
+   *
+   * @template {X extends HostedArenasPageContext ? X : never} T, X
+   * @override
+   * @this {T}
+   */
+  setupComponent () {
+    this.hostedArenasFetcher.fetchCompetitionsOnMounted()
+
+    return this
+  }
 }
+
+/**
+ * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams & {
+ *   route: ReturnType<import('vue-router').useRoute>
+ *   fetcherHash: {
+ *     hostedArenas: import('./HostedArenasFetcher').default
+ *   }
+ * }} HostedArenasPageContextParams
+ */
+
+/**
+ * @typedef {HostedArenasPageContextParams} HostedArenasPageContextFactoryParams
+ */

--- a/pages/hosted-arenas/HostedArenasPageContext.js
+++ b/pages/hosted-arenas/HostedArenasPageContext.js
@@ -18,6 +18,7 @@ export default class HostedArenasPageContext extends BaseFuroContext {
     componentContext,
 
     route,
+    router,
     fetcherHash,
   }) {
     super({
@@ -26,6 +27,7 @@ export default class HostedArenasPageContext extends BaseFuroContext {
     })
 
     this.route = route
+    this.router = router
     this.fetcherHash = fetcherHash
   }
 
@@ -42,6 +44,7 @@ export default class HostedArenasPageContext extends BaseFuroContext {
     props,
     componentContext,
     route,
+    router,
     fetcherHash,
   }) {
     return /** @type {InstanceType<T>} */ (
@@ -49,6 +52,7 @@ export default class HostedArenasPageContext extends BaseFuroContext {
         props,
         componentContext,
         route,
+        router,
         fetcherHash,
       })
     )
@@ -134,11 +138,56 @@ export default class HostedArenasPageContext extends BaseFuroContext {
       ? 1
       : currentPage
   }
+
+  /**
+   * Update `title` query.
+   *
+   * @param {{
+   *   title?: string
+   * }} params - Parameters.
+   * @returns {Promise<void>}
+   */
+  async updateTitleQuery ({
+    title,
+  }) {
+    const replacementQuery = this.buileTitleReplacementQuery({
+      title,
+    })
+
+    await this.router.replace({
+      query: replacementQuery,
+    })
+  }
+
+  /**
+   * Build replacement query for `title`.
+   *
+   * @param {{
+   *   title?: string
+   * }} params - Parameters.
+   * @returns {import('vue-router').LocationQuery}
+   */
+  buileTitleReplacementQuery ({
+    title,
+  }) {
+    const {
+      title: _,
+      ...restQuery
+    } = this.route.query
+
+    return title
+      ? {
+        ...restQuery,
+        title,
+      }
+      : restQuery
+  }
 }
 
 /**
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams & {
  *   route: ReturnType<import('vue-router').useRoute>
+ *   router: ReturnType<import('vue-router').useRouter>
  *   fetcherHash: {
  *     hostedArenas: import('./HostedArenasFetcher').default
  *   }

--- a/pages/hosted-arenas/HostedArenasPageContext.js
+++ b/pages/hosted-arenas/HostedArenasPageContext.js
@@ -2,6 +2,10 @@ import {
   BaseFuroContext,
 } from '@openreachtech/furo-nuxt'
 
+import {
+  PAGINATION,
+} from '~/app/constants'
+
 /**
  * HostedArenasPageContext
  *
@@ -182,6 +186,43 @@ export default class HostedArenasPageContext extends BaseFuroContext {
       }
       : restQuery
   }
+
+  /**
+   * get: competitionsCapsule
+   *
+   * @returns {import('~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule').default}
+   */
+  get competitionsCapsule () {
+    return this.fetcherHash
+      .hostedArenas
+      .competitionsCapsule
+  }
+
+  /**
+   * Extract `totalCount`.
+   *
+   * @returns {number}
+   */
+  extractTotalCount () {
+    const {
+      totalCount,
+    } = this.competitionsCapsule
+
+    return totalCount
+      ?? 0
+  }
+
+  /**
+   * Generate `competitions` pagination result.
+   *
+   * @returns {PaginationResult}
+   */
+  generateCompetitionsPaginationResult () {
+    return {
+      limit: PAGINATION.LIMIT,
+      totalRecords: this.extractTotalCount(),
+    }
+  }
 }
 
 /**
@@ -196,4 +237,11 @@ export default class HostedArenasPageContext extends BaseFuroContext {
 
 /**
  * @typedef {HostedArenasPageContextParams} HostedArenasPageContextFactoryParams
+ */
+
+/**
+ * @typedef {{
+ *   limit: number
+ *   totalRecords: number
+ * }} PaginationResult
  */

--- a/pages/hosted-arenas/HostedArenasPageContext.js
+++ b/pages/hosted-arenas/HostedArenasPageContext.js
@@ -154,7 +154,7 @@ export default class HostedArenasPageContext extends BaseFuroContext {
   async updateTitleQuery ({
     title,
   }) {
-    const replacementQuery = this.buileTitleReplacementQuery({
+    const replacementQuery = this.buildTitleReplacementQuery({
       title,
     })
 
@@ -171,7 +171,7 @@ export default class HostedArenasPageContext extends BaseFuroContext {
    * }} params - Parameters.
    * @returns {import('vue-router').LocationQuery}
    */
-  buileTitleReplacementQuery ({
+  buildTitleReplacementQuery ({
     title,
   }) {
     const {

--- a/pages/hosted-arenas/index.vue
+++ b/pages/hosted-arenas/index.vue
@@ -19,6 +19,7 @@ import {
 } from '#components'
 
 import AppSearchBar from '~/components/units/AppSearchBar.vue'
+import AppPagination from '~/components/units/AppPagination.vue'
 
 import CompetitionsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher'
 
@@ -30,6 +31,7 @@ export default defineComponent({
     NuxtLink,
     Icon,
     AppSearchBar,
+    AppPagination,
   },
 
   setup (
@@ -90,10 +92,13 @@ export default defineComponent({
 
     <AppSearchBar placeholder="Search your hosted arenas"
       size="large"
+      class="search"
       @search="query => context.updateTitleQuery({
         title: query,
       })"
     />
+
+    <AppPagination :pagination="context.generateCompetitionsPaginationResult()" />
   </div>
 </template>
 
@@ -139,5 +144,9 @@ export default defineComponent({
   font-size: var(--font-size-large);
   font-weight: 500;
   line-height: var(--size-line-height-large);
+}
+
+.unit-page > .search {
+  margin-block-end: 1.5rem;
 }
 </style>

--- a/pages/hosted-arenas/index.vue
+++ b/pages/hosted-arenas/index.vue
@@ -3,9 +3,19 @@ import {
   defineComponent,
 } from 'vue'
 
+import {
+  NuxtLink,
+  Icon,
+} from '#components'
+
 import HostedArenasPageContext from './HostedArenasPageContext'
 
 export default defineComponent({
+  components: {
+    NuxtLink,
+    Icon,
+  },
+
   setup (
     props,
     componentContext
@@ -26,6 +36,62 @@ export default defineComponent({
 
 <template>
   <div class="unit-page">
-    Hosted Arenas
+    <div class="header">
+      <NuxtLink to="/competitions"
+        class="link"
+      >
+        <Icon name="heroicons-outline:arrow-left"
+          size="1.5rem"
+        />
+      </NuxtLink>
+      <span class="heading">
+        My Hosted Arenas
+      </span>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.unit-page {
+  margin-inline: auto;
+
+  max-width: var(--size-body-max-width);
+
+  padding-block-end: 12rem;
+  padding-inline: var(--size-body-padding-inline-mobile);
+
+  @media (30rem < width) {
+    padding-inline: var(--size-body-padding-inline-desktop);
+  }
+}
+
+.unit-page > .header {
+  margin-block-end: 2.25rem;
+
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
+  color: var(--color-text-primary);
+}
+
+.unit-page > .header > .link {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
+  color: inherit;
+}
+
+.unit-page > .header > .link.back {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.unit-page > .header > .heading {
+  font-size: var(--font-size-large);
+  font-weight: 500;
+  line-height: var(--size-line-height-large);
+}
+</style>

--- a/pages/hosted-arenas/index.vue
+++ b/pages/hosted-arenas/index.vue
@@ -1,13 +1,25 @@
 <script>
 import {
   defineComponent,
+  reactive,
 } from 'vue'
+
+import {
+  useRoute,
+} from 'vue-router'
+import {
+  useGraphqlClient,
+} from '@openreachtech/furo-nuxt'
+import useWalletStore from '~/stores/wallet'
 
 import {
   NuxtLink,
   Icon,
 } from '#components'
 
+import CompetitionsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher'
+
+import HostedArenasFetcher from './HostedArenasFetcher'
 import HostedArenasPageContext from './HostedArenasPageContext'
 
 export default defineComponent({
@@ -20,9 +32,30 @@ export default defineComponent({
     props,
     componentContext
   ) {
+    const route = useRoute()
+    const walletStore = useWalletStore()
+
+    const statusReactive = reactive({
+      isLoadingCompetitions: true,
+    })
+
+    const competitionsGraphqlClient = useGraphqlClient(CompetitionsQueryGraphqlLauncher)
+    const hostedArenasFetcher = HostedArenasFetcher.create({
+      route,
+      walletStore,
+      graphqlClientHash: {
+        competitions: competitionsGraphqlClient,
+      },
+      statusReactive,
+    })
+
     const args = {
       props,
       componentContext,
+      route,
+      fetcherHash: {
+        hostedArenas: hostedArenasFetcher,
+      },
     }
     const context = HostedArenasPageContext.create(args)
       .setupComponent()

--- a/pages/hosted-arenas/index.vue
+++ b/pages/hosted-arenas/index.vue
@@ -6,6 +6,7 @@ import {
 
 import {
   useRoute,
+  useRouter,
 } from 'vue-router'
 import {
   useGraphqlClient,
@@ -17,6 +18,8 @@ import {
   Icon,
 } from '#components'
 
+import AppSearchBar from '~/components/units/AppSearchBar.vue'
+
 import CompetitionsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher'
 
 import HostedArenasFetcher from './HostedArenasFetcher'
@@ -26,6 +29,7 @@ export default defineComponent({
   components: {
     NuxtLink,
     Icon,
+    AppSearchBar,
   },
 
   setup (
@@ -33,6 +37,7 @@ export default defineComponent({
     componentContext
   ) {
     const route = useRoute()
+    const router = useRouter()
     const walletStore = useWalletStore()
 
     const statusReactive = reactive({
@@ -53,6 +58,7 @@ export default defineComponent({
       props,
       componentContext,
       route,
+      router,
       fetcherHash: {
         hostedArenas: hostedArenasFetcher,
       },
@@ -81,6 +87,13 @@ export default defineComponent({
         My Hosted Arenas
       </span>
     </div>
+
+    <AppSearchBar placeholder="Search your hosted arenas"
+      size="large"
+      @search="query => context.updateTitleQuery({
+        title: query,
+      })"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2695

# How

* Implement a page to control self-hosted competitions.
* Table data will be displayed in another PR to avoid large changes.

# Screenshots

![image](https://github.com/user-attachments/assets/b49cc34d-9257-4216-8b27-9072d4e7b4c1)

