### PR TITLE
Fix extended type of GraphQL payloads

### DIFF
--- a/app/graphql/client/mutations/uploadImage/UploadImageMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/uploadImage/UploadImageMutationGraphqlPayload.js
@@ -3,7 +3,7 @@ import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
 /**
  * UploadImageMutation graphql payload
  *
- * @extends {BaseAppGraphqlPayload<typeof UploadImageMutationGraphqlPayload, UploadImageMutationRequestVariables>}
+ * @extends {BaseAppGraphqlPayload<UploadImageMutationRequestVariables>}
  */
 export default class UploadImageMutationGraphqlPayload extends BaseAppGraphqlPayload {
   /** @override */

--- a/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlPayload.js
@@ -3,7 +3,7 @@ import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
 /**
  * AddressCurrentCompetitionQuery graphql payload
  *
- * @extends {BaseAppGraphqlPayload<typeof AddressCurrentCompetitionQueryGraphqlPayload, AddressCurrentCompetitionQueryRequestVariables>}
+ * @extends {BaseAppGraphqlPayload<AddressCurrentCompetitionQueryRequestVariables>}
  */
 export default class AddressCurrentCompetitionQueryGraphqlPayload extends BaseAppGraphqlPayload {
   /** @override */

--- a/app/graphql/client/queries/addressCurrentCompetitionTransfers/AddressCurrentCompetitionTransfersQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressCurrentCompetitionTransfers/AddressCurrentCompetitionTransfersQueryGraphqlPayload.js
@@ -3,7 +3,7 @@ import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
 /**
  * AddressCurrentCompetitionTransfersQuery graphql payload
  *
- * @extends {BaseAppGraphqlPayload<typeof AddressCurrentCompetitionTransfersQueryGraphqlPayload, AddressCurrentCompetitionTransfersQueryRequestVariables>}
+ * @extends {BaseAppGraphqlPayload<AddressCurrentCompetitionTransfersQueryRequestVariables>}
  */
 export default class AddressCurrentCompetitionTransfersQueryGraphqlPayload extends BaseAppGraphqlPayload {
   /** @override */

--- a/app/graphql/client/queries/addressPastCompetitions/AddressPastCompetitionsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressPastCompetitions/AddressPastCompetitionsQueryGraphqlPayload.js
@@ -3,7 +3,7 @@ import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
 /**
  * AddressPastCompetitionsQuery graphql payload
  *
- * @extends {BaseAppGraphqlPayload<typeof AddressPastCompetitionsQueryGraphqlPayload, AddressPastCompetitionsQueryRequestVariables>}
+ * @extends {BaseAppGraphqlPayload<AddressPastCompetitionsQueryRequestVariables>}
  */
 export default class AddressPastCompetitionsQueryGraphqlPayload extends BaseAppGraphqlPayload {
   /** @override */

--- a/app/graphql/client/queries/competition/CompetitionQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competition/CompetitionQueryGraphqlPayload.js
@@ -3,7 +3,7 @@ import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
 /**
  * Competitions query payload.
  *
- * @extends {BaseAppGraphqlPayload<typeof CompetitionQueryGraphqlPayload, CompetitionQueryRequestVariables>}
+ * @extends {BaseAppGraphqlPayload<CompetitionQueryRequestVariables>}
  */
 export default class CompetitionQueryGraphqlPayload extends BaseAppGraphqlPayload {
   /** @override */

--- a/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlPayload.js
@@ -3,7 +3,7 @@ import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
 /**
  * CompetitionLeaderboardQuery graphql payload
  *
- * @extends {BaseAppGraphqlPayload<typeof CompetitionLeaderboardQueryGraphqlPayload, CompetitionLeaderboardQueryRequestVariables>}
+ * @extends {BaseAppGraphqlPayload<CompetitionLeaderboardQueryRequestVariables>}
  */
 export default class CompetitionLeaderboardQueryGraphqlPayload extends BaseAppGraphqlPayload {
   /** @override */

--- a/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlPayload.js
@@ -3,7 +3,7 @@ import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
 /**
  * Competitions query payload.
  *
- * @extends {BaseAppGraphqlPayload<typeof CompetitionsQueryGraphqlPayload, CompetitionsQueryRequestVariables>}
+ * @extends {BaseAppGraphqlPayload<CompetitionsQueryRequestVariables>}
  */
 export default class CompetitionsQueryGraphqlPayload extends BaseAppGraphqlPayload {
   /** @override */

--- a/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlPayload.js
@@ -3,7 +3,7 @@ import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
 /**
  * SearchAddressesByNameQuery graphql payload
  *
- * @extends {BaseAppGraphqlPayload<typeof SearchAddressesByNameQueryGraphqlPayload, SearchAddressesByNameQueryRequestVariables>}
+ * @extends {BaseAppGraphqlPayload<SearchAddressesByNameQueryRequestVariables>}
  */
 export default class SearchAddressesByNameQueryGraphqlPayload extends BaseAppGraphqlPayload {
   /** @override */


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2696

# How

* Fix extended type of GraphQL payloads.
* This occurs because generic of payload changes in newer furo-nuxt versions.
