### PR TITLE
Provide more consistent naming for hosted arena

### DIFF
--- a/pages/hosted-competitions/HostedCompetitionsFetcher.js
+++ b/pages/hosted-competitions/HostedCompetitionsFetcher.js
@@ -2,11 +2,11 @@ import {
   PAGINATION,
 } from '~/app/constants'
 
-export default class HostedArenasFetcher {
+export default class HostedCompetitionsFetcher {
   /**
    * Constructor of this class.
    *
-   * @param {HostedArenasFetcherParams} params - Parameters.
+   * @param {HostedCompetitionsFetcherParams} params - Parameters.
    */
   constructor ({
     route,
@@ -23,8 +23,8 @@ export default class HostedArenasFetcher {
   /**
    * Factory method.
    *
-   * @template {X extends typeof HostedArenasFetcher ? X : never} T, X
-   * @param {HostedArenasFetcherFactoryParams} params - Parameters.
+   * @template {X extends typeof HostedCompetitionsFetcher ? X : never} T, X
+   * @param {HostedCompetitionsFetcherFactoryParams} params - Parameters.
    * @returns {InstanceType<T>}
    * @this {T}
    */
@@ -210,11 +210,11 @@ export default class HostedArenasFetcher {
  *   statusReactive: import('vue').Reactive<{
  *     isLoadingCompetitions: boolean
  *   }>
- * }} HostedArenasFetcherParams
+ * }} HostedCompetitionsFetcherParams
  */
 
 /**
- * @typedef {HostedArenasFetcherParams} HostedArenasFetcherFactoryParams
+ * @typedef {HostedCompetitionsFetcherParams} HostedCompetitionsFetcherFactoryParams
  */
 
 /**

--- a/pages/hosted-competitions/HostedCompetitionsPageContext.js
+++ b/pages/hosted-competitions/HostedCompetitionsPageContext.js
@@ -10,15 +10,15 @@ import {
 import CompetitionBadgeContext from '~/app/vue/contexts/badges/CompetitionBadgeContext'
 
 /**
- * HostedArenasPageContext
+ * HostedCompetitionsPageContext
  *
  * @extends {BaseFuroContext<null, {}, null>}
  */
-export default class HostedArenasPageContext extends BaseFuroContext {
+export default class HostedCompetitionsPageContext extends BaseFuroContext {
   /**
    * Constructor
    *
-   * @param {HostedArenasPageContextParams} params - Parameters of this constructor.
+   * @param {HostedCompetitionsPageContextParams} params - Parameters of this constructor.
    */
   constructor ({
     props,
@@ -43,9 +43,9 @@ export default class HostedArenasPageContext extends BaseFuroContext {
   /**
    * Factory method to create a new instance of this class.
    *
-   * @template {X extends typeof HostedArenasPageContext ? X : never} T, X
+   * @template {X extends typeof HostedCompetitionsPageContext ? X : never} T, X
    * @override
-   * @param {HostedArenasPageContextFactoryParams} params - Parameters of this factory method.
+   * @param {HostedCompetitionsPageContextFactoryParams} params - Parameters of this factory method.
    * @returns {InstanceType<T>} An instance of this class.
    * @this {T}
    */
@@ -79,23 +79,23 @@ export default class HostedArenasPageContext extends BaseFuroContext {
   }
 
   /**
-   * get: hostedArenasFetcher
+   * get: hostedCompetitionsFetcher
    *
-   * @returns {import('./HostedArenasFetcher').default}
+   * @returns {import('./HostedCompetitionsFetcher').default}
    */
-  get hostedArenasFetcher () {
-    return this.fetcherHash.hostedArenas
+  get hostedCompetitionsFetcher () {
+    return this.fetcherHash.hostedCompetitions
   }
 
   /**
    * Setup component.
    *
-   * @template {X extends HostedArenasPageContext ? X : never} T, X
+   * @template {X extends HostedCompetitionsPageContext ? X : never} T, X
    * @override
    * @this {T}
    */
   setupComponent () {
-    this.hostedArenasFetcher.fetchCompetitionsOnMounted()
+    this.hostedCompetitionsFetcher.fetchCompetitionsOnMounted()
 
     this.watch(
       [
@@ -104,7 +104,7 @@ export default class HostedArenasPageContext extends BaseFuroContext {
         () => this.extractCurrentPageFromRoute(),
       ],
       async () => {
-        await this.hostedArenasFetcher.fetchCompetitionsOnEvent()
+        await this.hostedCompetitionsFetcher.fetchCompetitionsOnEvent()
       }
     )
 
@@ -210,7 +210,7 @@ export default class HostedArenasPageContext extends BaseFuroContext {
    */
   get competitionsCapsule () {
     return this.fetcherHash
-      .hostedArenas
+      .hostedCompetitions
       .competitionsCapsule
   }
 
@@ -483,16 +483,16 @@ export default class HostedArenasPageContext extends BaseFuroContext {
  *   route: ReturnType<import('vue-router').useRoute>
  *   router: ReturnType<import('vue-router').useRouter>
  *   fetcherHash: {
- *     hostedArenas: import('./HostedArenasFetcher').default
+ *     hostedCompetitions: import('./HostedCompetitionsFetcher').default
  *   }
  *   statusReactive: import('vue').Reactive<{
  *     isLoadingCompetitions: boolean
  *   }>
- * }} HostedArenasPageContextParams
+ * }} HostedCompetitionsPageContextParams
  */
 
 /**
- * @typedef {HostedArenasPageContextParams} HostedArenasPageContextFactoryParams
+ * @typedef {HostedCompetitionsPageContextParams} HostedCompetitionsPageContextFactoryParams
  */
 
 /**

--- a/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsFetcher.js
+++ b/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsFetcher.js
@@ -1,8 +1,8 @@
-export default class HostedArenaDetailsFetcher {
+export default class HostedCompetitionDetailsFetcher {
   /**
    * Constructor of this class.
    *
-   * @param {HostedArenaDetailsFetcherParams} params - Parameters.
+   * @param {HostedCompetitionDetailsFetcherParams} params - Parameters.
    */
   constructor ({
     route,
@@ -17,8 +17,8 @@ export default class HostedArenaDetailsFetcher {
   /**
    * Factory method.
    *
-   * @template {X extends typeof HostedArenaDetailsFetcher ? X : never} T, X
-   * @param {HostedArenaDetailsFetcherFactoryParams} params - Parameters.
+   * @template {X extends typeof HostedCompetitionDetailsFetcher ? X : never} T, X
+   * @param {HostedCompetitionDetailsFetcherFactoryParams} params - Parameters.
    * @returns {InstanceType<T>}
    * @this {T}
    */
@@ -129,8 +129,8 @@ export default class HostedArenaDetailsFetcher {
    */
   extractCompetitionIdFromRoute () {
     const competitionIdParam = Array.isArray(this.route.params.competitionId)
-      ? this.route.params.arenaId[0]
-      : this.route.params.arenaId
+      ? this.route.params.competitionId[0]
+      : this.route.params.competitionId
     const competitionId = Number(competitionIdParam)
 
     return isNaN(competitionId)
@@ -146,11 +146,11 @@ export default class HostedArenaDetailsFetcher {
  *     competition: GraphqlClient
  *   }
  *   statusReactive: import('vue').Reactive<Record<string, boolean>>
- * }} HostedArenaDetailsFetcherParams
+ * }} HostedCompetitionDetailsFetcherParams
  */
 
 /**
- * @typedef {HostedArenaDetailsFetcherParams} HostedArenaDetailsFetcherFactoryParams
+ * @typedef {HostedCompetitionDetailsFetcherParams} HostedCompetitionDetailsFetcherFactoryParams
  */
 
 /**

--- a/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
+++ b/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
@@ -3,15 +3,15 @@ import {
 } from '@openreachtech/furo-nuxt'
 
 /**
- * HostedArenaDetailsPageContext
+ * HostedCompetitionDetailsPageContext
  *
  * @extends {BaseFuroContext<null, {}, null>}
  */
-export default class HostedArenaDetailsPageContext extends BaseFuroContext {
+export default class HostedCompetitionDetailsPageContext extends BaseFuroContext {
   /**
    * Constructor
    *
-   * @param {HostedArenaDetailsPageContextParams} params - Parameters of this constructor.
+   * @param {HostedCompetitionDetailsPageContextParams} params - Parameters of this constructor.
    */
   constructor ({
     props,
@@ -32,9 +32,9 @@ export default class HostedArenaDetailsPageContext extends BaseFuroContext {
   /**
    * Factory method to create a new instance of this class.
    *
-   * @template {X extends typeof HostedArenaDetailsPageContext ? X : never} T, X
+   * @template {X extends typeof HostedCompetitionDetailsPageContext ? X : never} T, X
    * @override
-   * @param {HostedArenaDetailsPageContextFactoryParams} params - Parameters of this factory method.
+   * @param {HostedCompetitionDetailsPageContextFactoryParams} params - Parameters of this factory method.
    * @returns {InstanceType<T>} An instance of this class.
    * @this {T}
    */
@@ -57,13 +57,13 @@ export default class HostedArenaDetailsPageContext extends BaseFuroContext {
   /**
    * Setup component.
    *
-   * @template {X extends HostedArenaDetailsPageContext ? X : never} T, X
+   * @template {X extends HostedCompetitionDetailsPageContext ? X : never} T, X
    * @override
    * @this {T}
    */
   setupComponent () {
     this.fetcherHash
-      .hostedArenaDetails
+      .hostedCompetitionDetails
       .fetchCompetitionOnMounted()
 
     return this
@@ -76,7 +76,7 @@ export default class HostedArenaDetailsPageContext extends BaseFuroContext {
    */
   get competitionCapsule () {
     return this.fetcherHash
-      .hostedArenaDetails
+      .hostedCompetitionDetails
       .competitionCapsule
   }
 }
@@ -84,14 +84,14 @@ export default class HostedArenaDetailsPageContext extends BaseFuroContext {
 /**
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams & {
  *   fetcherHash: {
- *     hostedArenaDetails: import('./HostedArenaDetailsFetcher').default
+ *     hostedCompetitionDetails: import('./HostedCompetitionDetailsFetcher').default
  *   }
  *   statusReactive: StatusReactive
- * }} HostedArenaDetailsPageContextParams
+ * }} HostedCompetitionDetailsPageContextParams
  */
 
 /**
- * @typedef {HostedArenaDetailsPageContextParams} HostedArenaDetailsPageContextFactoryParams
+ * @typedef {HostedCompetitionDetailsPageContextParams} HostedCompetitionDetailsPageContextFactoryParams
  */
 
 /**

--- a/pages/hosted-competitions/[competitionId]/index.vue
+++ b/pages/hosted-competitions/[competitionId]/index.vue
@@ -14,8 +14,8 @@ import {
 
 import CompetitionQueryGraphqlLauncher from '~/app/graphql/client/queries/competition/CompetitionQueryGraphqlLauncher'
 
-import HostedArenaDetailsFetcher from './HostedArenaDetailsFetcher'
-import HostedArenaDetailsPageContext from './HostedArenaDetailsPageContext'
+import HostedCompetitionDetailsFetcher from './HostedCompetitionDetailsFetcher'
+import HostedCompetitionDetailsPageContext from './HostedCompetitionDetailsPageContext'
 
 export default defineComponent({
   setup (
@@ -30,7 +30,7 @@ export default defineComponent({
 
     const competitionGraphqlClient = useGraphqlClient(CompetitionQueryGraphqlLauncher)
 
-    const hostedArenaDetailsFetcher = HostedArenaDetailsFetcher.create({
+    const hostedCompetitionDetailsFetcher = HostedCompetitionDetailsFetcher.create({
       route,
       graphqlClientHash: {
         competition: competitionGraphqlClient,
@@ -42,11 +42,11 @@ export default defineComponent({
       props,
       componentContext,
       fetcherHash: {
-        hostedArenaDetails: hostedArenaDetailsFetcher,
+        hostedCompetitionDetails: hostedCompetitionDetailsFetcher,
       },
       statusReactive,
     }
-    const context = HostedArenaDetailsPageContext.create(args)
+    const context = HostedCompetitionDetailsPageContext.create(args)
       .setupComponent()
 
     return {

--- a/pages/hosted-competitions/index.vue
+++ b/pages/hosted-competitions/index.vue
@@ -25,8 +25,8 @@ import AppIconBadge from '~/components/badges/AppIconBadge.vue'
 
 import CompetitionsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher'
 
-import HostedArenasFetcher from './HostedArenasFetcher'
-import HostedArenasPageContext from './HostedArenasPageContext'
+import HostedCompetitionsFetcher from './HostedCompetitionsFetcher'
+import HostedCompetitionsPageContext from './HostedCompetitionsPageContext'
 
 export default defineComponent({
   components: {
@@ -51,7 +51,7 @@ export default defineComponent({
     })
 
     const competitionsGraphqlClient = useGraphqlClient(CompetitionsQueryGraphqlLauncher)
-    const hostedArenasFetcher = HostedArenasFetcher.create({
+    const hostedCompetitionsFetcher = HostedCompetitionsFetcher.create({
       route,
       walletStore,
       graphqlClientHash: {
@@ -66,11 +66,11 @@ export default defineComponent({
       route,
       router,
       fetcherHash: {
-        hostedArenas: hostedArenasFetcher,
+        hostedCompetitions: hostedCompetitionsFetcher,
       },
       statusReactive,
     }
-    const context = HostedArenasPageContext.create(args)
+    const context = HostedCompetitionsPageContext.create(args)
       .setupComponent()
 
     return {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2949

# How

* Used grep to rename hostedArena to hostedCompetition for more consistency in naming.
* No logic changes.
