### PR TITLE
Remove redundant competition details actions

### DIFF
--- a/components/hosted-competition/HostedCompetitionDetails.vue
+++ b/components/hosted-competition/HostedCompetitionDetails.vue
@@ -194,35 +194,6 @@ export default defineComponent({
         </template>
       </div>
     </div>
-
-    <div class="actions">
-      <button class="button">
-        <Icon
-          name="heroicons:rocket-launch"
-          class="icon"
-          size="1rem"
-        />
-        <span>Start Now</span>
-      </button>
-      <div class="divider" />
-      <button class="button">
-        <Icon
-          name="heroicons-outline:flag"
-          class="icon"
-          size="1rem"
-        />
-        <span>End Arena</span>
-      </button>
-      <div class="divider" />
-      <button class="button cancel">
-        <Icon
-          name="heroicons-outline:x-mark"
-          class="icon"
-          size="1rem"
-        />
-        <span>Cancel Arena</span>
-      </button>
-    </div>
   </div>
 </template>
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2934

# How

* Simply removed redundant actions because the host is not allowed to do those actions.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/02893837-7f4d-4287-af30-84e4db004413)

## After

![image](https://github.com/user-attachments/assets/f4737245-66ec-4ee2-9f37-f430dc711ad1)
