### PR TITLE
Allow hosts to navigate to a competition details page

### DIFF
--- a/pages/hosted-competitions/HostedCompetitionsPageContext.js
+++ b/pages/hosted-competitions/HostedCompetitionsPageContext.js
@@ -287,6 +287,7 @@ export default class HostedCompetitionsPageContext extends BaseFuroContext {
     const competitions = this.extractCompetitions()
 
     return competitions.map(competition => ({
+      competitionId: competition.competitionId,
       title: competition.title,
       image: this.generateCompetitionImageUrl({
         image: competition.image,
@@ -299,6 +300,20 @@ export default class HostedCompetitionsPageContext extends BaseFuroContext {
       }),
       status: competition.status.statusId,
     }))
+  }
+
+  /**
+   * Generate URL to competition details page.
+   *
+   * @param {{
+   *   competitionId: number
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  generateCompetitionDetailsUrl ({
+    competitionId,
+  }) {
+    return `/hosted-competitions/${competitionId}`
   }
 
   /**

--- a/pages/hosted-competitions/index.vue
+++ b/pages/hosted-competitions/index.vue
@@ -113,7 +113,12 @@ export default defineComponent({
       :is-loading="context.isLoadingCompetitions"
     >
       <template #body-title="{ value, row }">
-        <span class="unit-column title">
+        <NuxtLink
+          class="unit-column title"
+          :to="context.generateCompetitionDetailsUrl({
+            competitionId: row.competitionId,
+          })"
+        >
           <img
             :src="row.image"
             :alt="value"
@@ -122,7 +127,7 @@ export default defineComponent({
           <span class="title">
             {{ value }}
           </span>
-        </span>
+        </NuxtLink>
       </template>
 
       <template #body-startDate="{ value }">

--- a/pages/hosted-competitions/index.vue
+++ b/pages/hosted-competitions/index.vue
@@ -260,6 +260,14 @@ export default defineComponent({
   display: inline-flex;
   align-items: center;
   gap: 1rem;
+
+  color: var(--color-text-primary);
+
+  transition: color 250ms var(--transition-timing-base);
+}
+
+.unit-column.title:hover {
+  color: var(--color-text-highlight-purple);
 }
 
 .unit-column.title > .image {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3046

# How

* Allow hosts to navigate to a competition details page.

# Screenshots

![image](https://github.com/user-attachments/assets/5e0c685d-b71a-4b2e-b01b-057018dd5e7e)
