### PR TITLE
Prohibit non-host users from accessing hosted competition details

### DIFF
--- a/pages/hosted-competitions/[competitionId]/index.vue
+++ b/pages/hosted-competitions/[competitionId]/index.vue
@@ -5,6 +5,10 @@ import {
 } from 'vue'
 
 import {
+  definePageMeta,
+} from '#imports'
+
+import {
   useRoute,
 } from 'vue-router'
 
@@ -49,6 +53,10 @@ export default defineComponent({
     props,
     componentContext
   ) {
+    definePageMeta({
+      middleware: 'competition-edit-permission',
+    })
+
     const route = useRoute()
 
     const statusReactive = reactive({


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/2951

# How

* Prohibit non-host users from accessing hosted competition details.
