### PR TITLE
More robust position for competition participant status select

### DIFF
--- a/components/hosted-competition/HostedCompetitionParticipants.vue
+++ b/components/hosted-competition/HostedCompetitionParticipants.vue
@@ -229,6 +229,7 @@ export default defineComponent({
         <span class="unit-status">
           <AppSelect
             class="select"
+            position="right"
             :items="context.generateParticipantStatusSelectOptions()"
             :model-value="String(value.statusId)"
             @update:model-value="context.emitBulkUpdateParticipantStatus({


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3081

# How

* Provide more robust position for competition participant status select.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/6281b626-15e2-41b2-9088-85bb3779edcb)

## After

![image](https://github.com/user-attachments/assets/5a9fb770-1c0f-42d9-ab31-1bcc96d1b718)
