### PR TITLE
Refetch competition details after form submission

### DIFF
--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
@@ -20,6 +20,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
     route,
     graphqlClientHash,
     formClerkHash,
+    fetcherHash,
     statusReactive,
     updateCompetitionFormShallowRef,
     updateCompetitionSchedulesFormShallowRef,
@@ -34,6 +35,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
     this.route = route
     this.graphqlClientHash = graphqlClientHash
     this.formClerkHash = formClerkHash
+    this.fetcherHash = fetcherHash
     this.statusReactive = statusReactive
     this.updateCompetitionFormShallowRef = updateCompetitionFormShallowRef
     this.updateCompetitionSchedulesFormShallowRef = updateCompetitionSchedulesFormShallowRef
@@ -56,6 +58,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
     route,
     graphqlClientHash,
     formClerkHash,
+    fetcherHash,
     statusReactive,
     updateCompetitionFormShallowRef,
     updateCompetitionSchedulesFormShallowRef,
@@ -69,6 +72,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
         route,
         graphqlClientHash,
         formClerkHash,
+        fetcherHash,
         statusReactive,
         updateCompetitionFormShallowRef,
         updateCompetitionSchedulesFormShallowRef,
@@ -289,6 +293,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
       },
       afterRequest: async capsule => {
         this.statusReactive.isUpdatingCompetition = false
+
+        await this.fetcherHash
+          .competition
+          .fetchCompetitionOnEvent()
       },
     }
   }
@@ -333,6 +341,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
       },
       afterRequest: async capsule => {
         this.statusReactive.isUpdatingCompetitionSchedules = false
+
+        await this.fetcherHash
+          .competition
+          .fetchCompetitionOnEvent()
       },
     }
   }
@@ -377,6 +389,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
       },
       afterRequest: async capsule => {
         this.statusReactive.isUpdatingCompetitionLimits = false
+
+        await this.fetcherHash
+          .competition
+          .fetchCompetitionOnEvent()
       },
     }
   }
@@ -421,6 +437,10 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
       },
       afterRequest: async capsule => {
         this.statusReactive.isUpdatingCompetitionPrizeRules = false
+
+        await this.fetcherHash
+          .competition
+          .fetchCompetitionOnEvent()
       },
     }
   }
@@ -440,6 +460,9 @@ export default class CompetitionDetailsEditMutationContext extends BaseFuroConte
  *   route: ReturnType<import('vue-router').useRoute>
  *   graphqlClientHash: Record<GraphqlClientHashKeys, GraphqlClient>
  *   formClerkHash: Record<FormClerkHashKeys, FormClerk>
+ *   fetcherHash: {
+ *     competition: import('./CompetitionDetailsEditFetcher').default
+ *   }
  *   statusReactive: StatusReactive
  *   updateCompetitionFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
  *   updateCompetitionSchedulesFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -185,6 +185,14 @@ export default defineComponent({
       <span class="heading">
         Edit League
       </span>
+      <Icon
+        name="svg-spinners:90-ring-with-bg"
+        size="1.25rem"
+        class="icon loading"
+        :class="{
+          hidden: !context.isLoadingInitialValue,
+        }"
+      />
     </div>
 
     <div class="unit-form-container">
@@ -348,6 +356,10 @@ export default defineComponent({
   font-size: var(--font-size-large);
   font-weight: 500;
   line-height: var(--size-line-height-large);
+}
+
+.unit-page > .header > .icon.loading.hidden {
+  display: none;
 }
 
 .unit-form-container {

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -153,6 +153,9 @@ export default defineComponent({
         updateCompetitionLimits: updateCompetitionLimitsFormClerk,
         updateCompetitionPrizeRules: updateCompetitionPrizeRulesFormClerk,
       },
+      fetcherHash: {
+        competition: competitionDetailsEditFetcher,
+      },
       updateCompetitionFormShallowRef,
       updateCompetitionSchedulesFormShallowRef,
       updateCompetitionLimitsFormShallowRef,

--- a/pages/(competitions)/competitions/[competitionId]/edit/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/edit/index.vue
@@ -12,8 +12,6 @@ import {
 } from '#components'
 
 import AppButton from '~/components/units/AppButton.vue'
-import AppLoadingLayout from '~/components/units/AppLoadingLayout.vue'
-import AppSkeleton from '~/components/units/AppSkeleton.vue'
 import AddCompetitionFormSteps from '~/components/competition-add/AddCompetitionFormSteps.vue'
 import AddCompetitionFormStepDetails from '~/components/competition-add/AddCompetitionFormStepDetails.vue'
 import AddCompetitionFormStepTimeline from '~/components/competition-add/AddCompetitionFormStepTimeline.vue'
@@ -54,8 +52,6 @@ export default defineComponent({
     NuxtLink,
     Icon,
     AppButton,
-    AppLoadingLayout,
-    AppSkeleton,
     AddCompetitionFormSteps,
     AddCompetitionFormStepDetails,
     AddCompetitionFormStepTimeline,
@@ -191,142 +187,128 @@ export default defineComponent({
       </span>
     </div>
 
-    <AppLoadingLayout :is-loading="context.isLoadingInitialValue">
-      <template #contents>
-        <!-- NOTE: Empty div wrapper as a workaround for hiding issue. Fixed in newer furo-nuxt version. -->
-        <div>
-          <div class="unit-form-container">
-            <div class="steps">
-              <form
-                :ref="mutationContext.updateCompetitionFormShallowRef"
-                class="unit-form step"
-                :class="context.generateStepClasses({
-                  step: 1,
-                })"
-                @submit.prevent="mutationContext.submitFormUpdateCompetition()"
-              >
-                <input
-                  type="number"
-                  class="input hidden"
-                  name="competitionId"
-                  :value="mutationContext.extractCompetitionIdFromRoute()"
-                >
-                <AddCompetitionFormStepDetails
-                  :validation-message="mutationContext.updateCompetitionValidationMessage"
-                  :initial-form-value-hash="context.generateStepDetailsInitialValueHash()"
-                  class="controls"
-                />
-                <AppButton
-                  type="submit"
-                  class="button submit"
-                  :is-loading="mutationContext.isUpdatingCompetition"
-                >
-                  Save changes
-                </AppButton>
-              </form>
+    <div class="unit-form-container">
+      <div class="steps">
+        <form
+          :ref="mutationContext.updateCompetitionFormShallowRef"
+          class="unit-form step"
+          :class="context.generateStepClasses({
+            step: 1,
+          })"
+          @submit.prevent="mutationContext.submitFormUpdateCompetition()"
+        >
+          <input
+            type="number"
+            class="input hidden"
+            name="competitionId"
+            :value="mutationContext.extractCompetitionIdFromRoute()"
+          >
+          <AddCompetitionFormStepDetails
+            :validation-message="mutationContext.updateCompetitionValidationMessage"
+            :initial-form-value-hash="context.generateStepDetailsInitialValueHash()"
+            class="controls"
+          />
+          <AppButton
+            type="submit"
+            class="button submit"
+            :is-loading="mutationContext.isUpdatingCompetition"
+          >
+            Save changes
+          </AppButton>
+        </form>
 
-              <form
-                :ref="mutationContext.updateCompetitionSchedulesFormShallowRef"
-                class="unit-form step"
-                :class="context.generateStepClasses({
-                  step: 2,
-                })"
-                @submit.prevent="mutationContext.submitFormUpdateCompetitionSchedules()"
-              >
-                <input
-                  type="number"
-                  class="input hidden"
-                  name="competitionId"
-                  :value="mutationContext.extractCompetitionIdFromRoute()"
-                >
-                <AddCompetitionFormStepTimeline
-                  :validation-message="mutationContext.updateCompetitionSchedulesValidationMessage"
-                  :initial-form-value-hash="context.generateStepTimelineInitialValueHash()"
-                  class="controls"
-                />
-                <AppButton
-                  type="submit"
-                  class="button submit"
-                  :is-loading="mutationContext.isUpdatingCompetitionSchedules"
-                >
-                  Save changes
-                </AppButton>
-              </form>
+        <form
+          :ref="mutationContext.updateCompetitionSchedulesFormShallowRef"
+          class="unit-form step"
+          :class="context.generateStepClasses({
+            step: 2,
+          })"
+          @submit.prevent="mutationContext.submitFormUpdateCompetitionSchedules()"
+        >
+          <input
+            type="number"
+            class="input hidden"
+            name="competitionId"
+            :value="mutationContext.extractCompetitionIdFromRoute()"
+          >
+          <AddCompetitionFormStepTimeline
+            :validation-message="mutationContext.updateCompetitionSchedulesValidationMessage"
+            :initial-form-value-hash="context.generateStepTimelineInitialValueHash()"
+            class="controls"
+          />
+          <AppButton
+            type="submit"
+            class="button submit"
+            :is-loading="mutationContext.isUpdatingCompetitionSchedules"
+          >
+            Save changes
+          </AppButton>
+        </form>
 
-              <form
-                :ref="mutationContext.updateCompetitionLimitsFormShallowRef"
-                class="unit-form step"
-                :class="context.generateStepClasses({
-                  step: 3,
-                })"
-                @submit.prevent="mutationContext.submitFormUpdateCompetitionLimits()"
-              >
-                <input
-                  type="number"
-                  class="input hidden"
-                  name="competitionId"
-                  :value="mutationContext.extractCompetitionIdFromRoute()"
-                >
-                <AddCompetitionFormStepParticipation
-                  :validation-message="mutationContext.updateCompetitionLimitsValidationMessage"
-                  :initial-form-value-hash="context.generateStepParticipationInitialValueHash()"
-                  class="controls"
-                />
-                <AppButton
-                  type="submit"
-                  class="button submit"
-                  :is-loading="mutationContext.isUpdatingCompetitionLimits"
-                >
-                  Save changes
-                </AppButton>
-              </form>
+        <form
+          :ref="mutationContext.updateCompetitionLimitsFormShallowRef"
+          class="unit-form step"
+          :class="context.generateStepClasses({
+            step: 3,
+          })"
+          @submit.prevent="mutationContext.submitFormUpdateCompetitionLimits()"
+        >
+          <input
+            type="number"
+            class="input hidden"
+            name="competitionId"
+            :value="mutationContext.extractCompetitionIdFromRoute()"
+          >
+          <AddCompetitionFormStepParticipation
+            :validation-message="mutationContext.updateCompetitionLimitsValidationMessage"
+            :initial-form-value-hash="context.generateStepParticipationInitialValueHash()"
+            class="controls"
+          />
+          <AppButton
+            type="submit"
+            class="button submit"
+            :is-loading="mutationContext.isUpdatingCompetitionLimits"
+          >
+            Save changes
+          </AppButton>
+        </form>
 
-              <form
-                :ref="mutationContext.updateCompetitionPrizeRulesFormShallowRef"
-                class="unit-form step"
-                :class="context.generateStepClasses({
-                  step: 4,
-                })"
-                @submit.prevent="mutationContext.submitFormUpdateCompetitionPrizeRules()"
-              >
-                <input
-                  type="number"
-                  class="input hidden"
-                  name="competitionId"
-                  :value="mutationContext.extractCompetitionIdFromRoute()"
-                >
-                <AddCompetitionFormStepPrize
-                  :validation-message="mutationContext.updateCompetitionPrizeRulesValidationMessage"
-                  :initial-form-value-hash="context.generateStepPrizeInitialValueHash()"
-                  should-omit-total-prize
-                  class="controls"
-                />
-                <AppButton
-                  type="submit"
-                  class="button submit"
-                  :is-loading="mutationContext.isUpdatingCompetitionPrizeRules"
-                >
-                  Save changes
-                </AppButton>
-              </form>
-            </div>
+        <form
+          :ref="mutationContext.updateCompetitionPrizeRulesFormShallowRef"
+          class="unit-form step"
+          :class="context.generateStepClasses({
+            step: 4,
+          })"
+          @submit.prevent="mutationContext.submitFormUpdateCompetitionPrizeRules()"
+        >
+          <input
+            type="number"
+            class="input hidden"
+            name="competitionId"
+            :value="mutationContext.extractCompetitionIdFromRoute()"
+          >
+          <AddCompetitionFormStepPrize
+            :validation-message="mutationContext.updateCompetitionPrizeRulesValidationMessage"
+            :initial-form-value-hash="context.generateStepPrizeInitialValueHash()"
+            should-omit-total-prize
+            class="controls"
+          />
+          <AppButton
+            type="submit"
+            class="button submit"
+            :is-loading="mutationContext.isUpdatingCompetitionPrizeRules"
+          >
+            Save changes
+          </AppButton>
+        </form>
+      </div>
 
-            <AddCompetitionFormSteps
-              :current-step="context.currentStep"
-              :steps="context.steps"
-              @go-to-step="context.goToStep($event)"
-            />
-          </div>
-        </div>
-      </template>
-
-      <template #loader>
-        <AppSkeleton
-          height="40rem"
-          class="unit-form-container"
-        />
-      </template>
-    </AppLoadingLayout>
+      <AddCompetitionFormSteps
+        :current-step="context.currentStep"
+        :steps="context.steps"
+        @go-to-step="context.goToStep($event)"
+      />
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3113

# How

* Invoke `competition` query after editing a competition.
* Replace the loading skeleton with a more subtle loading spinner to avoid UI flash.

> [!note]
> The input values will flicker when we submit the form. This is a known issue which will be resolved in newer furo version.
