### PR TITLE
Remove invalid value of AppSelect border radius

### DIFF
--- a/components/units/AppSelect.vue
+++ b/components/units/AppSelect.vue
@@ -216,7 +216,7 @@ export default defineComponent({
   border-width: var(--size-thinnest);
   border-style: solid;
   border-color: var(--color-border);
-  border-radius: var(--size-border-radius-tiny);
+  border-radius: 0.5rem;
 
   padding: 0.75rem;
 
@@ -244,7 +244,7 @@ export default defineComponent({
 }
 
 .unit-contents .item {
-  border-radius: var(--size-border-radius-micro);
+  border-radius: 0.25rem;
   padding-block: 0.625rem;
   padding-inline: 1rem;
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3129

# How

* Invalid border radius was left remained after copying the component from the admin repository. This PR removed it.
