### PR TITLE
Add button to download outcome CSV

### DIFF
--- a/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule.js
@@ -152,6 +152,17 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
       ?.name
       ?? null
   }
+
+  /**
+   * get: outcomeCsvUrl
+   *
+   * @returns {string | null}
+   */
+  get outcomeCsvUrl () {
+    return this.extractCompetition()
+      ?.outcomeCsvUrl
+      ?? null
+  }
 }
 
 /**
@@ -176,6 +187,7 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
  *   schedules: Array<Schedule>
  *   status: Status
  *   prizeRules: Array<PrizeRule>
+ *   outcomeCsvUrl?: string
  * }} CompetitionEntity
  */
 

--- a/app/graphql/client/queries/competition/CompetitionQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competition/CompetitionQueryGraphqlPayload.js
@@ -42,6 +42,7 @@ export default class CompetitionQueryGraphqlPayload extends BaseAppGraphqlPayloa
               rankTo
               amount
             }
+            outcomeCsvUrl
           }
         }
       }

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -1101,6 +1101,17 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   }
 
   /**
+   * get: competitionOutcomeCsvUrl
+   *
+   * @returns {string | null}
+   */
+  get competitionOutcomeCsvUrl () {
+    return this.competitionCapsuleRef
+      .value
+      .outcomeCsvUrl
+  }
+
+  /**
    * get: participantStatusId
    *
    * @returns {number | null}

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -111,8 +111,8 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
     }
 
     const response = await fetch(this.outcomeCsvUrl)
-    const pdfBlob = await response.blob()
-    const blobURL = URL.createObjectURL(pdfBlob)
+    const fileBlob = await response.blob()
+    const blobURL = URL.createObjectURL(fileBlob)
 
     const link = document.createElement('a')
 

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -92,6 +92,39 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   }
 
   /**
+   * get: outcomeCsvUrl
+   *
+   * @returns {PropsType['outcomeCsvUrl']}
+   */
+  get outcomeCsvUrl () {
+    return this.props.outcomeCsvUrl
+  }
+
+  /**
+   * Download outcome CSV.
+   *
+   * @returns {Promise<void>}
+   */
+  async downloadOutcomeCsv () {
+    if (this.outcomeCsvUrl === null) {
+      return
+    }
+
+    const response = await fetch(this.outcomeCsvUrl)
+    const pdfBlob = await response.blob()
+    const blobURL = URL.createObjectURL(pdfBlob)
+
+    const link = document.createElement('a')
+
+    link.href = blobURL
+    link.download = 'outcome.csv'
+
+    link.click()
+
+    URL.revokeObjectURL(blobURL)
+  }
+
+  /**
    * Generate section heading.
    *
    * @returns {string | null}
@@ -373,5 +406,6 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
  *   topThreeLeaderboardEntries: import('~/app/vue/contexts/CompetitionDetailsPageContext').TopThreeLeaderboardEntries
  *   leaderboardPaginationResult: PaginationResult
  *   lastLeaderboardUpdateTimestamp: string | null
+ *   outcomeCsvUrl: string | null
  * }} PropsType
  */

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -5,8 +5,10 @@ import {
 
 import {
   NuxtLink,
+  Icon,
 } from '#components'
 
+import AppButton from '~/components/units/AppButton.vue'
 import AppTable from '~/components/units/AppTable.vue'
 import AppPagination from '~/components/units/AppPagination.vue'
 import TopRankingCard from '~/components/competition-id/TopRankingCard.vue'
@@ -17,6 +19,8 @@ import SectionLeaderboardContext from '~/app/vue/contexts/competition/SectionLea
 export default defineComponent({
   components: {
     NuxtLink,
+    Icon,
+    AppButton,
     AppTable,
     AppPagination,
     TopRankingCard,
@@ -77,6 +81,14 @@ export default defineComponent({
         null,
       ],
       required: true,
+    },
+    outcomeCsvUrl: {
+      type: [
+        String,
+        null,
+      ],
+      required: false,
+      default: null,
     },
   },
 
@@ -323,11 +335,34 @@ export default defineComponent({
         </template>
       </AppTable>
 
-      <AppPagination
-        class="pagination"
-        page-key="leaderboardPage"
-        :pagination="context.leaderboardPaginationResult"
-      />
+      <div class="unit-footer">
+        <div class="empty" />
+
+        <AppPagination
+          class="pagination"
+          page-key="leaderboardPage"
+          :pagination="context.leaderboardPaginationResult"
+        />
+
+        <AppButton
+          variant="neutral"
+          class="button download-result"
+          :class="{
+            hidden: !context.outcomeCsvUrl,
+          }"
+          @click="context.downloadOutcomeCsv()"
+        >
+          <template #startIcon>
+            <Icon
+              name="heroicons:arrow-down-tray"
+              size="1rem"
+            />
+          </template>
+          <template #default>
+            Download full result
+          </template>
+        </AppButton>
+      </div>
     </div>
   </section>
 </template>
@@ -414,8 +449,37 @@ export default defineComponent({
   color: var(--color-text-secondary);
 }
 
-.unit-section > .inner > .pagination {
+.unit-footer {
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 1.75rem;
+  column-gap: 1rem;
+
   margin-block-start: 1.25rem;
+
+  @media (48rem < width) {
+    grid-template-columns: 1fr auto 1fr;
+  }
+}
+
+.unit-footer > .empty {
+  display: none;
+
+  @media (48rem < width) {
+    display: block;
+  }
+}
+
+.unit-footer > .button.download-result {
+  justify-self: center;
+
+  @media (48rem < width) {
+    justify-self: end;
+  }
+}
+
+.unit-footer > .button.download-result.hidden {
+  display: none;
 }
 
 /***************** Top 3 rankers ****************/

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -188,6 +188,7 @@ export default defineComponent({
       :is-loading-leaderboard="context.isLoadingLeaderboard"
       :leaderboard-pagination-result="context.generateLeaderboardPaginationResult()"
       :last-leaderboard-update-timestamp="context.extractLastLeaderboardUpdateTimestamp()"
+      :outcome-csv-url="context.competitionOutcomeCsvUrl"
     />
 
     <CompetitionEnrollmentDialog


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3123

# How

* Get `outcomeCsvUrl` from `competition` query.
* Add button to download outcome CSV.

# Screencasts

https://github.com/user-attachments/assets/2fe43811-05ef-4457-b860-b475e998d80a
