### PR TITLE
Hide button loader with visibility property

### DIFF
--- a/components/units/AppButton.vue
+++ b/components/units/AppButton.vue
@@ -150,6 +150,11 @@ export default defineComponent({
   user-select: none;
 }
 
+.unit-button > * {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+}
+
 .unit-button > .contents {
   display: inline-flex;
   align-items: center;
@@ -157,11 +162,11 @@ export default defineComponent({
 }
 
 .unit-button:not(.is-loading) > .loader {
-  display: none;
+  visibility: hidden;
 }
 
 .unit-button.is-loading > :not(.loader) {
-  display: none;
+  visibility: hidden;
 }
 
 /******************************************************/


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3169

# How

* Hide button loader with visibility property to avoid layout shift.

# Screencasts

## Before

https://github.com/user-attachments/assets/37d6f81d-58f8-439d-8bf2-772ad47a2158

## After

https://github.com/user-attachments/assets/b520743f-3a61-48ca-8879-4512a87e4aee