### PR TITLE
Set distint title for each page

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -1,4 +1,5 @@
-import dydxAppConfig from '~/app/dydxV4AppConfig.json'
+// NOTE: If this constant file is imported in `nuxt.config.js`, it must use relative paths.
+import dydxAppConfig from './dydxV4AppConfig.json'
 
 export const HEADER_KEY = {
   ACCESS_TOKEN: 'x-renchan-access-token',

--- a/app/constants.js
+++ b/app/constants.js
@@ -13,6 +13,8 @@ export const STORAGE_KEY = {
   WALLET: 'wallet',
 }
 
+export const BASE_PAGE_TITLE = 'dYdX Trading Arena'
+
 export const DYDX_TRADE_CTA_URL = 'https://dydx.trade/markets?utm_source=clc&utm_medium=trading-competition&utm_campaign=07042025-clc-menu-cta&utm_term=&utm_content=trading-comp-menu-cta'
 
 export const ORDINAL_SUFFIX_HASH = {

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -3,12 +3,12 @@ import {
 } from 'vue'
 
 import {
-  useHead,
-} from '@unhead/vue'
+  useRoute,
+} from 'vue-router'
 
 import {
-  useRoute,
-} from '#imports'
+  useHead,
+} from '@unhead/vue'
 
 import {
   BaseFuroContext,

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -3,12 +3,12 @@ import {
 } from 'vue'
 
 import {
-  useRoute,
-} from '#imports'
-
-import {
   useHead,
 } from '@unhead/vue'
+
+import {
+  useRoute,
+} from '#imports'
 
 import {
   BaseFuroContext,

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -7,10 +7,15 @@ import {
 } from '#imports'
 
 import {
+  useHead,
+} from '@unhead/vue'
+
+import {
   BaseFuroContext,
 } from '@openreachtech/furo-nuxt'
 
 import {
+  BASE_PAGE_TITLE,
   COMPETITION_STATUS,
   PAGINATION,
 } from '~/app/constants'
@@ -269,6 +274,19 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
       () => this.extractCurrentPage(),
       async () => {
         await this.fetchLeaderboardEntries()
+      }
+    )
+
+    this.watch(
+      () => this.competitionTitle,
+      () => {
+        if (this.competitionTitle === null) {
+          return
+        }
+
+        useHead({
+          title: `${this.competitionTitle} - ${BASE_PAGE_TITLE}`,
+        })
       }
     )
 

--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -1,10 +1,10 @@
 import {
-  BaseFuroContext,
-} from '@openreachtech/furo-nuxt'
+  useRoute,
+} from 'vue-router'
 
 import {
-  useRoute,
-} from '#imports'
+  BaseFuroContext,
+} from '@openreachtech/furo-nuxt'
 
 import {
   SCHEDULE_CATEGORY,

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -3,6 +3,10 @@ import {
 } from '#imports'
 
 import {
+  useHead,
+} from '@unhead/vue'
+
+import {
   BaseFuroContext,
 } from '@openreachtech/furo-nuxt'
 
@@ -10,6 +14,7 @@ import FinancialMetricNormalizer from '~/app/FinancialMetricNormalizer'
 
 import {
   BASE_INDEXER_URL,
+  BASE_PAGE_TITLE,
 } from '~/app/constants'
 
 /**
@@ -121,6 +126,19 @@ export default class ProfileDetailsContext extends BaseFuroContext {
       },
       {
         immediate: true,
+      }
+    )
+
+    this.watch(
+      () => this.addressName,
+      () => {
+        if (this.addressName === null) {
+          return
+        }
+
+        useHead({
+          title: `${this.addressName} (Profile) - ${BASE_PAGE_TITLE}`,
+        })
       }
     )
 

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -1,10 +1,9 @@
 import {
-  useRoute,
-} from '#imports'
-
-import {
   useHead,
 } from '@unhead/vue'
+import {
+  useRoute,
+} from 'vue-router'
 
 import {
   BaseFuroContext,

--- a/app/vue/contexts/profile/ProfileLeagueHistoryContext.js
+++ b/app/vue/contexts/profile/ProfileLeagueHistoryContext.js
@@ -1,6 +1,6 @@
 import {
   useRoute,
-} from '#imports'
+} from 'vue-router'
 
 import {
   BaseFuroContext,

--- a/app/vue/contexts/profile/ProfileTransferHistoryContext.js
+++ b/app/vue/contexts/profile/ProfileTransferHistoryContext.js
@@ -1,6 +1,6 @@
 import {
   useRoute,
-} from '#imports'
+} from 'vue-router'
 
 import {
   BaseFuroContext,

--- a/components/dialogs/CompetitionCancelationDialog.vue
+++ b/components/dialogs/CompetitionCancelationDialog.vue
@@ -6,7 +6,7 @@ import {
 
 import {
   useRoute,
-} from '#imports'
+} from 'vue-router'
 
 import AppButton from '~/components/units/AppButton.vue'
 import AppDialog from '~/components/units/AppDialog.vue'

--- a/components/dialogs/CompetitionEnrollmentDialog.vue
+++ b/components/dialogs/CompetitionEnrollmentDialog.vue
@@ -6,7 +6,7 @@ import {
 
 import {
   useRoute,
-} from '#imports'
+} from 'vue-router'
 
 import AppButton from '~/components/units/AppButton.vue'
 import AppDialog from '~/components/units/AppDialog.vue'

--- a/components/profile/SectionProfileOverview.vue
+++ b/components/profile/SectionProfileOverview.vue
@@ -5,7 +5,7 @@ import {
 
 import {
   useRoute,
-} from '#imports'
+} from 'vue-router'
 
 import {
   Icon,

--- a/middleware/010.pageTitle.global.js
+++ b/middleware/010.pageTitle.global.js
@@ -7,6 +7,10 @@ import {
   FuroMeta,
 } from '@openreachtech/furo-nuxt'
 
+import {
+  BASE_PAGE_TITLE,
+} from '~/app/constants'
+
 /**
  * Page Title middleware (global)
  *
@@ -19,7 +23,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   })
 
   const resolvedPageTitle = furoMeta.pageTitle
-    ?? 'dYdX Trading Arena'
+    ?? BASE_PAGE_TITLE
 
   useSeoMeta({
     title: resolvedPageTitle,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,6 +6,10 @@ import nodePolyfills from 'vite-plugin-node-stdlib-browser'
 
 import furoEnv from './app/globals/furo-env'
 
+import {
+  BASE_PAGE_TITLE,
+} from './app/constants'
+
 // Reference: https://nuxt.com/docs/api/nuxt-config.
 export default defineNuxtConfig({
   // https://nuxt.com/docs/api/nuxt-config#compatibilitydate
@@ -15,7 +19,7 @@ export default defineNuxtConfig({
   // Nuxt App configuration: https://nuxt.com/docs/api/nuxt-config#app.
   app: {
     head: {
-      title: '⋯', // Loading title, can not be empty.
+      title: BASE_PAGE_TITLE, // Loading title, can not be empty.
       script: [
         {
           innerHTML: `

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
@@ -2,6 +2,14 @@ import {
   BaseFuroContext,
 } from '@openreachtech/furo-nuxt'
 
+import {
+  useHead,
+} from '@unhead/vue'
+
+import {
+  BASE_PAGE_TITLE,
+} from '~/app/constants'
+
 /**
  * CompetitionDetailsEditPageContext
  *
@@ -73,6 +81,19 @@ export default class CompetitionDetailsEditPageContext extends BaseFuroContext {
     this.fetcherHash
       .competitionDetailsEdit
       .fetchCompetitionOnMounted()
+
+    this.watch(
+      () => this.competitionDetailsEditCapsule.title,
+      newTitle => {
+        if (newTitle === null) {
+          return
+        }
+
+        useHead({
+          title: `✏️ ${newTitle} - ${BASE_PAGE_TITLE}`,
+        })
+      }
+    )
 
     return this
   }

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
@@ -1,10 +1,10 @@
 import {
-  BaseFuroContext,
-} from '@openreachtech/furo-nuxt'
-
-import {
   useHead,
 } from '@unhead/vue'
+
+import {
+  BaseFuroContext,
+} from '@openreachtech/furo-nuxt'
 
 import {
   BASE_PAGE_TITLE,

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -54,7 +54,7 @@ export default defineComponent({
   ) {
     definePageMeta({
       $furo: {
-        pageTitle: `New arena - ${BASE_PAGE_TITLE}`,
+        pageTitle: `New Arena - ${BASE_PAGE_TITLE}`,
       },
     })
 

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -9,16 +9,16 @@ import {
   Icon,
 } from '#components'
 
+import {
+  definePageMeta,
+} from '#imports'
+
 import AppButton from '~/components/units/AppButton.vue'
 import AddCompetitionFormSteps from '~/components/competition-add/AddCompetitionFormSteps.vue'
 import AddCompetitionFormStepDetails from '~/components/competition-add/AddCompetitionFormStepDetails.vue'
 import AddCompetitionFormStepTimeline from '~/components/competition-add/AddCompetitionFormStepTimeline.vue'
 import AddCompetitionFormStepParticipation from '~/components/competition-add/AddCompetitionFormStepParticipation.vue'
 import AddCompetitionFormStepPrize from '~/components/competition-add/AddCompetitionFormStepPrize.vue'
-
-import {
-  definePageMeta,
-} from '#imports'
 
 import AddCompetitionMutationGraphqlLauncher from '~/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlLauncher'
 

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -16,6 +16,10 @@ import AddCompetitionFormStepTimeline from '~/components/competition-add/AddComp
 import AddCompetitionFormStepParticipation from '~/components/competition-add/AddCompetitionFormStepParticipation.vue'
 import AddCompetitionFormStepPrize from '~/components/competition-add/AddCompetitionFormStepPrize.vue'
 
+import {
+  definePageMeta,
+} from '#imports'
+
 import AddCompetitionMutationGraphqlLauncher from '~/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlLauncher'
 
 import {
@@ -25,6 +29,10 @@ import {
 import useAppFormClerk from '~/composables/useAppFormClerk'
 
 import AddCompetitionFormElementClerk from '~/app/domClerk/AddCompetitionFormElementClerk'
+
+import {
+  BASE_PAGE_TITLE,
+} from '~/app/constants'
 
 import AddCompetitionPageContext from '~/app/vue/contexts/AddCompetitionPageContext'
 
@@ -44,6 +52,12 @@ export default defineComponent({
     props,
     componentContext
   ) {
+    definePageMeta({
+      $furo: {
+        pageTitle: `New arena - ${BASE_PAGE_TITLE}`,
+      },
+    })
+
     const addCompetitionGraphqlClient = useGraphqlClient(AddCompetitionMutationGraphqlLauncher)
     const addCompetitionFormClerk = useAppFormClerk({
       FormElementClerk: AddCompetitionFormElementClerk,

--- a/pages/(competitions)/competitions/index.vue
+++ b/pages/(competitions)/competitions/index.vue
@@ -5,8 +5,21 @@ import {
 } from 'vue'
 
 import {
+  useRoute,
+  useRouter,
+} from 'vue-router'
+
+import {
   Icon,
 } from '#components'
+
+import {
+  definePageMeta,
+} from '#imports'
+
+import {
+  useGraphqlClient,
+} from '@openreachtech/furo-nuxt'
 
 import AppLeagueCard from '~/components/units/AppLeagueCard.vue'
 import AppPagination from '~/components/units/AppPagination.vue'
@@ -14,19 +27,6 @@ import AppLoadingLayout from '~/components/units/AppLoadingLayout.vue'
 import AppSkeleton from '~/components/units/AppSkeleton.vue'
 import AppSearchBar from '~/components/units/AppSearchBar.vue'
 import LeagueHeroSection from '~/components/LeagueHeroSection.vue'
-
-import {
-  definePageMeta,
-} from '#imports'
-
-import {
-  useRoute,
-  useRouter,
-} from 'vue-router'
-
-import {
-  useGraphqlClient,
-} from '@openreachtech/furo-nuxt'
 
 import CompetitionsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher'
 import CompetitionStatisticsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitionStatistics/CompetitionStatisticsQueryGraphqlLauncher'

--- a/pages/(competitions)/competitions/index.vue
+++ b/pages/(competitions)/competitions/index.vue
@@ -16,6 +16,10 @@ import AppSearchBar from '~/components/units/AppSearchBar.vue'
 import LeagueHeroSection from '~/components/LeagueHeroSection.vue'
 
 import {
+  definePageMeta,
+} from '#imports'
+
+import {
   useRoute,
   useRouter,
 } from 'vue-router'
@@ -26,6 +30,10 @@ import {
 
 import CompetitionsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher'
 import CompetitionStatisticsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitionStatistics/CompetitionStatisticsQueryGraphqlLauncher'
+
+import {
+  BASE_PAGE_TITLE,
+} from '~/app/constants'
 
 import CompetitionsPageContext from '~/app/vue/contexts/CompetitionsPageContext'
 
@@ -44,6 +52,12 @@ export default defineComponent({
     props,
     componentContext
   ) {
+    definePageMeta({
+      $furo: {
+        pageTitle: `Arenas - ${BASE_PAGE_TITLE}`,
+      },
+    })
+
     const route = useRoute()
     const router = useRouter()
 

--- a/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
+++ b/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
@@ -1,10 +1,10 @@
 import {
-  BaseFuroContext,
-} from '@openreachtech/furo-nuxt'
-
-import {
   useHead,
 } from '@unhead/vue'
+
+import {
+  BaseFuroContext,
+} from '@openreachtech/furo-nuxt'
 
 import {
   BASE_PAGE_TITLE,

--- a/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
+++ b/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
@@ -2,6 +2,14 @@ import {
   BaseFuroContext,
 } from '@openreachtech/furo-nuxt'
 
+import {
+  useHead,
+} from '@unhead/vue'
+
+import {
+  BASE_PAGE_TITLE,
+} from '~/app/constants'
+
 import CompetitionBadgeContext from '~/app/vue/contexts/badges/CompetitionBadgeContext'
 
 /**
@@ -89,6 +97,19 @@ export default class HostedCompetitionDetailsPageContext extends BaseFuroContext
         await this.fetcherHash
           .competitionParticipants
           .fetchCompetitionParticipantsOnEvent()
+      }
+    )
+
+    this.watch(
+      () => this.competitionTitle,
+      () => {
+        if (this.competitionTitle === null) {
+          return
+        }
+
+        useHead({
+          title: `${this.competitionTitle} - ${BASE_PAGE_TITLE}`,
+        })
       }
     )
 
@@ -246,13 +267,21 @@ export default class HostedCompetitionDetailsPageContext extends BaseFuroContext
   }
 
   /**
+   * get: competitionTitle
+   *
+   * @returns {string | null}
+   */
+  get competitionTitle () {
+    return this.competitionCapsule.title
+  }
+
+  /**
    * Generate title.
    *
    * @returns {string}
    */
   generateTitle () {
-    return this.competitionCapsule
-      .title
+    return this.competitionTitle
       ?? '----'
   }
 

--- a/pages/hosted-competitions/index.vue
+++ b/pages/hosted-competitions/index.vue
@@ -18,16 +18,16 @@ import {
   Icon,
 } from '#components'
 
+import {
+  definePageMeta,
+} from '#imports'
+
 import AppButton from '~/components/units/AppButton.vue'
 import AppSelect from '~/components/units/AppSelect.vue'
 import AppSearchBar from '~/components/units/AppSearchBar.vue'
 import AppPagination from '~/components/units/AppPagination.vue'
 import AppTable from '~/components/units/AppTable.vue'
 import AppIconBadge from '~/components/badges/AppIconBadge.vue'
-
-import {
-  definePageMeta,
-} from '#imports'
 
 import CompetitionsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher'
 

--- a/pages/hosted-competitions/index.vue
+++ b/pages/hosted-competitions/index.vue
@@ -25,7 +25,15 @@ import AppPagination from '~/components/units/AppPagination.vue'
 import AppTable from '~/components/units/AppTable.vue'
 import AppIconBadge from '~/components/badges/AppIconBadge.vue'
 
+import {
+  definePageMeta,
+} from '#imports'
+
 import CompetitionsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlLauncher'
+
+import {
+  BASE_PAGE_TITLE,
+} from '~/app/constants'
 
 import HostedCompetitionsFetcher from './HostedCompetitionsFetcher'
 import HostedCompetitionsPageContext from './HostedCompetitionsPageContext'
@@ -46,6 +54,12 @@ export default defineComponent({
     props,
     componentContext
   ) {
+    definePageMeta({
+      $furo: {
+        pageTitle: `My Arenas - ${BASE_PAGE_TITLE}`,
+      },
+    })
+
     const route = useRoute()
     const router = useRouter()
     const walletStore = useWalletStore()

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -7,11 +7,11 @@ import {
   NuxtLink,
 } from '#components'
 
-import AppMessage from '~/components/units/AppMessage.vue'
-
 import {
   definePageMeta,
 } from '#imports'
+
+import AppMessage from '~/components/units/AppMessage.vue'
 
 import {
   BASE_PAGE_TITLE,

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -9,6 +9,14 @@ import {
 
 import AppMessage from '~/components/units/AppMessage.vue'
 
+import {
+  definePageMeta,
+} from '#imports'
+
+import {
+  BASE_PAGE_TITLE,
+} from '~/app/constants'
+
 import TermsPageContext from './TermsPageContext'
 
 export default defineComponent({
@@ -21,6 +29,12 @@ export default defineComponent({
     props,
     componentContext
   ) {
+    definePageMeta({
+      $furo: {
+        pageTitle: `Terms of Use - ${BASE_PAGE_TITLE}`,
+      },
+    })
+
     const args = {
       props,
       componentContext,


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3229

# How

Create constant variable for base page title, then setup page title for each page with `definePageMeta` and `useHead`.

> [!note]
> Furo meta relies on `definePageMeta` for page title. However, this function will be compiled away and can't receive dynamic value from the server. Therefore, `useHead` is used wherever needed.

(1)
* Landing page → `dYdX Trading Arena`
* Arenas list → `Arenas - dYdX Trading Arena`
* My hosted arenas → `My Arenas - dYdX Trading Arena`
* Add arena → `New Arena - dYdX Trading Arena`
* Terms of Use → `Terms of Use - dYdX Trading Arena`

(2) Arena title is "Competition A"
* Arena Details → `Competition A - dYdX Trading Arena`
* Edit Arena → `✏️ Competition A - dYdX Trading Arena`

(3) Username is "Banner"
* Profile → `Banner (Profile) - dYdX Trading Arena`
