### PR TITLE
Show empty UI for profile overview

### DIFF
--- a/components/profile/ProfileFinancialOverview.vue
+++ b/components/profile/ProfileFinancialOverview.vue
@@ -64,7 +64,12 @@ export default defineComponent({
       <span>No records found.</span>
     </div>
 
-    <div class="accounts">
+    <div
+      class="accounts"
+      :class="{
+        hidden: context.shouldHideOverview(),
+      }"
+    >
       <div
         v-for="childSubaccount of context.childSubaccounts"
         :key="childSubaccount.subaccountNumber"
@@ -197,6 +202,10 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   gap: 2rem;
+}
+
+.unit-container > .accounts.hidden {
+  display: none;
 }
 
 .unit-account {

--- a/components/profile/ProfileFinancialOverview.vue
+++ b/components/profile/ProfileFinancialOverview.vue
@@ -3,12 +3,17 @@ import {
   defineComponent,
 } from 'vue'
 
+import {
+  Icon,
+} from '#components'
+
 import AppTable from '~/components/units/AppTable.vue'
 
 import ProfileFinancialOverviewContext from './ProfileFinancialOverviewContext'
 
 export default defineComponent({
   components: {
+    Icon,
     AppTable,
   },
 
@@ -45,6 +50,19 @@ export default defineComponent({
   <div class="unit-container">
     <!-- Past orders implementation is to be decided. -->
     <!-- <div></div> -->
+
+    <div
+      class="empty"
+      :class="{
+        hidden: !context.shouldHideOverview(),
+      }"
+    >
+      <Icon
+        name="heroicons:table-cells"
+        size="2rem"
+      />
+      <span>No records found.</span>
+    </div>
 
     <div class="accounts">
       <div
@@ -153,6 +171,26 @@ export default defineComponent({
 <style scoped>
 .unit-container {
   margin-block-start: 2rem;
+}
+
+.unit-container > .empty {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+
+  padding-block: 3rem;
+  padding-inline: 1rem;
+
+  font-size: var(--font-size-medium);
+  font-weight: 500;
+
+  color: var(--color-text-tertiary);
+}
+
+.unit-container > .empty.hidden {
+  display: none;
 }
 
 .unit-container > .accounts {

--- a/components/profile/ProfileFinancialOverviewContext.js
+++ b/components/profile/ProfileFinancialOverviewContext.js
@@ -202,6 +202,15 @@ export default class ProfileFinancialOverviewContext extends BaseFuroContext {
   }
 
   /**
+   * Should hide overview.
+   *
+   * @returns {boolean}
+   */
+  shouldHideOverview () {
+    return this.profileOverview === null
+  }
+
+  /**
    * Generate side position CSS classes.
    *
    * @param {{


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3225

# How

* Show empty UI when the indexer couldn't find any related data.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/7ce4e4ac-6c8d-4ecf-982c-561b07813bb7)

## After

![image](https://github.com/user-attachments/assets/79196a1f-d1cc-47ae-9755-bf193351e10e)
