### PR TITLE
Apply extension rules from `eslint-plugin-vue`

### DIFF
--- a/components/competition-id/SectionSchedules.vue
+++ b/components/competition-id/SectionSchedules.vue
@@ -79,7 +79,7 @@ export default defineComponent({
                   <span>
                     {{
                       context.normalizeTimestamp({
-                        timestamp: event.timestamp
+                        timestamp: event.timestamp,
                       })
                     }}
                   </span>

--- a/components/hosted-competition/HostedCompetitionDetails.vue
+++ b/components/hosted-competition/HostedCompetitionDetails.vue
@@ -178,7 +178,7 @@ export default defineComponent({
                 <span>
                   {{
                     context.normalizeTimestamp({
-                      timestamp: event.timestamp
+                      timestamp: event.timestamp,
                     })
                   }}
                 </span>

--- a/components/hosted-competition/HostedCompetitionParticipants.vue
+++ b/components/hosted-competition/HostedCompetitionParticipants.vue
@@ -214,7 +214,7 @@ export default defineComponent({
             is-rounded
             variant="neutral"
             @click="context.emitFetchParticipantsCurrentEquities({
-              competitionParticipantIds: [row.competitionParticipantId]
+              competitionParticipantIds: [row.competitionParticipantId],
             })"
           >
             <Icon

--- a/components/units/AppCheckbox.vue
+++ b/components/units/AppCheckbox.vue
@@ -74,9 +74,9 @@ export default {
     <div
       class="checkbox"
       :class="{
-        'checked': context.internalValueRef.value,
-        'disabled': context.disabled,
-        'indeterminate': context.shouldShowIndeterminateStatus(),
+        checked: context.internalValueRef.value,
+        disabled: context.disabled,
+        indeterminate: context.shouldShowIndeterminateStatus(),
       }"
     >
       <input

--- a/components/units/AppCheckbox.vue
+++ b/components/units/AppCheckbox.vue
@@ -67,7 +67,7 @@ export default {
   <div
     class="unit-checkbox"
     :class="{
-      disabled: disabled,
+      disabled: context.disabled,
     }"
     @click="context.toggle()"
   >

--- a/components/units/AppPagination.vue
+++ b/components/units/AppPagination.vue
@@ -70,7 +70,10 @@ export default defineComponent({
 <template>
   <FuroPagination
     class="design"
-    v-bind="{...$attrs, ...props}"
+    v-bind="{
+      ...$attrs,
+      ...props,
+    }"
   >
     <template #previous>
       <slot name="previous">

--- a/components/units/AppTimeline.vue
+++ b/components/units/AppTimeline.vue
@@ -79,7 +79,7 @@ export default defineComponent({
           <span>
             {{
               context.normalizeTimestamp({
-                timestamp: event.timestamp
+                timestamp: event.timestamp,
               })
             }}
           </span>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -672,6 +672,252 @@ export default [
       'vue/valid-next-tick': [
         'error',
       ],
+
+      // These are extension rules of eslint-plugin-vue. They wrap around core or stylistic rules and mostly share the same options.
+      'vue/array-bracket-newline': [
+        'error',
+        'consistent', // { multiline: true, minItems: null }
+      ],
+      'vue/array-bracket-spacing': [
+        'error',
+      ],
+      'vue/array-element-newline': [
+        'error',
+        'consistent', // 'always'
+        {
+          multiline: true, // false
+          minItems: null,
+        },
+      ],
+      'vue/arrow-spacing': [
+        'error',
+      ],
+      'vue/block-spacing': [
+        'error',
+      ],
+      'vue/brace-style': [
+        'error',
+        '1tbs', // = One True Brace Style
+        {
+          allowSingleLine: false,
+        },
+      ],
+      'vue/camelcase': [
+        'error',
+      ],
+      'vue/comma-dangle': [
+        'error',
+        {
+          arrays: 'always-multiline', // 'never'
+          objects: 'always-multiline', // 'never'
+          imports: 'always-multiline', // 'never'
+          exports: 'always-multiline', // 'never'
+          functions: 'never',
+        },
+      ],
+      'vue/comma-spacing': [
+        'error',
+      ],
+      'vue/comma-style': [
+        'error',
+      ],
+      'vue/dot-location': [
+        'error',
+        'property', // 'object'
+      ],
+      'vue/dot-notation': [
+        'off', // 'error'
+        {
+          allowKeywords: true,
+          allowPattern: '',
+        },
+      ],
+      'vue/eqeqeq': [
+        'error',
+      ],
+      'vue/func-call-spacing': [
+        'error',
+      ],
+      'vue/key-spacing': [
+        'error',
+      ],
+      'vue/keyword-spacing': [
+        'error',
+      ],
+      'vue/max-len': [
+        'off', // 'error'
+        {
+          code: 80,
+          tabWidth: 4,
+        },
+      ],
+      'vue/multiline-ternary': [
+        'error',
+      ],
+      'vue/no-console': [
+        'error',
+        {
+          allow: undefined, // When disable `allow` field, give undefined instead of empty array
+        },
+      ],
+      'vue/no-constant-condition': [
+        'error',
+      ],
+      'vue/no-empty-pattern': [
+        'error',
+      ],
+      'vue/no-extra-parens': [
+        'off', // 'error'
+        'all',
+        {
+          conditionalAssign: false,
+          returnAssign: false,
+          nestedBinaryExpressions: false,
+          ignoreJSX: 'none',
+          enforceForArrowConditionals: false,
+          enforceForSequenceExpressions: false,
+          enforceForNewInMemberExpressions: false,
+          enforceForFunctionPrototypeMethods: false,
+          allowParensAfterCommentPattern: '',
+        },
+      ],
+      'vue/no-irregular-whitespace': [
+        'error',
+        {
+          skipComments: false,
+          skipHTMLAttributeValues: false,
+          skipHTMLTextContents: false,
+          // skipJSXText: false, // NOTE: This option exists in core rule but not in eslint-plugin-vue.
+          skipRegExps: false,
+          skipStrings: false, // true
+          skipTemplates: false,
+        },
+      ],
+      'vue/no-loss-of-precision': [
+        'error',
+      ],
+      'vue/no-restricted-syntax': [
+        'error',
+        // There are 0 or more rest parameters in the array
+        // string | { selector: string, message: string }
+        // NOTE: It's ok to use Array#forEach if there's only one statement in the callback function.
+        // {
+        //   selector: 'CallExpression[callee.property.name=forEach]',
+        //   message: 'Never use forEach method',
+        // },
+        {
+          selector: 'CallExpression[callee.type=MemberExpression][callee.property.name=/^(every|filter|find|findIndex|findLast|findLastIndex|flatMap|forEach|group|groupToMap|map|reduce|reduceRight|some)$/] IfStatement',
+          message: 'Never use if in higher-order function',
+        },
+        {
+          selector: 'DoWhileStatement',
+          message: 'Never use do-while',
+        },
+        {
+          selector: 'ForInStatement',
+          message: 'Never use for-in',
+        },
+        {
+          selector: 'ForOfStatement',
+          message: 'Never use for-of',
+        },
+        {
+          selector: 'ForStatement',
+          message: 'Never use for',
+        },
+        {
+          selector: 'Identifier[name=/.+((?<!signTyped)Data|Info|(?<![gs]et|remove)Item|(?<!RadioNode)List|Manager)$/]', // 'Identifier[name=/.+(Data|Info|Item|List|Manager)$/]'
+          message: 'Not allowed to use "Data", "Info", "Item", "List", and "Manager" as suffix of identifier.',
+        },
+        {
+          selector: 'IfStatement IfStatement',
+          message: 'Never use nested-if including else-if',
+        },
+        {
+          selector: 'SwitchStatement',
+          message: 'Never use switch',
+        },
+        // FIXME: below is not required by other rules
+        {
+          selector: 'VariableDeclaration[kind=let]',
+          message: 'Never use let',
+        },
+        {
+          selector: 'WhileStatement',
+          message: 'Never use while',
+        },
+      ],
+      'vue/no-sparse-arrays': [
+        'error',
+      ],
+      'vue/no-useless-concat': [
+        'error',
+      ],
+      'vue/object-curly-newline': [
+        'error',
+      ],
+      'vue/object-curly-spacing': [
+        'error',
+        'always', // 'never'
+        {
+          arraysInObjects: true, // false
+          objectsInObjects: true, // false
+        },
+      ],
+      'vue/object-property-newline': [
+        'error',
+        {
+          allowAllPropertiesOnSameLine: true, // false
+        },
+      ],
+      'vue/object-shorthand': [
+        'error',
+      ],
+      'vue/operator-linebreak': [
+        'error',
+        'before', // 'after'
+        {
+          overrides: { // {}
+            '=': 'after',
+            '+=': 'after',
+            '-=': 'after',
+            '*=': 'after',
+            '/=': 'after',
+            '%=': 'after',
+            '**=': 'after',
+            '<<=': 'after',
+            '>>=': 'after',
+            '>>>=': 'after',
+            '&=': 'after',
+            '|=': 'after',
+            '^=': 'after',
+          },
+        },
+      ],
+      'vue/prefer-template': [
+        'error',
+      ],
+      'vue/quote-props': [
+        'error',
+        'as-needed', // 'always'
+        {
+          keywords: false,
+          unnecessary: true,
+          numbers: false,
+        },
+      ],
+      'vue/space-in-parens': [
+        'error',
+      ],
+      'vue/space-infix-ops': [
+        'error',
+      ],
+      'vue/space-unary-ops': [
+        'error',
+      ],
+      'vue/template-curly-spacing': [
+        'error',
+      ],
     },
   },
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3295

# How

* Apply extension rules from `eslint-plugin-vue`. From [array-bracket-newline](https://eslint.vuejs.org/rules/array-bracket-newline.html) to [template-curly-spacing](https://eslint.vuejs.org/rules/template-curly-spacing.html).
* Options of rules that have already existed in core and stylistic are copied directly from Openreachtech's ESLint config.
* Rules that use default value in our config are enabled without any further custom configurations.
* Most rules have the same options with the same rules from core, except for `no-irregular-whitespace`. This rule does not have `skipJSXText` option, which I have left a comment to note.
* After adding the rules, fixed some related lint errors.
