### PR TITLE
Reduce the stroke opaticy of "rectangles" backaround image

### DIFF
--- a/assets/img/backgrounds/rectangles.svg
+++ b/assets/img/backgrounds/rectangles.svg
@@ -43,80 +43,80 @@
 </g>
 <defs>
 <radialGradient id="paint0_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint1_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint2_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint3_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint4_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint5_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint6_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint7_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint8_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint9_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint10_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint11_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint12_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint13_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint14_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint15_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint16_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint17_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <radialGradient id="paint18_radial_198_13896" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(582.321 175.616) rotate(-8.27228) scale(569.93 957.128)">
-<stop stop-color="#2F2F51"/>
-<stop offset="1" stop-color="#1A1A2C"/>
+<stop stop-color="#2F2F51B3"/>
+<stop offset="1" stop-color="#1A1A2C80"/>
 </radialGradient>
 <clipPath id="clip0_198_13896">
 <rect width="1021" height="600" fill="white"/>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3403

# How

* Reduce the stroke opaticy of "rectangles" backaround image.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/0436cb7d-f0ce-43d8-a590-b92ff258e5b4)

## After

![image](https://github.com/user-attachments/assets/bbddc307-58f7-4f13-85d2-1f2c22438c1d)

