### PR TITLE
Stop form from overflowing

### DIFF
--- a/components/units/AppInput.vue
+++ b/components/units/AppInput.vue
@@ -78,6 +78,8 @@ export default defineComponent({
   display: inline-flex;
   flex-direction: column;
   gap: 0.25rem;
+
+  min-width: 0;
 }
 
 .unit-input > .input {

--- a/components/units/AppInput.vue
+++ b/components/units/AppInput.vue
@@ -79,6 +79,7 @@ export default defineComponent({
   flex-direction: column;
   gap: 0.25rem;
 
+  /* Make sure the input is shrinkable in flex layout. */
   min-width: 0;
 }
 

--- a/components/units/AppTextarea.vue
+++ b/components/units/AppTextarea.vue
@@ -65,6 +65,8 @@ export default defineComponent({
   display: inline-flex;
   flex-direction: column;
   gap: 0.25rem;
+
+  min-width: 0;
 }
 
 .unit-textarea .textarea {

--- a/components/units/AppTextarea.vue
+++ b/components/units/AppTextarea.vue
@@ -66,6 +66,7 @@ export default defineComponent({
   flex-direction: column;
   gap: 0.25rem;
 
+  /* Make sure the input is shrinkable in flex layout. */
   min-width: 0;
 }
 

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -264,6 +264,10 @@ export default defineComponent({
   grid-column: 1 / -1;
 }
 
+.unit-form > .steps > .content > .step {
+  min-width: 0;
+}
+
 .unit-form > .steps > .content > .step.hidden {
   visibility: hidden;
 }


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3492

# How

* Because of flex layout, the child elements do not shrink at certain point, which causes an overflowing effect.
* This happens because `min-width` in flex layout is turned into `auto`. To address it, we need to explicitly specify `min-width: 0` to the child elements.

# Screenshots

## Before

![Screenshot From 2025-05-29 09-33-57](https://github.com/user-attachments/assets/26a95692-c970-4b0a-b5c2-a2189b052ef9)

## After

![Screenshot From 2025-05-29 09-34-22](https://github.com/user-attachments/assets/fad4284b-bbd9-4ebc-b1b1-64f9c18bcd16)


