### PR TITLE
Fix image URL not being invoked correctly

### DIFF
--- a/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
@@ -235,19 +235,14 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
   /**
    * Revoke the image's object URL after it is loaded.
    *
-   * @param {{
-   *   objectUrl: string | null
-   * }} params - Parameters.
    * @returns {void}
    */
-  releaseImageObjectUrl ({
-    objectUrl,
-  }) {
-    if (!objectUrl) {
+  releaseImageObjectUrl () {
+    if (!this.imageSource) {
       return
     }
 
-    URL.revokeObjectURL(objectUrl)
+    URL.revokeObjectURL(this.imageSource)
   }
 
   /**

--- a/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
+++ b/app/vue/contexts/competition/AddCompetitionFormStepDetailsContext.js
@@ -236,7 +236,7 @@ export default class AddCompetitionFormStepDetailsContext extends BaseFuroContex
    * Revoke the image's object URL after it is loaded.
    *
    * @param {{
-   *   objectUrl: string
+   *   objectUrl: string | null
    * }} params - Parameters.
    * @returns {void}
    */

--- a/components/competition-add/AddCompetitionFormStepDetails.vue
+++ b/components/competition-add/AddCompetitionFormStepDetails.vue
@@ -157,9 +157,7 @@ export default defineComponent({
           :src="context.generateCompetitionImageUrl()"
           alt="League badge"
           class="image"
-          @load="context.releaseImageObjectUrl({
-            objectUrl: context.imageSourceRef.value,
-          })"
+          @load="context.releaseImageObjectUrl()"
         >
 
         <div class="actions">

--- a/components/competition-add/AddCompetitionFormStepDetails.vue
+++ b/components/competition-add/AddCompetitionFormStepDetails.vue
@@ -151,15 +151,15 @@ export default defineComponent({
           @change="context.uploadFile({
             changeEvent: $event,
           })"
-          @load="context.releaseImageObjectUrl({
-            objectUrl: context.imageSourceRef.value,
-          })"
         >
 
         <img
           :src="context.generateCompetitionImageUrl()"
           alt="League badge"
           class="image"
+          @load="context.releaseImageObjectUrl({
+            objectUrl: context.imageSourceRef.value,
+          })"
         >
 
         <div class="actions">


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3690

# How

* When the image is loaded, its object URL must be revoked. The `onload` event to do this is assigned to incorrect element. It should be on `<img>`, not on `<input>`.
