### PR TITLE
Display equity for participants with `awaiting_deposit` status

### DIFF
--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -163,26 +163,6 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   }
 
   /**
-   * Normalize equity.
-   *
-   * @param {{
-   *   equity: number
-   *   statusId: number
-   * }} params - Parameters.
-   * @returns {string | number}
-   */
-  normalizeEquity ({
-    equity,
-    statusId,
-  }) {
-    if (statusId !== COMPETITION_PARTICIPANT_STATUS.AWAITING_DEPOSIT.ID) {
-      return '--'
-    }
-
-    return equity
-  }
-
-  /**
    * Normalize status name.
    *
    * @param {{

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -181,12 +181,7 @@ export default defineComponent({
 
         <template #body-participantEquity="{ value, row }">
           <span class="unit-column equity">
-            {{
-              context.normalizeEquity({
-                equity: value,
-                statusId: row.participantStatus.id,
-              })
-            }}
+            {{ value }}
           </span>
         </template>
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3843

# How

* Display participants' equity no matter what their status is.

# Screenshots

## Before

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/62b62eee-c01d-49ea-a8fe-3314823efdff" />

## After

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/e458b871-7dee-452c-b32c-b3b2db8571eb" />

