### PR TITLE
Resolve to unknown error message if error code is null

### DIFF
--- a/app/graphql/client/BaseAppGraphqlCapsule.js
+++ b/app/graphql/client/BaseAppGraphqlCapsule.js
@@ -17,13 +17,13 @@ export default class BaseAppGraphqlCapsule extends BaseGraphqlCapsule {
   /**
    * Get error message after resolving its error code.
    *
-   * @returns {string | null} Resolved error message.
+   * @returns {string} Resolved error message.
    */
   getResolvedErrorMessage () {
     const errorCode = this.getErrorMessage()
 
     if (errorCode === null) {
-      return null
+      return ERROR_MESSAGE_HASH.Unknown
     }
 
     const errorCodeHashEntries = Object.entries(ERROR_CODE_HASH)


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3924

# How

* `getResolvedErrorMessage()` method of the extended `BaseAppGraphqlCapsule` is used to map error code to coresponding error message. If error code is `null`, return an unknown error message.