### PR TITLE
Add `Orders` tab in address detail page

### DIFF
--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -118,6 +118,15 @@ export default class ProfileDetailsContext extends BaseFuroContext {
   }
 
   /**
+   * get: isLoadingProfileOrders
+   *
+   * @returns {boolean}
+   */
+  get isLoadingProfileOrders () {
+    return this.statusReactive.isLoadingProfileOrders
+  }
+
+  /**
    * Setup component context.
    *
    * @template {X extends ProfileDetailsContext ? X : never} T, X

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -286,19 +286,19 @@ export default class ProfileDetailsContext extends BaseFuroContext {
       return
     }
 
+    this.statusReactive.isLoadingProfileOrders = true
+
+    const headers = {
+      accept: 'application/json',
+    }
+    const searchParams = new URLSearchParams({
+      address,
+      parentSubaccountNumber: '0',
+      status: 'OPEN,UNTRIGGERED',
+    })
+    const resourceUrl = `${BASE_INDEXER_URL}/orders/parentSubaccountNumber?${searchParams.toString()}`
+
     try {
-      this.statusReactive.isLoadingProfileOrders = true
-
-      const headers = {
-        accept: 'application/json',
-      }
-      const searchParams = new URLSearchParams({
-        address,
-        parentSubaccountNumber: '0',
-        status: 'OPEN,UNTRIGGERED',
-      })
-      const resourceUrl = `${BASE_INDEXER_URL}/orders/parentSubaccountNumber?${searchParams.toString()}`
-
       const response = await fetch(resourceUrl, {
         method: 'GET',
         headers,

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -106,6 +106,10 @@ export default class ProfileDetailsContext extends BaseFuroContext {
         tabKey: 'past-competitions',
         label: 'League History',
       },
+      {
+        tabKey: 'orders',
+        label: 'Orders',
+      },
     ]
   }
 

--- a/components/profile/ProfileOrders.vue
+++ b/components/profile/ProfileOrders.vue
@@ -173,6 +173,7 @@ export default defineComponent({
       class="table mobile"
       :header-entries="context.orderTableMobileHeaderEntries"
       :entries="context.generateOrderTableEntries()"
+      min-width="15rem"
     >
       <template
         #body-status="{

--- a/components/profile/ProfileOrders.vue
+++ b/components/profile/ProfileOrders.vue
@@ -41,13 +41,162 @@ export default defineComponent({
   <div class="unit-container">
     <AppTable
       :header-entries="context.orderTableHeaderEntries"
-      :entries="[]"
-    />
+      :entries="context.generateOrderTableEntries()"
+    >
+      <template
+        #body-type="{
+          value,
+        }"
+      >
+        <span class="unit-column type">
+          {{ value.toLowerCase() }}
+        </span>
+      </template>
+
+      <template
+        #body-side="{
+          value,
+        }"
+      >
+        <span
+          class="unit-column side"
+          :class="{
+            buy: context.isBuySide({
+              side: value,
+            }),
+            sell: context.isSellSide({
+              side: value,
+            }),
+          }"
+        >
+          {{ value.toLowerCase() }}
+        </span>
+      </template>
+
+      <template
+        #body-orderValue="{
+          value,
+        }"
+      >
+        {{
+          context.formatCurrency({
+            figure: value,
+          })
+        }}
+      </template>
+
+      <template
+        #body-price="{
+          value,
+        }"
+      >
+        <span class="unit-column price">
+          {{
+            context.formatCurrency({
+              figure: value,
+            })
+          }}
+        </span>
+      </template>
+
+      <template
+        #body-triggerPrice="{
+          value,
+        }"
+      >
+        <span
+          class="unit-column trigger-price"
+          :class="{
+            null: context.isNullish({
+              value,
+            }),
+          }"
+        >
+          {{
+            context.formatCurrency({
+              figure: value,
+            })
+          }}
+        </span>
+      </template>
+
+      <template
+        #body-marginMode="{
+          value,
+        }"
+      >
+        <span class="unit-column margin-mode">
+          {{ value }}
+        </span>
+      </template>
+
+      <template
+        #body-goodTilBlockTime="{
+          value,
+        }"
+      >
+        <span>
+          {{
+            context.formatRelativeTime({
+              timestamp: value,
+            })
+          }}
+        </span>
+      </template>
+    </AppTable>
   </div>
 </template>
 
 <style scoped>
 .unit-container {
   margin-block-start: 2rem;
+}
+
+.unit-column.type {
+  text-transform: capitalize;
+}
+
+.unit-column.side {
+  --color-text-side-buy: var(--palette-green);
+  --color-text-side-sell: var(--palette-red);
+  --color-background-side-buy: var(--palette-green-faded);
+  --color-background-side-sell: var(--palette-red-faded);
+
+  border-radius: 0.25rem;
+
+  padding-block: 0.125rem;
+  padding-inline: 0.25rem;
+
+  font-size: var(--font-size-small);
+
+  text-transform: capitalize;
+}
+
+.unit-column.side.buy {
+  color: var(--color-text-side-buy);
+  background-color: var(--color-background-side-buy);
+}
+
+.unit-column.side.sell {
+  color: var(--color-text-side-sell);
+  background-color: var(--color-background-side-sell);
+}
+
+.unit-column.trigger-price.null {
+  color: var(--color-text-placeholder);
+}
+
+.unit-column.margin-mode {
+  --color-background-margin-mode: var(--palette-layer-6);
+
+  border-radius: 0.25rem;
+
+  padding-block: 0.125rem;
+  padding-inline: 0.25rem;
+
+  font-size: var(--font-size-small);
+  text-transform: capitalize;
+
+  background-color: var(--color-background-margin-mode);
 }
 </style>

--- a/components/profile/ProfileOrders.vue
+++ b/components/profile/ProfileOrders.vue
@@ -12,6 +12,13 @@ export default defineComponent({
     AppTable,
   },
 
+  props: {
+    profileOrders: {
+      type: Array,
+      required: true,
+    },
+  },
+
   setup (
     props,
     componentContext

--- a/components/profile/ProfileOrders.vue
+++ b/components/profile/ProfileOrders.vue
@@ -3,12 +3,17 @@ import {
   defineComponent,
 } from 'vue'
 
+import {
+  NuxtLink,
+} from '#components'
+
 import AppTable from '~/components/units/AppTable.vue'
 
 import ProfileOrdersContext from './ProfileOrdersContext'
 
 export default defineComponent({
   components: {
+    NuxtLink,
     AppTable,
   },
 
@@ -43,6 +48,24 @@ export default defineComponent({
       :header-entries="context.orderTableHeaderEntries"
       :entries="context.generateOrderTableEntries()"
     >
+      <template
+        #body-ticker="{
+          value,
+        }"
+      >
+        <NuxtLink
+          class="unit-column ticker"
+          :to="context.generateTickerUrl({
+            ticker: value,
+          })"
+          external
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ value }}
+        </NuxtLink>
+      </template>
+
       <template
         #body-type="{
           value,
@@ -150,6 +173,16 @@ export default defineComponent({
 <style scoped>
 .unit-container {
   margin-block-start: 2rem;
+}
+
+.unit-column.ticker {
+  white-space: nowrap;
+
+  color: var(--color-text-secondary);
+}
+
+.unit-column.ticker:hover {
+  text-decoration: underline;
 }
 
 .unit-column.type {

--- a/components/profile/ProfileOrders.vue
+++ b/components/profile/ProfileOrders.vue
@@ -45,6 +45,7 @@ export default defineComponent({
 <template>
   <div class="unit-container">
     <AppTable
+      class="table"
       :header-entries="context.orderTableHeaderEntries"
       :entries="context.generateOrderTableEntries()"
     >
@@ -167,6 +168,72 @@ export default defineComponent({
         </span>
       </template>
     </AppTable>
+
+    <AppTable
+      class="table mobile"
+      :header-entries="context.orderTableMobileHeaderEntries"
+      :entries="context.generateOrderTableEntries()"
+    >
+      <template
+        #body-status="{
+          row,
+        }"
+      >
+        <span class="unit-column mobile status">
+          <span class="status">
+            {{ row.status.toLowerCase() }}
+          </span>
+          <span class="fill">
+            <span class="size">
+              {{
+                context.generateDisplayedFillSize({
+                  totalFilled: row.totalFilled,
+                  size: row.size,
+                })
+              }}
+            </span>
+            <span class="ticker">
+              {{ row.ticker }}
+            </span>
+          </span>
+        </span>
+      </template>
+
+      <template
+        #body-price="{
+          row,
+        }"
+      >
+        <span class="unit-column mobile price">
+          <span class="price">
+            <span
+              class="side"
+              :class="{
+                buy: context.isBuySide({
+                  side: row.side,
+                }),
+                sell: context.isSellSide({
+                  side: row.side,
+                }),
+              }"
+            >
+              {{ row.side.toLowerCase() }}
+            </span>
+            <span class="connector">@</span>
+            <span class="price">
+              {{
+                context.formatCurrency({
+                  figure: row.price,
+                })
+              }}
+            </span>
+          </span>
+          <span class="type">
+            {{ row.type.toLowerCase() }}
+          </span>
+        </span>
+      </template>
+    </AppTable>
   </div>
 </template>
 
@@ -231,5 +298,91 @@ export default defineComponent({
   text-transform: capitalize;
 
   background-color: var(--color-background-margin-mode);
+}
+
+/* UI for the table on mobile. */
+.unit-container > .table:not(.mobile) {
+  @media (width < 60rem) {
+    display: none;
+  }
+}
+
+.unit-container > .table.mobile {
+  @media (60rem <= width) {
+    display: none;
+  }
+}
+
+.unit-column.mobile.status {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.unit-column.mobile.status > .status {
+  text-transform: capitalize;
+}
+
+.unit-column.mobile.status > .fill {
+  font-size: var(--font-size-small);
+}
+
+.unit-column.mobile.status > .fill > .size {
+  color: var(--color-text-tertiary);
+}
+
+.unit-column.mobile.status > .fill > .ticker {
+  --color-background-ticker: var(--palette-layer-6);
+
+  margin-inline-start: 0.25rem;
+
+  border-radius: 0.25rem;
+
+  padding-block: 0.125rem;
+  padding-inline: 0.25rem;
+
+  font-size: var(--font-size-mini);
+  text-transform: capitalize;
+
+  background-color: var(--color-background-ticker);
+}
+
+.unit-column.mobile.price {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.unit-column.mobile.price > .price {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.unit-column.mobile.price > .price > .side {
+  --color-text-side-buy: var(--palette-green);
+  --color-text-side-sell: var(--palette-red);
+
+  text-transform: capitalize;
+}
+
+.unit-column.mobile.price > .price > .side.buy {
+  color: var(--color-text-side-buy);
+}
+
+.unit-column.mobile.price > .price > .side.sell {
+  color: var(--color-text-side-sell);
+}
+
+.unit-column.mobile.price > .price > .connector {
+  color: var(--color-text-tertiary);
+}
+
+.unit-column.mobile.price > .type {
+  font-size: var(--font-size-small);
+
+  text-transform: capitalize;
+
+  color: var(--color-text-tertiary);
 }
 </style>

--- a/components/profile/ProfileOrders.vue
+++ b/components/profile/ProfileOrders.vue
@@ -22,6 +22,11 @@ export default defineComponent({
       type: Array,
       required: true,
     },
+    isLoading: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 
   setup (
@@ -48,6 +53,7 @@ export default defineComponent({
       class="table"
       :header-entries="context.orderTableHeaderEntries"
       :entries="context.generateOrderTableEntries()"
+      :is-loading="context.isLoading"
     >
       <template
         #body-ticker="{

--- a/components/profile/ProfileOrders.vue
+++ b/components/profile/ProfileOrders.vue
@@ -1,0 +1,46 @@
+<script>
+import {
+  defineComponent,
+} from 'vue'
+
+import AppTable from '~/components/units/AppTable.vue'
+
+import ProfileOrdersContext from './ProfileOrdersContext'
+
+export default defineComponent({
+  components: {
+    AppTable,
+  },
+
+  setup (
+    props,
+    componentContext
+  ) {
+    const args = {
+      props,
+      componentContext,
+    }
+    const context = ProfileOrdersContext.create(args)
+      .setupComponent()
+
+    return {
+      context,
+    }
+  },
+})
+</script>
+
+<template>
+  <div class="unit-container">
+    <AppTable
+      :header-entries="context.orderTableHeaderEntries"
+      :entries="[]"
+    />
+  </div>
+</template>
+
+<style scoped>
+.unit-container {
+  margin-block-start: 2rem;
+}
+</style>

--- a/components/profile/ProfileOrdersContext.js
+++ b/components/profile/ProfileOrdersContext.js
@@ -2,6 +2,11 @@ import {
   BaseFuroContext,
 } from '@openreachtech/furo-nuxt'
 
+const ORDER_SIDE = {
+  BUY: 'BUY',
+  SELL: 'SELL',
+}
+
 /**
  * ProfileOrdersContext
  *
@@ -25,11 +30,11 @@ export default class ProfileOrdersContext extends BaseFuroContext {
   get orderTableHeaderEntries () {
     return [
       {
-        key: 'market',
+        key: 'ticker',
         label: 'Market',
       },
       {
-        key: 'status',
+        key: 'type',
         label: 'Status',
       },
       {
@@ -37,11 +42,11 @@ export default class ProfileOrdersContext extends BaseFuroContext {
         label: 'Side',
       },
       {
-        key: 'amount',
+        key: 'size',
         label: 'Amount',
       },
       {
-        key: 'filled',
+        key: 'totalFilled',
         label: 'Filled',
       },
       {
@@ -53,14 +58,226 @@ export default class ProfileOrdersContext extends BaseFuroContext {
         label: 'Price',
       },
       {
-        key: 'trigger',
+        key: 'triggerPrice',
         label: 'Trigger',
       },
       {
         key: 'marginMode',
         label: 'Margin Mode',
       },
+      {
+        key: 'goodTilBlockTime',
+        label: 'Good Til',
+        columnOptions: {
+          textAlign: 'end',
+        },
+      },
     ]
+  }
+
+  /**
+   * Generate order table entries.
+   *
+   * @returns {Array<Partial<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOrder>>}
+   */
+  generateOrderTableEntries () {
+    return this.profileOrders.map(it => ({
+      ticker: it.ticker,
+      type: it.type,
+      side: it.side,
+      size: it.size,
+      totalFilled: it.totalFilled,
+      orderValue: this.calculateOrderValue({
+        size: it.size,
+        price: it.price,
+      }),
+      price: it.price,
+      triggerPrice: it.triggerPrice,
+      marginMode: this.generateDisplayedMarginMode({
+        subaccountNumber: it.subaccountNumber,
+      }),
+      goodTilBlockTime: it.goodTilBlockTime,
+    }))
+  }
+
+  /**
+   * Check if is "BUY" side order.
+   *
+   * @param {{
+   *   side: string
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isBuySide ({
+    side,
+  }) {
+    return side === ORDER_SIDE.BUY
+  }
+
+  /**
+   * Check if is "SELL" side order.
+   *
+   * @param {{
+   *   side: string
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isSellSide ({
+    side,
+  }) {
+    return side === ORDER_SIDE.SELL
+  }
+
+  /**
+   * Calculate order value.
+   *
+   * @param {{
+   *   size: string | number
+   *   price: string | number
+   * }} params - Parameters.
+   * @returns {number}
+   */
+  calculateOrderValue ({
+    size,
+    price,
+  }) {
+    const normalizedSize = typeof size === 'string'
+      ? parseFloat(size)
+      : size
+    const normalizedPrice = typeof price === 'string'
+      ? parseFloat(price)
+      : price
+
+    if (
+      isNaN(normalizedSize)
+      || isNaN(normalizedPrice)
+    ) {
+      return 0
+    }
+
+    return normalizedSize * normalizedPrice
+  }
+
+  /**
+   * Generate displayed margin mode.
+   *
+   * @param {{
+   *   subaccountNumber: number
+   * }} params - Parameters.
+   * @returns {'cross' | 'isolated'}
+   */
+  generateDisplayedMarginMode ({
+    subaccountNumber,
+  }) {
+    if (subaccountNumber >= 128) {
+      return 'isolated'
+    }
+
+    return 'cross'
+  }
+
+  /**
+   * Format currency.
+   *
+   * @param {{
+   *   figure: string | number
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  formatCurrency ({
+    figure,
+  }) {
+    if (this.isNullish({
+      value: figure,
+    })) {
+      return '--'
+    }
+
+    const normalizedFigure = typeof figure === 'string'
+      ? parseFloat(figure)
+      : figure
+
+    const formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+
+    return formatter.format(normalizedFigure)
+  }
+
+  /**
+   * Format relative time.
+   *
+   * @param {{
+   *   timestamp: Date | string | number
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  formatRelativeTime ({
+    timestamp,
+  }) {
+    if (this.isNullish({
+      value: timestamp,
+    })) {
+      return '--'
+    }
+
+    const date = new Date(timestamp)
+    const remainingTime = date.getTime() - Date.now()
+    const remainingDayCount = Math.floor(remainingTime / (1000 * 60 * 60 * 24))
+
+    const formatter = new Intl.RelativeTimeFormat('en-US', {
+      numeric: 'always',
+      style: 'narrow',
+    })
+    const unit = this.generateRelativeTimeUnit({
+      remainingDayCount,
+    })
+
+    return formatter.format(
+      remainingDayCount,
+      unit
+    )
+      .replace('in ', '')
+  }
+
+  /**
+   * Generate relative time unit.
+   *
+   * @param {{
+   *   remainingDayCount: number
+   * }} params - Parameters.
+   * @returns {Intl.RelativeTimeFormatUnit}
+   */
+  generateRelativeTimeUnit ({
+    remainingDayCount,
+  }) {
+    if (remainingDayCount >= 30) {
+      return 'month'
+    }
+
+    if (remainingDayCount >= 7) {
+      return 'week'
+    }
+
+    return 'day'
+  }
+
+  /**
+   * Check if a value is null or undefined.
+   *
+   * @param {{
+   *   value: *
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isNullish ({
+    value,
+  }) {
+    return value === null
+      || value === undefined
   }
 }
 

--- a/components/profile/ProfileOrdersContext.js
+++ b/components/profile/ProfileOrdersContext.js
@@ -101,6 +101,20 @@ export default class ProfileOrdersContext extends BaseFuroContext {
   }
 
   /**
+   * Generate ticker URL.
+   *
+   * @param {{
+   *   ticker: string
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  generateTickerUrl ({
+    ticker,
+  }) {
+    return `https://dydx.trade/trade/${ticker}`
+  }
+
+  /**
    * Check if is "BUY" side order.
    *
    * @param {{

--- a/components/profile/ProfileOrdersContext.js
+++ b/components/profile/ProfileOrdersContext.js
@@ -1,0 +1,56 @@
+import {
+  BaseFuroContext,
+} from '@openreachtech/furo-nuxt'
+
+/**
+ * ProfileOrdersContext
+ *
+ * @extends {BaseFuroContext<null, {}, null>}
+ */
+export default class ProfileOrdersContext extends BaseFuroContext {
+  /**
+   * get: orderTableHeaderEntries
+   *
+   * @returns {Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>}
+   */
+  get orderTableHeaderEntries () {
+    return [
+      {
+        key: 'market',
+        label: 'Market',
+      },
+      {
+        key: 'status',
+        label: 'Status',
+      },
+      {
+        key: 'side',
+        label: 'Side',
+      },
+      {
+        key: 'amount',
+        label: 'Amount',
+      },
+      {
+        key: 'filled',
+        label: 'Filled',
+      },
+      {
+        key: 'orderValue',
+        label: 'Order Value',
+      },
+      {
+        key: 'price',
+        label: 'Price',
+      },
+      {
+        key: 'trigger',
+        label: 'Trigger',
+      },
+      {
+        key: 'marginMode',
+        label: 'Margin Mode',
+      },
+    ]
+  }
+}

--- a/components/profile/ProfileOrdersContext.js
+++ b/components/profile/ProfileOrdersContext.js
@@ -76,6 +76,27 @@ export default class ProfileOrdersContext extends BaseFuroContext {
   }
 
   /**
+   * get: orderTableMobileHeaderEntries
+   *
+   * @returns {Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>}
+   */
+  get orderTableMobileHeaderEntries () {
+    return [
+      {
+        key: 'status',
+        label: 'Status | Fill',
+      },
+      {
+        key: 'price',
+        label: 'Price | Type',
+        columnOptions: {
+          textAlign: 'end',
+        },
+      },
+    ]
+  }
+
+  /**
    * Generate order table entries.
    *
    * @returns {Array<Partial<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOrder>>}
@@ -84,6 +105,7 @@ export default class ProfileOrdersContext extends BaseFuroContext {
     return this.profileOrders.map(it => ({
       ticker: it.ticker,
       type: it.type,
+      status: it.status,
       side: it.side,
       size: it.size,
       totalFilled: it.totalFilled,
@@ -188,6 +210,29 @@ export default class ProfileOrdersContext extends BaseFuroContext {
     }
 
     return 'cross'
+  }
+
+  /**
+   * Generate displayed fill size.
+   *
+   * @param {{
+   *   totalFilled: string | number
+   *   size: string | number
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  generateDisplayedFillSize ({
+    totalFilled,
+    size,
+  }) {
+    const normalizedTotalFilled = typeof totalFilled === 'string'
+      ? parseFloat(totalFilled)
+      : totalFilled
+    const normalizedSize = typeof size === 'string'
+      ? parseFloat(size)
+      : size
+
+    return `${normalizedTotalFilled.toFixed(4)} / ${normalizedSize.toFixed(4)}`
   }
 
   /**

--- a/components/profile/ProfileOrdersContext.js
+++ b/components/profile/ProfileOrdersContext.js
@@ -23,6 +23,15 @@ export default class ProfileOrdersContext extends BaseFuroContext {
   }
 
   /**
+   * get: isLoading
+   *
+   * @returns {boolean}
+   */
+  get isLoading () {
+    return this.props.isLoading
+  }
+
+  /**
    * get: orderTableHeaderEntries
    *
    * @returns {Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>}
@@ -343,5 +352,6 @@ export default class ProfileOrdersContext extends BaseFuroContext {
 /**
  * @typedef {{
  *   profileOrders: Array<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOrder>
+ *   isLoading: boolean
  * }} PropsType
  */

--- a/components/profile/ProfileOrdersContext.js
+++ b/components/profile/ProfileOrdersContext.js
@@ -5,9 +5,18 @@ import {
 /**
  * ProfileOrdersContext
  *
- * @extends {BaseFuroContext<null, {}, null>}
+ * @extends {BaseFuroContext<null, PropsType, null>}
  */
 export default class ProfileOrdersContext extends BaseFuroContext {
+  /**
+   * get: profileOrders
+   *
+   * @returns {Array<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOrder>}
+   */
+  get profileOrders () {
+    return this.props.profileOrders
+  }
+
   /**
    * get: orderTableHeaderEntries
    *
@@ -54,3 +63,9 @@ export default class ProfileOrdersContext extends BaseFuroContext {
     ]
   }
 }
+
+/**
+ * @typedef {{
+ *   profileOrders: Array<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOrder>
+ * }} PropsType
+ */

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -150,7 +150,10 @@ export default defineComponent({
 
         <ProfileLeagueHistory />
 
-        <ProfileOrders :profile-orders="context.profileOrders" />
+        <ProfileOrders
+          :profile-orders="context.profileOrders"
+          :is-loading="context.isLoadingProfileOrders"
+        />
       </template>
     </AppTabLayout>
 

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -8,10 +8,11 @@ import {
 import AppTabLayout from '~/components/units/AppTabLayout.vue'
 import SectionProfileOverview from '~/components/profile/SectionProfileOverview.vue'
 import SectionProfileFinancialMetrics from '~/components/profile/SectionProfileFinancialMetrics.vue'
+import ProfileRenameDialog from '~/components/dialogs/ProfileRenameDialog.vue'
 import ProfileTransferHistory from '~/components/profile/ProfileTransferHistory.vue'
 import ProfileLeagueHistory from '~/components/profile/ProfileLeagueHistory.vue'
 import ProfileFinancialOverview from '~/components/profile/ProfileFinancialOverview.vue'
-import ProfileRenameDialog from '~/components/dialogs/ProfileRenameDialog.vue'
+import ProfileOrders from '~/components/profile/ProfileOrders.vue'
 
 import {
   useGraphqlClient,
@@ -38,6 +39,7 @@ export default defineComponent({
     ProfileTransferHistory,
     ProfileLeagueHistory,
     ProfileFinancialOverview,
+    ProfileOrders,
   },
 
   setup (
@@ -142,6 +144,8 @@ export default defineComponent({
         <ProfileTransferHistory />
 
         <ProfileLeagueHistory />
+
+        <ProfileOrders />
       </template>
     </AppTabLayout>
 

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -150,7 +150,7 @@ export default defineComponent({
 
         <ProfileLeagueHistory />
 
-        <ProfileOrders />
+        <ProfileOrders :profile-orders="context.profileOrders" />
       </template>
     </AppTabLayout>
 

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -63,10 +63,14 @@ export default defineComponent({
     const mutationErrorMessageRef = ref(null)
     /** @type {import('vue').Ref<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOverview | null>} */
     const profileOverviewRef = ref(null)
+    /** @type {import('vue').Ref<Array<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOrder>>} */
+    const profileOrdersRef = ref([])
+
     const statusReactive = reactive({
       isLoading: false,
       isFetchingName: false,
       isLoadingProfileOverview: true,
+      isLoadingProfileOrders: true,
     })
     const mutationStatusReactive = reactive({
       isRenaming: false,
@@ -81,6 +85,7 @@ export default defineComponent({
         competitionParticipant: competitionParticipantGraphqlClient,
       },
       profileOverviewRef,
+      profileOrdersRef,
       errorMessageRef,
       statusReactive,
     }


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3731

# How

* Fetch `ListOrdersForParentSubaccount` from dYdX Indexer and display the data in "Orders" tab.
* Table layout on mobile is different so there are two table elements. Each one is hidden accordingly using media query.


# Screenshots

![image](https://github.com/user-attachments/assets/cae55e62-be4c-413c-9e63-886df2b2c7cf)

> [!note]
> Tab buttons overflowing will be fixed in another pull request.

![image](https://github.com/user-attachments/assets/068afd50-e3cf-4a46-b22c-c8868c21dbc4)
