### PR TITLE
Make tab buttons more responsive on smaller screens

### DIFF
--- a/components/units/AppTabLayout.vue
+++ b/components/units/AppTabLayout.vue
@@ -43,7 +43,15 @@ export default defineComponent({
 
     overflow-x: auto;
 
-    gap: 2rem;
+    gap: 0.75rem;
+
+    @media (30rem < width) {
+      gap: 1rem;
+    }
+
+    @media (60rem < width) {
+      gap: 2rem;
+    }
   }
 
   .furo-layout.tab.design > .tabs > .tab {
@@ -52,7 +60,7 @@ export default defineComponent({
     border-block-end-color: transparent;
 
     padding-block: 0 0.75rem;
-    padding-inline: 1rem;
+    padding-inline: 0.75rem;
 
     font-size: var(--font-size-small);
     font-weight: 500;
@@ -66,6 +74,8 @@ export default defineComponent({
       border-color 150ms var(--transition-timing-base);
 
     @media (48rem < width) {
+      padding-inline: 1rem;
+
       font-size: var(--font-size-base);
     }
   }

--- a/components/units/AppTabLayout.vue
+++ b/components/units/AppTabLayout.vue
@@ -41,6 +41,8 @@ export default defineComponent({
     border-block-end-style: solid;
     border-block-end-color: var(--color-border);
 
+    overflow-x: auto;
+
     gap: 2rem;
   }
 
@@ -54,6 +56,8 @@ export default defineComponent({
 
     font-size: var(--font-size-base);
     font-weight: 500;
+
+    white-space: nowrap;
 
     background-color: transparent;
     color: var(--color-text-tertiary);

--- a/components/units/AppTabLayout.vue
+++ b/components/units/AppTabLayout.vue
@@ -54,7 +54,7 @@ export default defineComponent({
     padding-block: 0 0.75rem;
     padding-inline: 1rem;
 
-    font-size: var(--font-size-base);
+    font-size: var(--font-size-small);
     font-weight: 500;
 
     white-space: nowrap;
@@ -64,6 +64,10 @@ export default defineComponent({
 
     transition: color 250ms var(--transition-timing-base),
       border-color 150ms var(--transition-timing-base);
+
+    @media (48rem < width) {
+      font-size: var(--font-size-base);
+    }
   }
 
   .furo-layout.tab.design > .tabs > .tab:hover {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1673

# How

* Make tab buttons scrollable.
* Don't allow tab's label to wrap on whitespace.
* Reduce tab button's font size on smaller screens.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/fa708494-13a7-4a02-a870-e707960511af)

## After

![Screenshot From 2025-06-16 08-55-10](https://github.com/user-attachments/assets/d968905c-2364-49db-9573-31f1b339a849)

