### PR TITLE
Add GraphQL definitions for competitionTradingMetrics query

### DIFF
--- a/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlCapsule.js
@@ -1,0 +1,85 @@
+import BaseAppGraphqlCapsule from '~/app/graphql/client/BaseAppGraphqlCapsule'
+
+/**
+ * `competitionTradingMetrics` query graphql capsule.
+ *
+ * @extends {BaseAppGraphqlCapsule<CompetitionTradingMetricsQueryResponseContent>}
+ */
+export default class CompetitionTradingMetricsQueryGraphqlCapsule extends BaseAppGraphqlCapsule {
+  /**
+   * Extract `competitionTradingMetrics` value hash.
+   *
+   * @returns {CompetitionTradingMetricsQueryResponseContent['competitionTradingMetrics'] | null}
+   */
+  extractCompetitionTradingMetricsValueHash () {
+    return this.extractContent()
+      ?.competitionTradingMetrics
+      ?? null
+  }
+
+  /**
+   * get: metrics
+   *
+   * @returns {Array<TradingMetric>}
+   */
+  get metrics () {
+    return this.extractCompetitionTradingMetricsValueHash()
+      ?.metrics
+      ?? []
+  }
+
+  /**
+   * get: pagination
+   *
+   * @returns {Pagination | null}
+   */
+  get pagination () {
+    return this.extractCompetitionTradingMetricsValueHash()
+      ?.pagination
+      ?? null
+  }
+
+  /**
+   * get: totalCount
+   *
+   * @returns {number | null}
+   */
+  get totalCount () {
+    return this.pagination
+      ?.totalCount
+      ?? null
+  }
+}
+
+/**
+ * @typedef {{
+ *   competitionTradingMetrics: {
+ *     metrics: Array<TradingMetric>
+ *     pagination: Pagination
+ *   }
+ * }} CompetitionTradingMetricsQueryResponseContent
+ */
+
+/**
+ * @typedef {{
+ *   address: {
+ *     address: string
+ *     name: string
+ *   }
+ *   makerFees: number
+ *   takerFees: number
+ *   totalFees: number
+ *   makeVolume: number
+ *   takerVolume: number
+ *   totalVolume: number
+ *   calculatedAt: string // ISO string
+ * }} TradingMetric
+ */
+
+/**
+ * @typedef {{
+ *   totalCount: number
+ *   limit: number
+ *   offset: number
+ * }} Pagination
+ */

--- a/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlLauncher.js
@@ -1,0 +1,21 @@
+import BaseAppGraphqlLauncher from '~/app/graphql/client/BaseAppGraphqlLauncher'
+
+import CompetitionTradingMetricsQueryGraphqlPayload from './CompetitionTradingMetricsQueryGraphqlPayload'
+import CompetitionTradingMetricsQueryGraphqlCapsule from './CompetitionTradingMetricsQueryGraphqlCapsule'
+
+/**
+ * `competitionTradingMetrics` query graphql launcher.
+ *
+ * @extends {BaseAppGraphqlLauncher}
+ */
+export default class CompetitionTradingMetricsQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
+  /** @override */
+  static get Payload () {
+    return CompetitionTradingMetricsQueryGraphqlPayload
+  }
+
+  /** @override */
+  static get Capsule () {
+    return CompetitionTradingMetricsQueryGraphqlCapsule
+  }
+}

--- a/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlPayload.js
@@ -1,0 +1,52 @@
+import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
+
+/**
+ * `competitionTradingMetrics` query payload.
+ *
+ * @extends {BaseAppGraphqlPayload<CompetitionTradingMetricsQueryRequestVariables>}
+ */
+export default class CompetitionTradingMetricsQueryGraphqlPayload extends BaseAppGraphqlPayload {
+  /** @override */
+  static get document () {
+    return /* GraphQL */ `
+      query CompetitionTradingMetricsQuery ($input: CompetitionTradingMetricsInput!) {
+        competitionTradingMetrics (input: $input) {
+          metrics {
+            address {
+              address
+              name
+            }
+            makerFees
+            takerFees
+            totalFees
+            makeVolume
+            takerVolume
+            totalVolume
+            calculatedAt
+          }
+          pagination {
+            totalCount
+            limit
+            offset
+          }
+        }
+      }
+    `
+  }
+}
+
+/**
+ * @typedef {{
+ *   input: {
+ *     competitionId: number
+ *     pagination: {
+ *       limit: number
+ *       offset: number
+ *       sort?: {
+ *         targetColumn: string
+ *         orderBy: string
+ *       }
+ *     }
+ *   }
+ * }} CompetitionTradingMetricsQueryRequestVariables
+ */


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3973

# How

* Add GraphQL definitions for competitionTradingMetrics query.
