### PR TITLE
Add indicator for user with unrecovered local address

### DIFF
--- a/components/units/AppWalletAccount.vue
+++ b/components/units/AppWalletAccount.vue
@@ -85,6 +85,12 @@ export default defineComponent({
         class="image"
       >
 
+      <Icon
+        class="wallet error"
+        name="heroicons:exclamation-triangle"
+        size="1.25rem"
+      />
+
       <span>{{ context.generateSourceAccountAddress() }}</span>
 
       <Icon
@@ -219,6 +225,18 @@ export default defineComponent({
 .unit-account > .button > .image {
   width: 1.25rem;
   height: 1.25rem;
+}
+
+.unit-account:not(.recovered) > .button > .image {
+  display: none;
+}
+
+.unit-account > .button > .wallet.error {
+  color: var(--color-text-message-warn);
+}
+
+.unit-account.recovered > .button > .wallet.error {
+  display: none;
 }
 
 .unit-account > .button > .icon {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1706

# How

* Show a warning sign for user that has not recovered their local wallet address. Just like what `dydx.trade` does for better UX.

# Screenshots

![image](https://github.com/user-attachments/assets/a1103a07-1aad-45ca-b9e0-557fe4d12f67)
