### PR TITLE
Make sure displayed ranking text does not wrap

### DIFF
--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -616,6 +616,8 @@ export default defineComponent({
 
 /***************** Non-podium rankers ****************/
 .unit-rank:where(.ongoing, .outcome) {
+  white-space: nowrap;
+
   color: var(--color-text-primary);
 }
 

--- a/components/profile/ProfileLeagueHistory.vue
+++ b/components/profile/ProfileLeagueHistory.vue
@@ -185,6 +185,8 @@ export default defineComponent({
   font-weight: 500;
   line-height: var(--size-line-height-base);
 
+  white-space: nowrap;
+
   color: var(--color-text-secondary);
 }
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3974

# How

* Do not wrap ranking label.

# Screenshots

## Before

![Screenshot From 2025-06-16 09-29-03](https://github.com/user-attachments/assets/121e5ea2-122e-4734-9fd3-26cd1ca2618a)

## After

![image](https://github.com/user-attachments/assets/cb429b3e-232f-4a83-83c3-f4fa36de8bef)

