### PR TITLE
Add "Trades" tab in address detail page

### DIFF
--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -114,6 +114,10 @@ export default class ProfileDetailsContext extends BaseFuroContext {
         tabKey: 'orders',
         label: 'Orders',
       },
+      {
+        tabKey: 'trades',
+        label: 'Trades',
+      },
     ]
   }
 

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -131,6 +131,15 @@ export default class ProfileDetailsContext extends BaseFuroContext {
   }
 
   /**
+   * get: isLoadingProfileTrades
+   *
+   * @returns {boolean}
+   */
+  get isLoadingProfileTrades () {
+    return this.statusReactive.isLoadingProfileTrades
+  }
+
+  /**
    * Setup component context.
    *
    * @template {X extends ProfileDetailsContext ? X : never} T, X
@@ -620,6 +629,7 @@ export default class ProfileDetailsContext extends BaseFuroContext {
  *   isFetchingName: boolean
  *   isLoadingProfileOverview: boolean
  *   isLoadingProfileOrders: boolean
+ *   isLoadingProfileTrades: boolean
  * }} StatusReactive
  */
 

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -356,7 +356,7 @@ export default class ProfileDetailsContext extends BaseFuroContext {
       return
     }
 
-    this.statusReactive.isLoadingProfileTrades = false
+    this.statusReactive.isLoadingProfileTrades = true
 
     const searchParams = new URLSearchParams({
       address,

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -361,6 +361,7 @@ export default class ProfileDetailsContext extends BaseFuroContext {
     const searchParams = new URLSearchParams({
       address,
       parentSubaccountNumber: '0',
+      limit: '100', // Only fetch the latest 100 trade fills.
     })
     const resourceUrl = `${BASE_INDEXER_URL}/fills/parentSubaccountNumber?${searchParams.toString()}`
     const fetchOptionHash = this.generateFetchOptionHash()

--- a/components/profile/ProfileTrades.vue
+++ b/components/profile/ProfileTrades.vue
@@ -23,6 +23,11 @@ export default defineComponent({
       type: Array,
       required: true,
     },
+    isLoading: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 
   setup (
@@ -48,6 +53,7 @@ export default defineComponent({
     <AppTable
       :header-entries="context.tradeTableHeaderEntries"
       :entries="context.generateTradeTableEntries()"
+      :is-loading="context.isLoading"
       min-width="50rem"
     >
       <template

--- a/components/profile/ProfileTrades.vue
+++ b/components/profile/ProfileTrades.vue
@@ -3,9 +3,28 @@ import {
   defineComponent,
 } from 'vue'
 
+import {
+  NuxtLink,
+} from '#components'
+
+import AppTable from '~/components/units/AppTable.vue'
+
 import ProfileTradesContext from './ProfileTradesContext'
 
 export default defineComponent({
+  components: {
+    NuxtLink,
+    AppTable,
+  },
+
+  props: {
+    profileTrades: {
+      /** @type {import('vue').PropType<import('./ProfileTradesContext').PropsType['profileTrades']>} */
+      type: Array,
+      required: true,
+    },
+  },
+
   setup (
     props,
     componentContext
@@ -26,12 +45,181 @@ export default defineComponent({
 
 <template>
   <div class="unit-container">
-    Profile Trades
+    <AppTable
+      :header-entries="context.tradeTableHeaderEntries"
+      :entries="context.generateTradeTableEntries()"
+      min-width="50rem"
+    >
+      <template
+        #body-market="{
+          value,
+        }"
+      >
+        <NuxtLink
+          :to="context.generateMarketUrl({
+            market: value,
+          })"
+          class="unit-column market"
+          external
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ value }}
+        </NuxtLink>
+      </template>
+
+      <template
+        #body-createdAt="{
+          value,
+        }"
+      >
+        <time
+          class="unit-column created-at"
+          :datetime="value"
+        >
+          {{
+            context.formatRelativeTime({
+              timestamp: value,
+            })
+          }}
+        </time>
+      </template>
+
+      <template
+        #body-type="{
+          value,
+        }"
+      >
+        <span class="unit-column type">
+          {{ value.toLowerCase() }}
+        </span>
+      </template>
+
+      <template
+        #body-side="{
+          value,
+        }"
+      >
+        <span
+          class="unit-column side"
+          :class="{
+            buy: context.isBuySide({
+              side: value,
+            }),
+            sell: context.isSellSide({
+              side: value,
+            }),
+          }"
+        >
+          {{ value.toLowerCase() }}
+        </span>
+      </template>
+
+      <template
+        #body-price="{
+          value,
+        }"
+      >
+        <span class="unit-column price">
+          {{
+            context.formatCurrency({
+              figure: value,
+            })
+          }}
+        </span>
+      </template>
+
+      <template
+        #body-total="{
+          value,
+        }"
+      >
+        <span class="unit-column total">
+          {{
+            context.formatCurrency({
+              figure: value,
+            })
+          }}
+        </span>
+      </template>
+
+      <template
+        #body-fee="{
+          value,
+        }"
+      >
+        <span class="unit-column fee">
+          {{
+            context.formatCurrency({
+              figure: value,
+            })
+          }}
+        </span>
+      </template>
+
+      <template
+        #body-liquidity="{
+          value,
+        }"
+      >
+        <span class="unit-column liquidity">
+          {{ value.toLowerCase() }}
+        </span>
+      </template>
+    </AppTable>
   </div>
 </template>
 
 <style scoped>
 .unit-container {
   margin-block-start: 2rem;
+}
+
+.unit-column.market {
+  color: var(--color-text-primary);
+
+  white-space: nowrap;
+}
+
+.unit-column.market:hover {
+  text-decoration: underline;
+}
+
+.unit-column.created-at {
+  color: var(--color-text-tertiary);
+}
+
+.unit-column.type {
+  text-transform: capitalize;
+}
+
+.unit-column.side {
+  --color-text-side-buy: var(--palette-green);
+  --color-text-side-sell: var(--palette-red);
+  --color-background-side-buy: var(--palette-green-faded);
+  --color-background-side-sell: var(--palette-red-faded);
+
+  border-radius: 0.25rem;
+
+  padding-block: 0.125rem;
+  padding-inline: 0.25rem;
+
+  font-size: var(--font-size-small);
+
+  text-transform: capitalize;
+}
+
+.unit-column.side.buy {
+  color: var(--color-text-side-buy);
+  background-color: var(--color-background-side-buy);
+}
+
+.unit-column.side.sell {
+  color: var(--color-text-side-sell);
+  background-color: var(--color-background-side-sell);
+}
+
+.unit-column.liquidity {
+  text-transform: capitalize;
 }
 </style>

--- a/components/profile/ProfileTrades.vue
+++ b/components/profile/ProfileTrades.vue
@@ -51,6 +51,7 @@ export default defineComponent({
 <template>
   <div class="unit-container">
     <AppTable
+      class="table"
       :header-entries="context.tradeTableHeaderEntries"
       :entries="context.generateTradeTableEntries()"
       :is-loading="context.isLoading"
@@ -173,6 +174,91 @@ export default defineComponent({
         </span>
       </template>
     </AppTable>
+
+    <AppTable
+      class="table mobile"
+      :header-entries="context.tradeTableMobileHeaderEntries"
+      :entries="context.generateTradeTableEntries()"
+      :is-loading="context.isLoading"
+      min-width="20rem"
+    >
+      <template
+        #body-createdAt="{
+          value,
+        }"
+      >
+        <time
+          class="unit-column mobile created-at"
+          :datetime="value"
+        >
+          {{
+            context.formatRelativeTime({
+              timestamp: value,
+            })
+          }}
+        </time>
+      </template>
+
+      <template
+        #body-typeSize="{
+          row,
+        }"
+      >
+        <span class="unit-column mobile type-size">
+          <span class="type">
+            {{ row.type.toLowerCase() }}
+          </span>
+          <span class="size">
+            {{ row.size }}
+          </span>
+        </span>
+      </template>
+
+      <template
+        #body-priceFee="{
+          row,
+        }"
+      >
+        <span class="unit-column mobile price-fee">
+          <span class="valuation">
+            <span
+              class="side"
+              :class="{
+                buy: context.isBuySide({
+                  side: row.side,
+                }),
+                sell: context.isSellSide({
+                  side: row.side,
+                }),
+              }"
+            >
+              {{ row.side.toLowerCase() }}
+            </span>
+            <span class="connector">@</span>
+            <span class="price">
+              {{
+                context.formatCurrency({
+                  figure: row.price,
+                })
+              }}
+            </span>
+          </span>
+
+          <span class="commission">
+            <span class="liquidity">
+              {{ row.liquidity.toLowerCase() }}
+            </span>
+            <span class="fee">
+              {{
+                context.formatCurrency({
+                  figure: row.fee,
+                })
+              }}
+            </span>
+          </span>
+        </span>
+      </template>
+    </AppTable>
   </div>
 </template>
 
@@ -227,5 +313,79 @@ export default defineComponent({
 
 .unit-column.liquidity {
   text-transform: capitalize;
+}
+
+/* UI for the table on mobile. */
+.unit-container > .table:not(.mobile) {
+  @media (width < 60rem) {
+    display: none;
+  }
+}
+
+.unit-container > .table.mobile {
+  @media (60rem <= width) {
+    display: none;
+  }
+}
+
+.unit-column.mobile.type-size {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.unit-column.mobile.type-size > .type {
+  text-transform: capitalize;
+}
+
+.unit-column.mobile.type-size > .size {
+  font-size: var(--font-size-small);
+
+  color: var(--color-text-tertiary);
+}
+
+.unit-column.mobile.price-fee {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.unit-column.mobile.price-fee > .valuation {
+  display: inline-flex;
+  align-items: start;
+  gap: 0.25rem;
+}
+
+.unit-column.mobile.price-fee > .valuation > .side {
+  --color-text-side-buy: var(--palette-green);
+  --color-text-side-sell: var(--palette-red);
+
+  text-transform: capitalize;
+}
+
+.unit-column.mobile.price-fee > .valuation > .side.buy {
+  color: var(--color-text-side-buy);
+}
+
+.unit-column.mobile.price-fee > .valuation > .side.sell {
+  color: var(--color-text-side-sell);
+}
+
+.unit-column.mobile.price-fee > .valuation > .connector {
+  color: var(--color-text-tertiary);
+}
+
+.unit-column.mobile.price-fee > .commission {
+  font-size: var(--font-size-small);
+}
+
+.unit-column.mobile.price-fee > .commission > .liquidity {
+  text-transform: capitalize;
+}
+
+.unit-column.mobile.price-fee > .commission > .fee {
+  margin-inline-start: 0.25rem;
+
+  color: var(--color-text-tertiary);
 }
 </style>

--- a/components/profile/ProfileTrades.vue
+++ b/components/profile/ProfileTrades.vue
@@ -1,0 +1,37 @@
+<script>
+import {
+  defineComponent,
+} from 'vue'
+
+import ProfileTradesContext from './ProfileTradesContext'
+
+export default defineComponent({
+  setup (
+    props,
+    componentContext
+  ) {
+    const args = {
+      props,
+      componentContext,
+    }
+    const context = ProfileTradesContext.create(args)
+      .setupComponent()
+
+    return {
+      context,
+    }
+  },
+})
+</script>
+
+<template>
+  <div class="unit-container">
+    Profile Trades
+  </div>
+</template>
+
+<style scoped>
+.unit-container {
+  margin-block-start: 2rem;
+}
+</style>

--- a/components/profile/ProfileTradesContext.js
+++ b/components/profile/ProfileTradesContext.js
@@ -81,6 +81,31 @@ export default class ProfileTradesContext extends BaseFuroContext {
   }
 
   /**
+   * get: tradeTableMobileHeaderEntries
+   *
+   * @returns {Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>}
+   */
+  get tradeTableMobileHeaderEntries () {
+    return [
+      {
+        key: 'createdAt',
+        label: 'Time',
+      },
+      {
+        key: 'typeSize',
+        label: 'Type | Amount',
+      },
+      {
+        key: 'priceFee',
+        label: 'Price | Fee',
+        columnOptions: {
+          textAlign: 'end',
+        },
+      },
+    ]
+  }
+
+  /**
    * Generate body entries for trade table.
    *
    * @returns {Array<Partial<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileTradeFill>>}

--- a/components/profile/ProfileTradesContext.js
+++ b/components/profile/ProfileTradesContext.js
@@ -23,6 +23,15 @@ export default class ProfileTradesContext extends BaseFuroContext {
   }
 
   /**
+   * get: isLoading
+   *
+   * @returns {PropsType['isLoading']}
+   */
+  get isLoading () {
+    return this.props.isLoading
+  }
+
+  /**
    * get: tradeTableHeaderEntries
    *
    * @returns {Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>}
@@ -272,5 +281,6 @@ export default class ProfileTradesContext extends BaseFuroContext {
 /**
  * @typedef {{
  *   profileTrades: Array<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileTradeFill>
+ *   isLoading: boolean
  * }} PropsType
  */

--- a/components/profile/ProfileTradesContext.js
+++ b/components/profile/ProfileTradesContext.js
@@ -2,11 +2,275 @@ import {
   BaseFuroContext,
 } from '@openreachtech/furo-nuxt'
 
+const ORDER_SIDE = {
+  BUY: 'BUY',
+  SELL: 'SELL',
+}
+
 /**
  * ProfileTradesContext
  *
- * @extends {BaseFuroContext<null, {}, null>}
+ * @extends {BaseFuroContext<null, PropsType, null>}
  */
 export default class ProfileTradesContext extends BaseFuroContext {
+  /**
+   * get: profileTrades
+   *
+   * @returns {PropsType['profileTrades']}
+   */
+  get profileTrades () {
+    return this.props.profileTrades
+  }
 
+  /**
+   * get: tradeTableHeaderEntries
+   *
+   * @returns {Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>}
+   */
+  get tradeTableHeaderEntries () {
+    return [
+      {
+        key: 'market',
+        label: 'Market',
+      },
+      {
+        key: 'createdAt',
+        label: 'Time',
+      },
+      {
+        key: 'type',
+        label: 'Type',
+      },
+      {
+        key: 'side',
+        label: 'Side',
+      },
+      {
+        key: 'size',
+        label: 'Amount',
+      },
+      {
+        key: 'price',
+        label: 'Price',
+      },
+      {
+        key: 'total',
+        label: 'Total',
+      },
+      {
+        key: 'fee',
+        label: 'Fee',
+      },
+      {
+        key: 'liquidity',
+        label: 'Liquidity',
+        columnOptions: {
+          textAlign: 'end',
+        },
+      },
+    ]
+  }
+
+  /**
+   * Generate body entries for trade table.
+   *
+   * @returns {Array<Partial<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileTradeFill>>}
+   */
+  generateTradeTableEntries () {
+    return this.profileTrades.map(it => ({
+      market: it.market,
+      createdAt: it.createdAt,
+      type: it.type,
+      side: it.side,
+      size: it.size,
+      price: it.price,
+      total: this.calculateTotalValue({
+        size: it.size,
+        price: it.price,
+      }),
+      fee: it.fee,
+      liquidity: it.liquidity,
+    }))
+  }
+
+  /**
+   * Calculate total value.
+   *
+   * @param {{
+   *   size: string | number
+   *   price: string | number
+   * }} params - Parameters.
+   * @returns {number}
+   */
+  calculateTotalValue ({
+    size,
+    price,
+  }) {
+    const normalizedSize = typeof size === 'string'
+      ? parseFloat(size)
+      : size
+    const normalizedPrice = typeof price === 'string'
+      ? parseFloat(price)
+      : price
+
+    if (
+      isNaN(normalizedSize)
+      || isNaN(normalizedPrice)
+    ) {
+      return 0
+    }
+
+    return normalizedSize * normalizedPrice
+  }
+
+  /**
+   * Generate market URL.
+   *
+   * @param {{
+   *   market: string
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  generateMarketUrl ({
+    market,
+  }) {
+    return `https://dydx.trade/trade/${market}`
+  }
+
+  /**
+   * Format currency.
+   *
+   * @param {{
+   *   figure: string | number
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  formatCurrency ({
+    figure,
+  }) {
+    if (this.isNullish({
+      value: figure,
+    })) {
+      return '--'
+    }
+
+    const normalizedFigure = typeof figure === 'string'
+      ? parseFloat(figure)
+      : figure
+
+    const formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+
+    return formatter.format(normalizedFigure)
+  }
+
+  /**
+   * Format relative time.
+   *
+   * @param {{
+   *   timestamp: Date | string | number
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  formatRelativeTime ({
+    timestamp,
+  }) {
+    if (this.isNullish({
+      value: timestamp,
+    })) {
+      return '--'
+    }
+
+    const date = new Date(timestamp)
+    const remainingTime = date.getTime() - Date.now()
+    const remainingDayCount = Math.floor(remainingTime / (1000 * 60 * 60 * 24))
+
+    const formatter = new Intl.RelativeTimeFormat('en-US', {
+      numeric: 'always',
+      style: 'narrow',
+    })
+    const unit = this.generateRelativeTimeUnit({
+      remainingDayCount,
+    })
+
+    return formatter.format(
+      remainingDayCount,
+      unit
+    )
+  }
+
+  /**
+   * Generate relative time unit.
+   *
+   * @param {{
+   *   remainingDayCount: number
+   * }} params - Parameters.
+   * @returns {Intl.RelativeTimeFormatUnit}
+   */
+  generateRelativeTimeUnit ({
+    remainingDayCount,
+  }) {
+    if (remainingDayCount >= 30) {
+      return 'month'
+    }
+
+    if (remainingDayCount >= 7) {
+      return 'week'
+    }
+
+    return 'day'
+  }
+
+  /**
+   * Check if is "BUY" side order.
+   *
+   * @param {{
+   *   side: string
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isBuySide ({
+    side,
+  }) {
+    return side === ORDER_SIDE.BUY
+  }
+
+  /**
+   * Check if is "SELL" side order.
+   *
+   * @param {{
+   *   side: string
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isSellSide ({
+    side,
+  }) {
+    return side === ORDER_SIDE.SELL
+  }
+
+  /**
+   * Check if a value is null or undefined.
+   *
+   * @param {{
+   *   value: *
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isNullish ({
+    value,
+  }) {
+    return value === null
+      || value === undefined
+  }
 }
+
+/**
+ * @typedef {{
+ *   profileTrades: Array<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileTradeFill>
+ * }} PropsType
+ */

--- a/components/profile/ProfileTradesContext.js
+++ b/components/profile/ProfileTradesContext.js
@@ -1,0 +1,12 @@
+import {
+  BaseFuroContext,
+} from '@openreachtech/furo-nuxt'
+
+/**
+ * ProfileTradesContext
+ *
+ * @extends {BaseFuroContext<null, {}, null>}
+ */
+export default class ProfileTradesContext extends BaseFuroContext {
+
+}

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -161,7 +161,7 @@ export default defineComponent({
           :is-loading="context.isLoadingProfileOrders"
         />
 
-        <ProfileTrades />
+        <ProfileTrades :profile-trades="context.profileTrades" />
       </template>
     </AppTabLayout>
 

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -161,7 +161,10 @@ export default defineComponent({
           :is-loading="context.isLoadingProfileOrders"
         />
 
-        <ProfileTrades :profile-trades="context.profileTrades" />
+        <ProfileTrades
+          :profile-trades="context.profileTrades"
+          :is-loading="context.isLoadingProfileTrades"
+        />
       </template>
     </AppTabLayout>
 

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -13,6 +13,7 @@ import ProfileTransferHistory from '~/components/profile/ProfileTransferHistory.
 import ProfileLeagueHistory from '~/components/profile/ProfileLeagueHistory.vue'
 import ProfileFinancialOverview from '~/components/profile/ProfileFinancialOverview.vue'
 import ProfileOrders from '~/components/profile/ProfileOrders.vue'
+import ProfileTrades from '~/components/profile/ProfileTrades.vue'
 
 import {
   useGraphqlClient,
@@ -40,6 +41,7 @@ export default defineComponent({
     ProfileLeagueHistory,
     ProfileFinancialOverview,
     ProfileOrders,
+    ProfileTrades,
   },
 
   setup (
@@ -154,6 +156,8 @@ export default defineComponent({
           :profile-orders="context.profileOrders"
           :is-loading="context.isLoadingProfileOrders"
         />
+
+        <ProfileTrades />
       </template>
     </AppTabLayout>
 

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -67,6 +67,8 @@ export default defineComponent({
     const profileOverviewRef = ref(null)
     /** @type {import('vue').Ref<Array<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileOrder>>} */
     const profileOrdersRef = ref([])
+    /** @type {import('vue').Ref<Array<import('~/app/vue/contexts/profile/ProfileDetailsPageContext').ProfileTradeFill>>} */
+    const profileTradesRef = ref([])
 
     const statusReactive = reactive({
       isLoading: false,
@@ -89,6 +91,7 @@ export default defineComponent({
       },
       profileOverviewRef,
       profileOrdersRef,
+      profileTradesRef,
       errorMessageRef,
       statusReactive,
     }

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -73,6 +73,7 @@ export default defineComponent({
       isFetchingName: false,
       isLoadingProfileOverview: true,
       isLoadingProfileOrders: true,
+      isLoadingProfileTrades: true,
     })
     const mutationStatusReactive = reactive({
       isRenaming: false,


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3738

# How

* Fetch and display trade fills with `GetFillsForParentSubaccount` from dYdX Indexer.
* Table layout on mobile and desktop are different so there are two table elements. They will be hidden with media query accordingly.
* Using the provided pagination from the API will cause the order to be reversed. This pull request will only fetch the latest 100 trade fills.

# Screenshots

![image](https://github.com/user-attachments/assets/e8aeca71-9a8f-4244-a3b8-f1792d1d7891)

![image](https://github.com/user-attachments/assets/380ebbe2-607d-4e17-825f-38dee0b8e972)
