### PR TITLE
Prohibit unauthenticated access to `/hosted-competitions`

### DIFF
--- a/app/vue/contexts/AppWalletAccountContext.js
+++ b/app/vue/contexts/AppWalletAccountContext.js
@@ -135,7 +135,7 @@ export default class AppWalletAccountContext extends BaseFuroContext {
         label: 'My league profile',
       },
       {
-        href: '/hosted-competitions',
+        href: this.generateMyHostedCompetitionsUrl(),
         iconName: 'heroicons-outline:rectangle-stack',
         label: 'My hosted arenas',
       },
@@ -293,6 +293,19 @@ export default class AppWalletAccountContext extends BaseFuroContext {
     }
 
     return `/profiles/${localWalletAddress}`
+  }
+
+  /**
+   * Generate my-hosted-competitions page URL.
+   *
+   * @returns {string}
+   */
+  generateMyHostedCompetitionsUrl () {
+    if (!this.localWalletAddress) {
+      return ''
+    }
+
+    return '/hosted-competitions'
   }
 
   /**

--- a/middleware/000.gateway.global.js
+++ b/middleware/000.gateway.global.js
@@ -1,0 +1,62 @@
+import {
+  defineNuxtRouteMiddleware,
+  navigateTo,
+} from '#imports'
+
+import useWalletStore from '~/stores/wallet'
+
+const AUTHENTICATION_REQUIRED_ROUTES = [
+  '/hosted-competitions',
+]
+
+/**
+ * Remove a forward slash at the end of a string.
+ *
+ * @param {string} string - A string.
+ * @returns {string} The string after being stripped of ending forward slash.
+ */
+function stripEndingForwardSlash (string) {
+  return string.replace(/\/$/u, '')
+}
+
+export default defineNuxtRouteMiddleware(async to => {
+  // Skip this middleware on the server.
+  if (import.meta.server) {
+    return goNextAsIs()
+  }
+
+  const normalizedDestinationPath = stripEndingForwardSlash(to.path)
+
+  if (
+    AUTHENTICATION_REQUIRED_ROUTES.includes(normalizedDestinationPath)
+    && !hasSignedIn()
+  ) {
+    return navigateTo('/competitions')
+  }
+
+  return goNextAsIs()
+})
+
+/**
+ * Check if the user has signed in.
+ *
+ * @returns {boolean}
+ */
+function hasSignedIn () {
+  const walletStore = useWalletStore()
+  const localAddress = walletStore.walletStoreRef
+    .value
+    .localWallet
+    .address
+
+  return Boolean(localAddress)
+}
+
+/**
+ * Go next as is.
+ *
+ * @returns {Promise<void>}
+ */
+async function goNextAsIs () {
+  return Promise.resolve()
+}


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3993

# How

* If the user has not signed in with their local wallet, disable link to `/hosted-competitions`.
* Add a global middleware to ban access to routes that require login.

# Screenshots

![image](https://github.com/user-attachments/assets/cd80b198-4cc5-4c67-85ab-57d4bff9f0b7)
