### PR TITLE
Control active tab in tab layout with route query

### DIFF
--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -4,9 +4,6 @@ import {
 import {
   useHead,
 } from '@unhead/vue'
-import {
-  useRoute,
-} from 'vue-router'
 
 import {
   BaseFuroContext,
@@ -35,6 +32,7 @@ export default class ProfileDetailsContext extends BaseFuroContext {
     componentContext,
 
     route,
+    router,
     graphqlClientHash,
     profileOverviewRef,
     profileOrdersRef,
@@ -48,6 +46,7 @@ export default class ProfileDetailsContext extends BaseFuroContext {
     })
 
     this.route = route
+    this.router = router
     this.graphqlClientHash = graphqlClientHash
     this.profileOverviewRef = profileOverviewRef
     this.profileOrdersRef = profileOrdersRef
@@ -68,6 +67,8 @@ export default class ProfileDetailsContext extends BaseFuroContext {
   static create ({
     props,
     componentContext,
+    route,
+    router,
     graphqlClientHash,
     profileOverviewRef,
     profileOrdersRef,
@@ -75,13 +76,12 @@ export default class ProfileDetailsContext extends BaseFuroContext {
     errorMessageRef,
     statusReactive,
   }) {
-    const route = useRoute()
-
     return /** @type {InstanceType<T>} */ (
       new this({
         props,
         componentContext,
         route,
+        router,
         graphqlClientHash,
         profileOverviewRef,
         profileOrdersRef,
@@ -123,6 +123,49 @@ export default class ProfileDetailsContext extends BaseFuroContext {
         label: 'Trades',
       },
     ]
+  }
+
+  /**
+   * Extract active tab key from route.
+   *
+   * @returns {import('vue-router').LocationQueryValue}
+   */
+  extractActiveTabKeyFromRoute () {
+    const activeTabKey = Array.isArray(this.route.query.tab)
+      ? this.route.query.tab.at(0)
+      : this.route.query.tab
+
+    if (!activeTabKey) {
+      return this.profileTabs
+        .at(0)
+        ?.tabKey
+        ?? null
+    }
+
+    return activeTabKey
+  }
+
+  /**
+   * Change tab.
+   *
+   * @param {{
+   *   fromTab: import('@openreachtech/furo-nuxt/lib/contexts/concretes/FuroTabItemContext').default
+   *   toTab: import('@openreachtech/furo-nuxt/lib/contexts/concretes/FuroTabItemContext').default
+   *   tabKey?: string
+   * }} params - Parameters.
+   * @returns {Promise<void>}
+   */
+  async changeTab ({
+    fromTab,
+    toTab,
+    tabKey = 'tab',
+  }) {
+    await this.router.replace({
+      query: {
+        ...this.route.query,
+        [tabKey]: toTab.tabKey,
+      },
+    })
   }
 
   /**
@@ -670,18 +713,19 @@ export default class ProfileDetailsContext extends BaseFuroContext {
 
 /**
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams & {
+ *   route: ReturnType<import('vue-router').useRoute>
+ *   router: ReturnType<import('vue-router').useRouter>
  *   graphqlClientHash: Record<GraphqlClientHashKeys, GraphqlClient>
  *   profileOverviewRef: import('vue').Ref<ProfileOverview | null>
  *   profileOrdersRef: import('vue').Ref<Array<ProfileOrder>>
  *   profileTradesRef: import('vue').Ref<Array<ProfileTradeFill>>
  *   errorMessageRef: import('vue').Ref<string | null>
  *   statusReactive: StatusReactive
- *   route: ReturnType<typeof useRoute>
  * }} ProfileDetailsContextParams
  */
 
 /**
- * @typedef {Omit<ProfileDetailsContextParams, FactoryOmittedKeys>} ProfileDetailsContextFactoryParams
+ * @typedef {ProfileDetailsContextParams} ProfileDetailsContextFactoryParams
  */
 
 /**
@@ -689,10 +733,6 @@ export default class ProfileDetailsContext extends BaseFuroContext {
  *   | 'addressName'
  *   | 'competitionParticipant'
  * } GraphqlClientHashKeys
- */
-
-/**
- * @typedef {'route'} FactoryOmittedKeys
  */
 
 /**

--- a/components/units/AppTabLayout.vue
+++ b/components/units/AppTabLayout.vue
@@ -5,6 +5,10 @@ import {
 
 import FuroTabLayout from '@openreachtech/furo-nuxt/lib/components/FuroTabLayout.vue'
 
+const EVENT_NAME = {
+  CHANGE_TAB: 'changeTab',
+}
+
 export default defineComponent({
   name: 'AppTabLayout',
 
@@ -13,6 +17,10 @@ export default defineComponent({
   },
 
   inheritAttrs: false,
+
+  emits: [
+    EVENT_NAME.CHANGE_TAB,
+  ],
 
   setup (props) {
     return {
@@ -26,6 +34,7 @@ export default defineComponent({
   <FuroTabLayout
     class="design"
     v-bind="$attrs"
+    @change-tab="$emit('changeTab', $event)"
   >
     <template #contents>
       <slot name="contents" />

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -5,6 +5,11 @@ import {
   ref,
 } from 'vue'
 
+import {
+  useRoute,
+  useRouter,
+} from 'vue-router'
+
 import AppTabLayout from '~/components/units/AppTabLayout.vue'
 import SectionProfileOverview from '~/components/profile/SectionProfileOverview.vue'
 import SectionProfileFinancialMetrics from '~/components/profile/SectionProfileFinancialMetrics.vue'
@@ -48,6 +53,9 @@ export default defineComponent({
     props,
     componentContext
   ) {
+    const route = useRoute()
+    const router = useRouter()
+
     const addressCurrentCompetitionGraphqlClient = useGraphqlClient(AddressCurrentCompetitionQueryGraphqlLauncher)
     const addressNameGraphqlClient = useGraphqlClient(AddressNameQueryGraphqlLauncher)
     const competitionParticipantGraphqlClient = useGraphqlClient(CompetitionParticipantQueryGraphqlLauncher)
@@ -84,6 +92,8 @@ export default defineComponent({
     const args = {
       props,
       componentContext,
+      route,
+      router,
       graphqlClientHash: {
         addressCurrentCompetition: addressCurrentCompetitionGraphqlClient,
         addressName: addressNameGraphqlClient,
@@ -147,7 +157,11 @@ export default defineComponent({
     <AppTabLayout
       class="tabs"
       :tabs="context.profileTabs"
-      :active-tab-key="context.profileTabs[0].tabKey"
+      :active-tab-key="context.extractActiveTabKeyFromRoute()"
+      @change-tab="context.changeTab({
+        fromTab: $event.fromTab,
+        toTab: $event.toTab,
+      })"
     >
       <template #contents>
         <ProfileFinancialOverview :profile-overview="context.profileOverview" />

--- a/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
+++ b/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
@@ -28,6 +28,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseFuroContext
     componentContext,
 
     route,
+    router,
     fetcherHash,
     statusReactive,
   }) {
@@ -37,6 +38,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseFuroContext
     })
 
     this.route = route
+    this.router = router
     this.fetcherHash = fetcherHash
     this.statusReactive = statusReactive
   }
@@ -54,6 +56,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseFuroContext
     props,
     componentContext,
     route,
+    router,
     fetcherHash,
     statusReactive,
   }) {
@@ -62,6 +65,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseFuroContext
         props,
         componentContext,
         route,
+        router,
         fetcherHash,
         statusReactive,
       })
@@ -369,6 +373,49 @@ export default class HostedCompetitionDetailsPageContext extends BaseFuroContext
   }
 
   /**
+   * Extract active tab key from route.
+   *
+   * @returns {import('vue-router').LocationQueryValue}
+   */
+  extractActiveTabKeyFromRoute () {
+    const activeTabKey = Array.isArray(this.route.query.tab)
+      ? this.route.query.tab.at(0)
+      : this.route.query.tab
+
+    if (!activeTabKey) {
+      return this.tabs
+        .at(0)
+        ?.tabKey
+        ?? null
+    }
+
+    return activeTabKey
+  }
+
+  /**
+   * Change tab.
+   *
+   * @param {{
+   *   fromTab: import('@openreachtech/furo-nuxt/lib/contexts/concretes/FuroTabItemContext').default
+   *   toTab: import('@openreachtech/furo-nuxt/lib/contexts/concretes/FuroTabItemContext').default
+   *   tabKey?: string
+   * }} params - Parameters.
+   * @returns {Promise<void>}
+   */
+  async changeTab ({
+    fromTab,
+    toTab,
+    tabKey = 'tab',
+  }) {
+    await this.router.replace({
+      query: {
+        ...this.route.query,
+        [tabKey]: toTab.tabKey,
+      },
+    })
+  }
+
+  /**
    * get: competitionParticipantStatuses
    *
    * @returns {Array<import('~/app/graphql/client/queries/competitionParticipantStatuses/CompetitionParticipantStatusesQueryGraphqlCapsule').Status>}
@@ -384,6 +431,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseFuroContext
 /**
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams & {
  *   route: ReturnType<import('vue-router').useRoute>
+ *   router: ReturnType<import('vue-router').useRouter>
  *   fetcherHash: {
  *     competitionParticipants: import('./CompetitionParticipantsFetcher').default
  *     competitionParticipantStatuses: import('./CompetitionParticipantStatusesFetcher').default

--- a/pages/hosted-competitions/[competitionId]/index.vue
+++ b/pages/hosted-competitions/[competitionId]/index.vue
@@ -10,6 +10,7 @@ import {
 
 import {
   useRoute,
+  useRouter,
 } from 'vue-router'
 
 import {
@@ -58,6 +59,7 @@ export default defineComponent({
     })
 
     const route = useRoute()
+    const router = useRouter()
 
     const statusReactive = reactive({
       isLoadingCompetition: false,
@@ -95,6 +97,7 @@ export default defineComponent({
       props,
       componentContext,
       route,
+      router,
       fetcherHash: {
         competitionParticipants: competitionParticipantsFetcher,
         competitionParticipantStatuses: competitionParticipantStatusesFetcher,
@@ -179,7 +182,11 @@ export default defineComponent({
 
     <AppTabLayout
       :tabs="context.tabs"
-      :active-tab-key="context.tabs[0].tabKey"
+      :active-tab-key="context.extractActiveTabKeyFromRoute()"
+      @change-tab="context.changeTab({
+        fromTab: $event.fromTab,
+        toTab: $event.toTab,
+      })"
     >
       <template #contents>
         <div class="tab content">


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4014

# How

* Extract active tab key from route. If there's none, get the first element from the tabs array (_previous behavior_).
* Update route query when changing tab.
* This will open the same tab after reloading a page, providing better UX.

# Screencasts

https://github.com/user-attachments/assets/3b464381-f5e0-4d33-ba29-eb953b684aac