### PR TITLE
Display competition trading metrics for each arena

### DIFF
--- a/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlCapsule.js
@@ -40,6 +40,17 @@ export default class CompetitionTradingMetricsQueryGraphqlCapsule extends BaseAp
   }
 
   /**
+   * get: limit
+   *
+   * @returns {number | null}
+   */
+  get limit () {
+    return this.pagination
+      ?.limit
+      ?? null
+  }
+
+  /**
    * get: totalCount
    *
    * @returns {number | null}

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -245,6 +245,39 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   }
 
   /**
+   * get: leaderboardFinalOutcomeHeaderEntries
+   *
+   * @returns {Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>}
+   */
+  get metricLeaderboardHeaderEntries () {
+    return [
+      {
+        key: 'name',
+        label: 'Name',
+      },
+      {
+        key: 'address',
+        label: 'Address',
+      },
+      {
+        key: 'makerVolume',
+        label: 'Maker Volume',
+      },
+      {
+        key: 'takerVolume',
+        label: 'Total Volume',
+      },
+      {
+        key: 'totalVolume',
+        label: 'Total Volume',
+        columnOptions: {
+          textAlign: 'end',
+        },
+      },
+    ]
+  }
+
+  /**
    * Setup component context.
    *
    * @template {X extends CompetitionDetailsPageContext ? X : never} T, X
@@ -635,6 +668,27 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
         offset,
       },
     }
+  }
+
+  /**
+   * Generate entries of metric leaderboard.
+   *
+   * @returns {Array<MetricLeaderboardEntry>}
+   */
+  generateMetricLeaderboardEntries () {
+    return this.fetcherHash.competitionTradingMetrics
+      .competitionTradingMetricsCapsule
+      .metrics
+      .map(it => ({
+        name: it.address.name,
+        address: it.address.address,
+        makerFees: it.makerFees,
+        takerFees: it.takerFees,
+        totalFees: it.totalFees,
+        makerVolume: it.makeVolume,
+        takerVolume: it.takerVolume,
+        totalVolume: it.totalVolume,
+      }))
   }
 
   /**
@@ -1115,6 +1169,15 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   }
 
   /**
+   * get: isLoadingCompetitionTradingMetrics
+   *
+   * @returns {boolean}
+   */
+  get isLoadingCompetitionTradingMetrics () {
+    return this.statusReactive.isLoadingCompetitionTradingMetrics
+  }
+
+  /**
    * get: isLoadingParticipant
    *
    * @returns {boolean}
@@ -1519,6 +1582,29 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   }
 
   /**
+   * Generate pagination result for competition trading metrics.
+   *
+   * @returns {PaginationResult}
+   */
+  generateMetricLeaderboardPaginationResult () {
+    const limit = this.fetcherHash
+      .competitionTradingMetrics
+      .competitionTradingMetricsCapsule
+      .limit
+      ?? 0
+    const totalRecords = this.fetcherHash
+      .competitionTradingMetrics
+      .competitionTradingMetricsCapsule
+      .totalCount
+      ?? 0
+
+    return {
+      limit,
+      totalRecords,
+    }
+  }
+
+  /**
    * Extract last leaderboard update timestamp.
    *
    * @returns {string | null} ISO string or `null` if unknown.
@@ -1697,6 +1783,19 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
  *   roi: number
  *   prize: string | null
  * }} NormalizedTopThreeLeaderboardEntry
+ */
+
+/**
+ * @typedef {{
+ *   name: string
+ *   address: string
+ *   makerFees: number
+ *   takerFees: number
+ *   totalFees: number
+ *   makerVolume: number
+ *   takerVolume: number
+ *   totalVolume: number
+ * }} MetricLeaderboardEntry
  */
 
 /**

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -245,7 +245,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   }
 
   /**
-   * get: leaderboardFinalOutcomeHeaderEntries
+   * get: metricLeaderboardHeaderEntries
    *
    * @returns {Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>}
    */

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -265,7 +265,7 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
       },
       {
         key: 'takerVolume',
-        label: 'Total Volume',
+        label: 'Taker Volume',
       },
       {
         key: 'totalVolume',

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -579,12 +579,17 @@ export default class CompetitionDetailsPageContext extends BaseFuroContext {
   /**
    * Extract current page.
    *
+   * @param {{
+   *   pageParamKey?: 'pnlLeaderboardPage' | 'volumeLeaderboardPage'
+   * }} [params] - Parameters.
    * @returns {number} Current page.
    */
-  extractCurrentPage () {
-    const currentPageQuery = Array.isArray(this.route.query.leaderboardPage)
-      ? this.route.query.leaderboardPage[0]
-      : this.route.query.leaderboardPage
+  extractCurrentPage ({
+    pageParamKey = 'pnlLeaderboardPage',
+  } = {}) {
+    const currentPageQuery = Array.isArray(this.route.query[pageParamKey])
+      ? this.route.query[pageParamKey].at(0)
+      : this.route.query[pageParamKey]
     const currentPage = Number(currentPageQuery)
 
     return isNaN(currentPage)

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -29,6 +29,52 @@ const SECTION_HEADING_HASH = {
  */
 export default class SectionLeaderboardContext extends BaseFuroContext {
   /**
+   * Constructor
+   *
+   * @param {SectionLeaderboardContextParams} params - Parameters of this constructor.
+   */
+  constructor ({
+    props,
+    componentContext,
+
+    route,
+    router,
+  }) {
+    super({
+      props,
+      componentContext,
+    })
+
+    this.route = route
+    this.router = router
+  }
+
+  /**
+   * Factory method to create a new instance of this class.
+   *
+   * @template {X extends typeof SectionLeaderboardContext ? X : never} T, X
+   * @override
+   * @param {SectionLeaderboardContextFactoryParams} params - Parameters of this factory method.
+   * @returns {InstanceType<T>} An instance of this class.
+   * @this {T}
+   */
+  static create ({
+    props,
+    componentContext,
+    route,
+    router,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        props,
+        componentContext,
+        route,
+        router,
+      })
+    )
+  }
+
+  /**
    * get: competitionStatusId
    *
    * @returns {number | null}
@@ -98,6 +144,70 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
    */
   get outcomeCsvUrl () {
     return this.props.outcomeCsvUrl
+  }
+
+  /**
+   * get: leaderboardTabs.
+   *
+   * @returns {Array<{
+   *   tabKey: string
+   *   label: string
+   * }>} Tabs.
+   */
+  get leaderboardTabs () {
+    return [
+      {
+        tabKey: 'pnl',
+        label: 'PnL Ranking',
+      },
+      {
+        tabKey: 'metrics',
+        label: 'Volume Ranking',
+      },
+    ]
+  }
+
+  /**
+   * Extract active tab key from route.
+   *
+   * @returns {import('vue-router').LocationQueryValue}
+   */
+  extractActiveTabKeyFromRoute () {
+    const activeTabKey = Array.isArray(this.route.query.leaderboardTab)
+      ? this.route.query.leaderboardTab.at(0)
+      : this.route.query.leaderboardTab
+
+    if (!activeTabKey) {
+      return this.leaderboardTabs
+        .at(0)
+        ?.tabKey
+        ?? null
+    }
+
+    return activeTabKey
+  }
+
+  /**
+   * Change tab.
+   *
+   * @param {{
+   *   fromTab: import('@openreachtech/furo-nuxt/lib/contexts/concretes/FuroTabItemContext').default
+   *   toTab: import('@openreachtech/furo-nuxt/lib/contexts/concretes/FuroTabItemContext').default
+   *   tabKey?: string
+   * }} params - Parameters.
+   * @returns {Promise<void>}
+   */
+  async changeTab ({
+    fromTab,
+    toTab,
+    tabKey = 'tab',
+  }) {
+    await this.router.replace({
+      query: {
+        ...this.route.query,
+        [tabKey]: toTab.tabKey,
+      },
+    })
   }
 
   /**
@@ -418,28 +528,13 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
 
 /**
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<PropsType> & {
- *   route: ReturnType<import('#imports').useRoute>
- *   graphqlClientHash: Record<GraphqlClientHashKeys, GraphqlClient>
- *   statusReactive: StatusReactive
+ *   route: ReturnType<import('vue-router').useRoute>
+ *   router: ReturnType<import('vue-router').useRouter>
  * }} SectionLeaderboardContextParams
  */
 
 /**
  * @typedef {SectionLeaderboardContextParams} SectionLeaderboardContextFactoryParams
- */
-
-/**
- * @typedef {'competitionLeaderboard'} GraphqlClientHashKeys
- */
-
-/**
- * @typedef {ReturnType<import('@openreachtech/furo-nuxt').useGraphqlClient>} GraphqlClient
- */
-
-/**
- * @typedef {{
- *   isLoading: boolean
- * }} StatusReactive
  */
 
 /**

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -560,6 +560,53 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
       canceled: statusId === COMPETITION_PARTICIPANT_STATUS.CANCELED.ID,
     }
   }
+
+  /**
+   * Format currency.
+   *
+   * @param {{
+   *   figure: string | number
+   * }} params - Parameters.
+   * @returns {string}
+   * @todo Please put this method in `BaseAppFuroContext`.
+   */
+  formatCurrency ({
+    figure,
+  }) {
+    if (this.isNullish({
+      value: figure,
+    })) {
+      return '--'
+    }
+
+    const normalizedFigure = typeof figure === 'string'
+      ? parseFloat(figure)
+      : figure
+
+    const formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+
+    return formatter.format(normalizedFigure)
+  }
+
+  /**
+   * Check if a value is null or undefined.
+   *
+   * @param {{
+   *   value: *
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isNullish ({
+    value,
+  }) {
+    return value === null
+      || value === undefined
+  }
 }
 
 /**

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -93,6 +93,15 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   }
 
   /**
+   * get: isLoadingMetricLeaderboard
+   *
+   * @returns {PropsType['isLoadingMetricLeaderboard']}
+   */
+  get isLoadingMetricLeaderboard () {
+    return this.props.isLoadingMetricLeaderboard
+  }
+
+  /**
    * get: leaderboardTableHeaderEntries
    *
    * @returns {PropsType['leaderboardTableHeaderEntries']} Header entries.
@@ -120,12 +129,39 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
   }
 
   /**
+   * get: metricLeaderboardTableHeaderEntries
+   *
+   * @returns {PropsType['metricLeaderboardTableHeaderEntries']}
+   */
+  get metricLeaderboardTableHeaderEntries () {
+    return this.props.metricLeaderboardTableHeaderEntries
+  }
+
+  /**
+   * get: metricLeaderboardTableEntries
+   *
+   * @returns {PropsType['metricLeaderboardTableEntries']}
+   */
+  get metricLeaderboardTableEntries () {
+    return this.props.metricLeaderboardTableEntries
+  }
+
+  /**
    * get: leaderboardPaginationResult
    *
    * @returns {PropsType['leaderboardPaginationResult']} Pagination result.
    */
   get leaderboardPaginationResult () {
     return this.props.leaderboardPaginationResult
+  }
+
+  /**
+   * get: metricLeaderboardPaginationResult
+   *
+   * @returns {PropsType['metricLeaderboardPaginationResult']} Pagination result.
+   */
+  get metricLeaderboardPaginationResult () {
+    return this.props.metricLeaderboardPaginationResult
   }
 
   /**
@@ -548,10 +584,14 @@ export default class SectionLeaderboardContext extends BaseFuroContext {
  * @typedef {{
  *   competitionStatusId: number | null
  *   isLoadingLeaderboard: boolean
+ *   isLoadingMetricLeaderboard: boolean
  *   leaderboardTableHeaderEntries: Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>
  *   leaderboardTableEntries: import('~/app/vue/contexts/CompetitionDetailsPageContext').LeaderboardEntries
+ *   metricLeaderboardTableHeaderEntries: Array<import('~/app/vue/contexts/AppTableContext').HeaderEntry>
+ *   metricLeaderboardTableEntries: Array<import('~/app/vue/contexts/CompetitionDetailsPageContext').MetricLeaderboardEntry>
  *   topThreeLeaderboardEntries: import('~/app/vue/contexts/CompetitionDetailsPageContext').TopThreeLeaderboardEntries
  *   leaderboardPaginationResult: PaginationResult
+ *   metricLeaderboardPaginationResult: PaginationResult
  *   lastLeaderboardUpdateTimestamp: string | null
  *   outcomeCsvUrl: string | null
  * }} PropsType

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -120,258 +120,260 @@ export default defineComponent({
         {{ context.generateSectionHeading() }}
       </h2>
 
-      <div
-        class="unit-champions"
-        :class="context.generateTopRankerClasses()"
-      >
+      <div class="unit-leaderboard pnl">
         <div
-          v-for="(it, index) of context.generateTopThree()"
-          :key="index"
-          class="champion"
+          class="champions"
+          :class="context.generateTopRankerClasses()"
         >
-          <TopRankingCard
-            :rank-details="it"
-            :should-hide-prize="!context.hasFinishedCompetition()"
-            class="card"
+          <div
+            v-for="(it, index) of context.generateTopThree()"
+            :key="index"
+            class="champion"
+          >
+            <TopRankingCard
+              :rank-details="it"
+              :should-hide-prize="!context.hasFinishedCompetition()"
+              class="card"
+            />
+
+            <div class="tail" />
+          </div>
+        </div>
+
+        <span
+          class="note"
+          :class="context.generateLastUpdateNoteClasses()"
+        >
+          {{ context.formatLastLeaderboardUpdateTimestamp() }}
+        </span>
+
+        <AppTable
+          :header-entries="context.leaderboardTableHeaderEntries"
+          :entries="context.leaderboardTableEntries"
+          :is-loading="context.isLoadingLeaderboard"
+          class="table"
+        >
+          <!-- ** Competition participants list ** -->
+          <template #body-participantName="{ value, row }">
+            <NuxtLink
+              class="unit-name participant"
+              :to="context.generateProfileUrl({
+                address: row.participantAddress,
+              })"
+            >
+              {{ value }}
+            </NuxtLink>
+          </template>
+
+          <template #body-participantAddress="{ value }">
+            <span class="unit-address participant">
+              <span>{{ value }}</span>
+
+              <LinkTooltipButton
+                tooltip-message="View on Mintscan"
+                :href="context.generateAddressUrl({
+                  address: value,
+                })"
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            </span>
+          </template>
+
+          <template #body-participantEquity="{ value, row }">
+            <span class="unit-column equity">
+              {{ value }}
+            </span>
+          </template>
+
+          <template #body-participantStatus="{ value }">
+            <span
+              class="unit-status participant"
+              :class="context.generateParticipantStatusClasses({
+                statusId: value.statusId,
+              })"
+            >
+              {{
+                context.normalizeStatusName({
+                  statusName: value.name,
+                })
+              }}
+            </span>
+          </template>
+
+          <!-- ** Ongoing competition leaderboard ** -->
+          <template #body-ongoingRank="{ value }">
+            <span class="unit-rank ongoing">
+              <span class="indicator">#</span> {{ value }}
+            </span>
+          </template>
+
+          <template #body-ongoingName="{ value, row }">
+            <NuxtLink
+              class="unit-name ongoing"
+              :to="context.generateProfileUrl({
+                address: row.ongoingAddress,
+              })"
+            >
+              {{ value }}
+            </NuxtLink>
+          </template>
+
+          <template #body-ongoingAddress="{ value }">
+            <span class="unit-address ongoing">
+              <span>
+                {{
+                  context.shortenAddress({
+                    address: value,
+                  })
+                }}
+              </span>
+
+              <LinkTooltipButton
+                tooltip-message="View on Mintscan"
+                :href="context.generateAddressUrl({
+                  address: value,
+                })"
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            </span>
+          </template>
+
+          <template #body-ongoingBaseline="{ value }">
+            <span class="unit-baseline ongoing">
+              {{
+                context.normalizePerformanceBaseline({
+                  figure: value,
+                })
+              }}
+            </span>
+          </template>
+
+          <template #body-ongoingRoi="{ value }">
+            <span class="unit-roi ongoing">
+              {{
+                context.normalizeRoi({
+                  figure: value,
+                })
+              }}
+            </span>
+          </template>
+
+          <template #body-ongoingPnl="{ value }">
+            <span class="unit-pnl ongoing">
+              {{
+                context.normalizePnl({
+                  figure: value,
+                })
+              }}
+            </span>
+          </template>
+
+          <!-- ** Leaderboard final outcome ** -->
+          <template #body-outcomeRank="{ value }">
+            <span class="unit-rank outcome">
+              <span class="indicator">#</span> {{ value }}
+            </span>
+          </template>
+
+          <template #body-outcomeName="{ value, row }">
+            <NuxtLink
+              class="unit-name outcome"
+              :to="context.generateProfileUrl({
+                address: row.outcomeAddress,
+              })"
+            >
+              {{ value }}
+            </NuxtLink>
+          </template>
+
+          <template #body-outcomeAddress="{ value }">
+            <span class="unit-address outcome">
+              <span>
+                {{
+                  context.shortenAddress({
+                    address: value,
+                  })
+                }}
+              </span>
+
+              <LinkTooltipButton
+                tooltip-message="View on Mintscan"
+                :href="context.generateAddressUrl({
+                  address: value,
+                })"
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            </span>
+          </template>
+
+          <template #body-outcomeBaseline="{ value }">
+            <span class="unit-baseline outcome">
+              {{
+                context.normalizePerformanceBaseline({
+                  figure: value,
+                })
+              }}
+            </span>
+          </template>
+
+          <template #body-outcomeRoi="{ value }">
+            <span class="unit-roi outcome">
+              {{
+                context.normalizeRoi({
+                  figure: value,
+                })
+              }}
+            </span>
+          </template>
+
+          <template #body-outcomePnl="{ value }">
+            <span class="unit-pnl outcome">
+              {{
+                context.normalizePnl({
+                  figure: value,
+                })
+              }}
+            </span>
+          </template>
+
+          <template #body-outcomePrize="{ value }">
+            <span class="unit-prize outcome">
+              ${{ value }}
+            </span>
+          </template>
+        </AppTable>
+
+        <div class="footer">
+          <div class="empty" />
+
+          <AppPagination
+            class="pagination"
+            page-key="leaderboardPage"
+            :pagination="context.leaderboardPaginationResult"
           />
 
-          <div class="tail" />
+          <AppButton
+            variant="neutral"
+            class="button download-result"
+            :class="{
+              hidden: !context.outcomeCsvUrl,
+            }"
+            @click="context.downloadOutcomeCsv()"
+          >
+            <template #startIcon>
+              <Icon
+                name="heroicons:arrow-down-tray"
+                size="1rem"
+              />
+            </template>
+            <template #default>
+              Download full result
+            </template>
+          </AppButton>
         </div>
-      </div>
-
-      <span
-        class="note"
-        :class="context.generateLastUpdateNoteClasses()"
-      >
-        {{ context.formatLastLeaderboardUpdateTimestamp() }}
-      </span>
-
-      <AppTable
-        :header-entries="context.leaderboardTableHeaderEntries"
-        :entries="context.leaderboardTableEntries"
-        :is-loading="context.isLoadingLeaderboard"
-        class="table"
-      >
-        <!-- ** Competition participants list ** -->
-        <template #body-participantName="{ value, row }">
-          <NuxtLink
-            class="unit-name participant"
-            :to="context.generateProfileUrl({
-              address: row.participantAddress,
-            })"
-          >
-            {{ value }}
-          </NuxtLink>
-        </template>
-
-        <template #body-participantAddress="{ value }">
-          <span class="unit-address participant">
-            <span>{{ value }}</span>
-
-            <LinkTooltipButton
-              tooltip-message="View on Mintscan"
-              :href="context.generateAddressUrl({
-                address: value,
-              })"
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          </span>
-        </template>
-
-        <template #body-participantEquity="{ value, row }">
-          <span class="unit-column equity">
-            {{ value }}
-          </span>
-        </template>
-
-        <template #body-participantStatus="{ value }">
-          <span
-            class="unit-status participant"
-            :class="context.generateParticipantStatusClasses({
-              statusId: value.statusId,
-            })"
-          >
-            {{
-              context.normalizeStatusName({
-                statusName: value.name,
-              })
-            }}
-          </span>
-        </template>
-
-        <!-- ** Ongoing competition leaderboard ** -->
-        <template #body-ongoingRank="{ value }">
-          <span class="unit-rank ongoing">
-            <span class="indicator">#</span> {{ value }}
-          </span>
-        </template>
-
-        <template #body-ongoingName="{ value, row }">
-          <NuxtLink
-            class="unit-name ongoing"
-            :to="context.generateProfileUrl({
-              address: row.ongoingAddress,
-            })"
-          >
-            {{ value }}
-          </NuxtLink>
-        </template>
-
-        <template #body-ongoingAddress="{ value }">
-          <span class="unit-address ongoing">
-            <span>
-              {{
-                context.shortenAddress({
-                  address: value,
-                })
-              }}
-            </span>
-
-            <LinkTooltipButton
-              tooltip-message="View on Mintscan"
-              :href="context.generateAddressUrl({
-                address: value,
-              })"
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          </span>
-        </template>
-
-        <template #body-ongoingBaseline="{ value }">
-          <span class="unit-baseline ongoing">
-            {{
-              context.normalizePerformanceBaseline({
-                figure: value,
-              })
-            }}
-          </span>
-        </template>
-
-        <template #body-ongoingRoi="{ value }">
-          <span class="unit-roi ongoing">
-            {{
-              context.normalizeRoi({
-                figure: value,
-              })
-            }}
-          </span>
-        </template>
-
-        <template #body-ongoingPnl="{ value }">
-          <span class="unit-pnl ongoing">
-            {{
-              context.normalizePnl({
-                figure: value,
-              })
-            }}
-          </span>
-        </template>
-
-        <!-- ** Leaderboard final outcome ** -->
-        <template #body-outcomeRank="{ value }">
-          <span class="unit-rank outcome">
-            <span class="indicator">#</span> {{ value }}
-          </span>
-        </template>
-
-        <template #body-outcomeName="{ value, row }">
-          <NuxtLink
-            class="unit-name outcome"
-            :to="context.generateProfileUrl({
-              address: row.outcomeAddress,
-            })"
-          >
-            {{ value }}
-          </NuxtLink>
-        </template>
-
-        <template #body-outcomeAddress="{ value }">
-          <span class="unit-address outcome">
-            <span>
-              {{
-                context.shortenAddress({
-                  address: value,
-                })
-              }}
-            </span>
-
-            <LinkTooltipButton
-              tooltip-message="View on Mintscan"
-              :href="context.generateAddressUrl({
-                address: value,
-              })"
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          </span>
-        </template>
-
-        <template #body-outcomeBaseline="{ value }">
-          <span class="unit-baseline outcome">
-            {{
-              context.normalizePerformanceBaseline({
-                figure: value,
-              })
-            }}
-          </span>
-        </template>
-
-        <template #body-outcomeRoi="{ value }">
-          <span class="unit-roi outcome">
-            {{
-              context.normalizeRoi({
-                figure: value,
-              })
-            }}
-          </span>
-        </template>
-
-        <template #body-outcomePnl="{ value }">
-          <span class="unit-pnl outcome">
-            {{
-              context.normalizePnl({
-                figure: value,
-              })
-            }}
-          </span>
-        </template>
-
-        <template #body-outcomePrize="{ value }">
-          <span class="unit-prize outcome">
-            ${{ value }}
-          </span>
-        </template>
-      </AppTable>
-
-      <div class="unit-footer">
-        <div class="empty" />
-
-        <AppPagination
-          class="pagination"
-          page-key="leaderboardPage"
-          :pagination="context.leaderboardPaginationResult"
-        />
-
-        <AppButton
-          variant="neutral"
-          class="button download-result"
-          :class="{
-            hidden: !context.outcomeCsvUrl,
-          }"
-          @click="context.downloadOutcomeCsv()"
-        >
-          <template #startIcon>
-            <Icon
-              name="heroicons:arrow-down-tray"
-              size="1rem"
-            />
-          </template>
-          <template #default>
-            Download full result
-          </template>
-        </AppButton>
       </div>
     </div>
   </section>
@@ -439,7 +441,7 @@ export default defineComponent({
   display: none;
 }
 
-.unit-section > .inner > .note {
+.unit-leaderboard > .note {
   align-self: end;
   text-align: end;
 
@@ -449,11 +451,11 @@ export default defineComponent({
   color: var(--color-text-tertiary);
 }
 
-.unit-section > .inner > .note.hidden {
+.unit-leaderboard > .note.hidden {
   display: none;
 }
 
-.unit-section > .inner > .table {
+.unit-leaderboard > .table {
   margin-block-start: 1rem;
 
   font-size: var(--font-size-base);
@@ -463,7 +465,7 @@ export default defineComponent({
   color: var(--color-text-secondary);
 }
 
-.unit-footer {
+.unit-leaderboard > .footer {
   display: grid;
   grid-template-columns: 1fr;
   row-gap: 1.75rem;
@@ -476,7 +478,7 @@ export default defineComponent({
   }
 }
 
-.unit-footer > .empty {
+.unit-leaderboard > .footer > .empty {
   display: none;
 
   @media (48rem < width) {
@@ -484,7 +486,7 @@ export default defineComponent({
   }
 }
 
-.unit-footer > .button.download-result {
+.unit-leaderboard > .footer > .button.download-result {
   justify-self: center;
 
   @media (48rem < width) {
@@ -492,12 +494,12 @@ export default defineComponent({
   }
 }
 
-.unit-footer > .button.download-result.hidden {
+.unit-leaderboard > .footer > .button.download-result.hidden {
   display: none;
 }
 
 /***************** Top 3 rankers ****************/
-.unit-champions {
+.unit-leaderboard > .champions {
   margin-block-end: 3rem;
 
   display: flex;
@@ -513,11 +515,11 @@ export default defineComponent({
   }
 }
 
-.unit-champions.hidden {
+.unit-leaderboard > .champions.hidden {
   display: none;
 }
 
-.unit-champions > .champion {
+.unit-leaderboard > .champions > .champion {
   display: flex;
   flex-direction: column;
 
@@ -526,7 +528,7 @@ export default defineComponent({
   }
 }
 
-.unit-champions > .champion:first-of-type {
+.unit-leaderboard > .champions > .champion:first-of-type {
   @media (48rem < width) {
     order: 1;
 
@@ -538,7 +540,7 @@ export default defineComponent({
   }
 }
 
-.unit-champions > .champion:nth-of-type(2) {
+.unit-leaderboard > .champions > .champion:nth-of-type(2) {
   @media (48rem < width) {
     margin-block-start: 15rem;
 
@@ -550,11 +552,11 @@ export default defineComponent({
   }
 }
 
-.unit-champions > .champion > .card {
+.unit-leaderboard > .champions > .champion > .card {
   z-index: calc(var(--value-z-index-layer-content) + 0);
 }
 
-.unit-champions > .champion:last-of-type {
+.unit-leaderboard > .champions > .champion:last-of-type {
   @media (48rem < width) {
     margin-block-start: 15.5rem;
 
@@ -566,7 +568,7 @@ export default defineComponent({
   }
 }
 
-.unit-champions > .champion > .tail {
+.unit-leaderboard > .champions > .champion > .tail {
   display: none;
 
   flex: 1;
@@ -578,7 +580,7 @@ export default defineComponent({
   }
 }
 
-.unit-champions > .champion:first-of-type > .tail {
+.unit-leaderboard > .champions > .champion:first-of-type > .tail {
   clip-path: polygon(
     0.18% 0%,
     100% 0%,
@@ -588,7 +590,7 @@ export default defineComponent({
   background-image: linear-gradient(to bottom, #1F1F30E5, #101018);
 }
 
-.unit-champions > .champion:nth-of-type(2) > .tail {
+.unit-leaderboard > .champions > .champion:nth-of-type(2) > .tail {
   margin-inline-start: -6rem;
 
   clip-path: polygon(
@@ -601,7 +603,7 @@ export default defineComponent({
   background-image: linear-gradient(to bottom, #1F1F30E5, #101018);
 }
 
-.unit-champions > .champion:last-of-type > .tail {
+.unit-leaderboard > .champions > .champion:last-of-type > .tail {
   margin-inline-end: -6.5rem;
 
   clip-path: polygon(

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -374,7 +374,7 @@ export default defineComponent({
 
               <AppPagination
                 class="pagination"
-                page-key="leaderboardPage"
+                page-key="pnlLeaderboardPage"
                 :pagination="context.leaderboardPaginationResult"
               />
 

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -135,6 +135,7 @@ export default defineComponent({
       <AppTabLayout
         :tabs="context.leaderboardTabs"
         :active-tab-key="context.extractActiveTabKeyFromRoute()"
+        class="leaderboard"
         @change-tab="context.changeTab({
           fromTab: $event.fromTab,
           toTab: $event.toTab,
@@ -696,5 +697,64 @@ export default defineComponent({
 
 .unit-status.participant.canceled {
   color: var(--color-text-participant-status-canceled);
+}
+</style>
+
+<style>
+@layer {
+  .furo-layout.tab.leaderboard {
+    --color-background-tab: var(--palette-layer-0);
+    --color-background-tab-active: var(--palette-layer-4);
+
+    --color-text-tab: var(--color-text-placeholder);
+    --color-text-tab-active: var(--color-text-primary);
+
+    --size-tab-min-width: 10rem;
+  }
+
+  .furo-layout.tab.leaderboard > .tabs {
+    gap: 0;
+
+    border: none;
+    border-radius: 0.5rem;
+
+    margin-block-end: 4rem;
+    margin-inline: auto;
+
+    inline-size: fit-content;
+
+    padding-block: 0.2rem;
+    padding-inline: 0.2rem;
+
+    background-color: var(--color-background-tab);
+  }
+
+  .furo-layout.tab.leaderboard > .tabs > .tab {
+    border: none;
+    border-radius: 0.375rem;
+
+    min-width: var(--size-tab-min-width);
+
+    padding-block: 0.5rem;
+    padding-inline: 1rem;
+
+    line-height: 1.3;
+
+    color: var(--color-text-tab);
+
+    transition: color 250ms var(--transition-timing-base),
+      background-color 150ms var(--transition-timing-base);
+  }
+
+  .furo-layout.tab.leaderboard > .tabs > .tab:hover {
+    color: var(--color-text-tab-active);
+  }
+
+  .furo-layout.tab.leaderboard > .tabs > .tab.active {
+    background-color: var(--color-background-tab-active);
+    color: var(--color-text-tab-active);
+
+    pointer-events: none;
+  }
 }
 </style>

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -8,8 +8,14 @@ import {
   Icon,
 } from '#components'
 
+import {
+  useRoute,
+  useRouter,
+} from 'vue-router'
+
 import AppButton from '~/components/units/AppButton.vue'
 import AppTable from '~/components/units/AppTable.vue'
+import AppTabLayout from '~/components/units/AppTabLayout.vue'
 import AppPagination from '~/components/units/AppPagination.vue'
 import TopRankingCard from '~/components/competition-id/TopRankingCard.vue'
 import LinkTooltipButton from '~/components/buttons/LinkTooltipButton.vue'
@@ -22,6 +28,7 @@ export default defineComponent({
     Icon,
     AppButton,
     AppTable,
+    AppTabLayout,
     AppPagination,
     TopRankingCard,
     LinkTooltipButton,
@@ -96,9 +103,14 @@ export default defineComponent({
     props,
     componentContext
   ) {
+    const route = useRoute()
+    const router = useRouter()
+
     const args = {
       props,
       componentContext,
+      route,
+      router,
     }
     const context = SectionLeaderboardContext.create(args)
       .setupComponent()
@@ -120,261 +132,273 @@ export default defineComponent({
         {{ context.generateSectionHeading() }}
       </h2>
 
-      <div class="unit-leaderboard pnl">
-        <div
-          class="champions"
-          :class="context.generateTopRankerClasses()"
-        >
-          <div
-            v-for="(it, index) of context.generateTopThree()"
-            :key="index"
-            class="champion"
-          >
-            <TopRankingCard
-              :rank-details="it"
-              :should-hide-prize="!context.hasFinishedCompetition()"
-              class="card"
-            />
-
-            <div class="tail" />
-          </div>
-        </div>
-
-        <span
-          class="note"
-          :class="context.generateLastUpdateNoteClasses()"
-        >
-          {{ context.formatLastLeaderboardUpdateTimestamp() }}
-        </span>
-
-        <AppTable
-          :header-entries="context.leaderboardTableHeaderEntries"
-          :entries="context.leaderboardTableEntries"
-          :is-loading="context.isLoadingLeaderboard"
-          class="table"
-        >
-          <!-- ** Competition participants list ** -->
-          <template #body-participantName="{ value, row }">
-            <NuxtLink
-              class="unit-name participant"
-              :to="context.generateProfileUrl({
-                address: row.participantAddress,
-              })"
+      <AppTabLayout
+        :tabs="context.leaderboardTabs"
+        :active-tab-key="context.extractActiveTabKeyFromRoute()"
+        @change-tab="context.changeTab({
+          fromTab: $event.fromTab,
+          toTab: $event.toTab,
+          tabKey: 'leaderboardTab',
+        })"
+      >
+        <template #contents>
+          <div class="unit-leaderboard pnl">
+            <div
+              class="champions"
+              :class="context.generateTopRankerClasses()"
             >
-              {{ value }}
-            </NuxtLink>
-          </template>
+              <div
+                v-for="(it, index) of context.generateTopThree()"
+                :key="index"
+                class="champion"
+              >
+                <TopRankingCard
+                  :rank-details="it"
+                  :should-hide-prize="!context.hasFinishedCompetition()"
+                  class="card"
+                />
 
-          <template #body-participantAddress="{ value }">
-            <span class="unit-address participant">
-              <span>{{ value }}</span>
+                <div class="tail" />
+              </div>
+            </div>
 
-              <LinkTooltipButton
-                tooltip-message="View on Mintscan"
-                :href="context.generateAddressUrl({
-                  address: value,
-                })"
-                target="_blank"
-                rel="noopener noreferrer"
-              />
-            </span>
-          </template>
-
-          <template #body-participantEquity="{ value, row }">
-            <span class="unit-column equity">
-              {{ value }}
-            </span>
-          </template>
-
-          <template #body-participantStatus="{ value }">
             <span
-              class="unit-status participant"
-              :class="context.generateParticipantStatusClasses({
-                statusId: value.statusId,
-              })"
+              class="note"
+              :class="context.generateLastUpdateNoteClasses()"
             >
-              {{
-                context.normalizeStatusName({
-                  statusName: value.name,
-                })
-              }}
+              {{ context.formatLastLeaderboardUpdateTimestamp() }}
             </span>
-          </template>
 
-          <!-- ** Ongoing competition leaderboard ** -->
-          <template #body-ongoingRank="{ value }">
-            <span class="unit-rank ongoing">
-              <span class="indicator">#</span> {{ value }}
-            </span>
-          </template>
-
-          <template #body-ongoingName="{ value, row }">
-            <NuxtLink
-              class="unit-name ongoing"
-              :to="context.generateProfileUrl({
-                address: row.ongoingAddress,
-              })"
+            <AppTable
+              :header-entries="context.leaderboardTableHeaderEntries"
+              :entries="context.leaderboardTableEntries"
+              :is-loading="context.isLoadingLeaderboard"
+              class="table"
             >
-              {{ value }}
-            </NuxtLink>
-          </template>
+              <!-- ** Competition participants list ** -->
+              <template #body-participantName="{ value, row }">
+                <NuxtLink
+                  class="unit-name participant"
+                  :to="context.generateProfileUrl({
+                    address: row.participantAddress,
+                  })"
+                >
+                  {{ value }}
+                </NuxtLink>
+              </template>
 
-          <template #body-ongoingAddress="{ value }">
-            <span class="unit-address ongoing">
-              <span>
-                {{
-                  context.shortenAddress({
-                    address: value,
-                  })
-                }}
-              </span>
+              <template #body-participantAddress="{ value }">
+                <span class="unit-address participant">
+                  <span>{{ value }}</span>
 
-              <LinkTooltipButton
-                tooltip-message="View on Mintscan"
-                :href="context.generateAddressUrl({
-                  address: value,
-                })"
-                target="_blank"
-                rel="noopener noreferrer"
+                  <LinkTooltipButton
+                    tooltip-message="View on Mintscan"
+                    :href="context.generateAddressUrl({
+                      address: value,
+                    })"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                </span>
+              </template>
+
+              <template #body-participantEquity="{ value, row }">
+                <span class="unit-column equity">
+                  {{ value }}
+                </span>
+              </template>
+
+              <template #body-participantStatus="{ value }">
+                <span
+                  class="unit-status participant"
+                  :class="context.generateParticipantStatusClasses({
+                    statusId: value.statusId,
+                  })"
+                >
+                  {{
+                    context.normalizeStatusName({
+                      statusName: value.name,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <!-- ** Ongoing competition leaderboard ** -->
+              <template #body-ongoingRank="{ value }">
+                <span class="unit-rank ongoing">
+                  <span class="indicator">#</span> {{ value }}
+                </span>
+              </template>
+
+              <template #body-ongoingName="{ value, row }">
+                <NuxtLink
+                  class="unit-name ongoing"
+                  :to="context.generateProfileUrl({
+                    address: row.ongoingAddress,
+                  })"
+                >
+                  {{ value }}
+                </NuxtLink>
+              </template>
+
+              <template #body-ongoingAddress="{ value }">
+                <span class="unit-address ongoing">
+                  <span>
+                    {{
+                      context.shortenAddress({
+                        address: value,
+                      })
+                    }}
+                  </span>
+
+                  <LinkTooltipButton
+                    tooltip-message="View on Mintscan"
+                    :href="context.generateAddressUrl({
+                      address: value,
+                    })"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                </span>
+              </template>
+
+              <template #body-ongoingBaseline="{ value }">
+                <span class="unit-baseline ongoing">
+                  {{
+                    context.normalizePerformanceBaseline({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <template #body-ongoingRoi="{ value }">
+                <span class="unit-roi ongoing">
+                  {{
+                    context.normalizeRoi({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <template #body-ongoingPnl="{ value }">
+                <span class="unit-pnl ongoing">
+                  {{
+                    context.normalizePnl({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <!-- ** Leaderboard final outcome ** -->
+              <template #body-outcomeRank="{ value }">
+                <span class="unit-rank outcome">
+                  <span class="indicator">#</span> {{ value }}
+                </span>
+              </template>
+
+              <template #body-outcomeName="{ value, row }">
+                <NuxtLink
+                  class="unit-name outcome"
+                  :to="context.generateProfileUrl({
+                    address: row.outcomeAddress,
+                  })"
+                >
+                  {{ value }}
+                </NuxtLink>
+              </template>
+
+              <template #body-outcomeAddress="{ value }">
+                <span class="unit-address outcome">
+                  <span>
+                    {{
+                      context.shortenAddress({
+                        address: value,
+                      })
+                    }}
+                  </span>
+
+                  <LinkTooltipButton
+                    tooltip-message="View on Mintscan"
+                    :href="context.generateAddressUrl({
+                      address: value,
+                    })"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                </span>
+              </template>
+
+              <template #body-outcomeBaseline="{ value }">
+                <span class="unit-baseline outcome">
+                  {{
+                    context.normalizePerformanceBaseline({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <template #body-outcomeRoi="{ value }">
+                <span class="unit-roi outcome">
+                  {{
+                    context.normalizeRoi({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <template #body-outcomePnl="{ value }">
+                <span class="unit-pnl outcome">
+                  {{
+                    context.normalizePnl({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <template #body-outcomePrize="{ value }">
+                <span class="unit-prize outcome">
+                  ${{ value }}
+                </span>
+              </template>
+            </AppTable>
+
+            <div class="footer">
+              <div class="empty" />
+
+              <AppPagination
+                class="pagination"
+                page-key="leaderboardPage"
+                :pagination="context.leaderboardPaginationResult"
               />
-            </span>
-          </template>
 
-          <template #body-ongoingBaseline="{ value }">
-            <span class="unit-baseline ongoing">
-              {{
-                context.normalizePerformanceBaseline({
-                  figure: value,
-                })
-              }}
-            </span>
-          </template>
-
-          <template #body-ongoingRoi="{ value }">
-            <span class="unit-roi ongoing">
-              {{
-                context.normalizeRoi({
-                  figure: value,
-                })
-              }}
-            </span>
-          </template>
-
-          <template #body-ongoingPnl="{ value }">
-            <span class="unit-pnl ongoing">
-              {{
-                context.normalizePnl({
-                  figure: value,
-                })
-              }}
-            </span>
-          </template>
-
-          <!-- ** Leaderboard final outcome ** -->
-          <template #body-outcomeRank="{ value }">
-            <span class="unit-rank outcome">
-              <span class="indicator">#</span> {{ value }}
-            </span>
-          </template>
-
-          <template #body-outcomeName="{ value, row }">
-            <NuxtLink
-              class="unit-name outcome"
-              :to="context.generateProfileUrl({
-                address: row.outcomeAddress,
-              })"
-            >
-              {{ value }}
-            </NuxtLink>
-          </template>
-
-          <template #body-outcomeAddress="{ value }">
-            <span class="unit-address outcome">
-              <span>
-                {{
-                  context.shortenAddress({
-                    address: value,
-                  })
-                }}
-              </span>
-
-              <LinkTooltipButton
-                tooltip-message="View on Mintscan"
-                :href="context.generateAddressUrl({
-                  address: value,
-                })"
-                target="_blank"
-                rel="noopener noreferrer"
-              />
-            </span>
-          </template>
-
-          <template #body-outcomeBaseline="{ value }">
-            <span class="unit-baseline outcome">
-              {{
-                context.normalizePerformanceBaseline({
-                  figure: value,
-                })
-              }}
-            </span>
-          </template>
-
-          <template #body-outcomeRoi="{ value }">
-            <span class="unit-roi outcome">
-              {{
-                context.normalizeRoi({
-                  figure: value,
-                })
-              }}
-            </span>
-          </template>
-
-          <template #body-outcomePnl="{ value }">
-            <span class="unit-pnl outcome">
-              {{
-                context.normalizePnl({
-                  figure: value,
-                })
-              }}
-            </span>
-          </template>
-
-          <template #body-outcomePrize="{ value }">
-            <span class="unit-prize outcome">
-              ${{ value }}
-            </span>
-          </template>
-        </AppTable>
-
-        <div class="footer">
-          <div class="empty" />
-
-          <AppPagination
-            class="pagination"
-            page-key="leaderboardPage"
-            :pagination="context.leaderboardPaginationResult"
-          />
-
-          <AppButton
-            variant="neutral"
-            class="button download-result"
-            :class="{
-              hidden: !context.outcomeCsvUrl,
-            }"
-            @click="context.downloadOutcomeCsv()"
-          >
-            <template #startIcon>
-              <Icon
-                name="heroicons:arrow-down-tray"
-                size="1rem"
-              />
-            </template>
-            <template #default>
-              Download full result
-            </template>
-          </AppButton>
-        </div>
-      </div>
+              <AppButton
+                variant="neutral"
+                class="button download-result"
+                :class="{
+                  hidden: !context.outcomeCsvUrl,
+                }"
+                @click="context.downloadOutcomeCsv()"
+              >
+                <template #startIcon>
+                  <Icon
+                    name="heroicons:arrow-down-tray"
+                    size="1rem"
+                  />
+                </template>
+                <template #default>
+                  Download full result
+                </template>
+              </AppButton>
+            </div>
+          </div>
+        </template>
+      </AppTabLayout>
     </div>
   </section>
 </template>

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -429,6 +429,103 @@ export default defineComponent({
               </AppButton>
             </div>
           </div>
+
+          <div class="unit-leaderboard volume">
+            <AppTable
+              class="table"
+              :header-entries="context.metricLeaderboardTableHeaderEntries"
+              :entries="context.metricLeaderboardTableEntries"
+              :is-loading="context.isLoadingMetricLeaderboard"
+              min-width="50rem"
+            >
+              <template
+                #body-name="{
+                  value,
+                  row,
+                }"
+              >
+                <NuxtLink
+                  :to="context.generateProfileUrl({
+                    address: row.address,
+                  })"
+                  class="unit-column metric name"
+                >
+                  {{ value }}
+                </NuxtLink>
+              </template>
+
+              <template
+                #body-address="{
+                  value,
+                }"
+              >
+                <span class="unit-column metric address">
+                  <span>
+                    {{
+                      context.shortenAddress({
+                        address: value,
+                      })
+                    }}
+                  </span>
+                  <LinkTooltipButton
+                    tooltip-message="View on Mintscan"
+                    :href="context.generateAddressUrl({
+                      address: value,
+                    })"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                </span>
+              </template>
+
+              <template
+                #body-makerVolume="{
+                  value,
+                }"
+              >
+                <span class="unit-column metric makerVolume">
+                  {{
+                    context.formatCurrency({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <template
+                #body-takerVolume="{
+                  value,
+                }"
+              >
+                <span class="unit-column metric takerVolume">
+                  {{
+                    context.formatCurrency({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+
+              <template
+                #body-totalVolume="{
+                  value,
+                }"
+              >
+                <span class="unit-column metric totalVolume">
+                  {{
+                    context.formatCurrency({
+                      figure: value,
+                    })
+                  }}
+                </span>
+              </template>
+            </AppTable>
+
+            <AppPagination
+              page-key="volumeLeaderboardPage"
+              :pagination="context.metricLeaderboardPaginationResult"
+            />
+          </div>
         </template>
       </AppTabLayout>
     </div>
@@ -526,8 +623,6 @@ export default defineComponent({
   grid-template-columns: 1fr;
   row-gap: 1.75rem;
   column-gap: 1rem;
-
-  margin-block-start: 1.25rem;
 
   @media (48rem < width) {
     grid-template-columns: 1fr auto 1fr;
@@ -672,6 +767,10 @@ export default defineComponent({
   background-image: linear-gradient(to bottom, #1F1F30E5, #101018);
 }
 
+.unit-leaderboard > .table {
+  margin-block-end: 1.25rem;
+}
+
 /***************** Non-podium rankers ****************/
 .unit-rank:where(.ongoing, .outcome) {
   white-space: nowrap;
@@ -728,6 +827,21 @@ export default defineComponent({
 
 .unit-status.participant.canceled {
   color: var(--color-text-participant-status-canceled);
+}
+
+/***************** Trading volume leaderboard ****************/
+.unit-column.metric.name {
+  color: inherit;
+}
+
+.unit-column.metric.name:hover {
+  text-decoration: underline;
+}
+
+.unit-column.metric.address {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 </style>
 

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -46,6 +46,10 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+    isLoadingMetricLeaderboard: {
+      type: Boolean,
+      required: true,
+    },
     leaderboardTableHeaderEntries: {
       /**
        * @type {import('vue').PropType<
@@ -73,10 +77,37 @@ export default defineComponent({
       type: Array,
       required: true,
     },
+    metricLeaderboardTableHeaderEntries: {
+      /**
+       * @type {import('vue').PropType<
+       *   import('~/app/vue/contexts/competition/SectionLeaderboardContext').PropsType['metricLeaderboardTableHeaderEntries']
+       * >}
+       */
+      type: Array,
+      required: true,
+    },
+    metricLeaderboardTableEntries: {
+      /**
+       * @type {import('vue').PropType<
+       *   import('~/app/vue/contexts/competition/SectionLeaderboardContext').PropsType['metricLeaderboardTableEntries']
+       * >}
+       */
+      type: Array,
+      required: true,
+    },
     leaderboardPaginationResult: {
       /**
        * @type {import('vue').PropType<
        *   import('~/app/vue/contexts/competition/SectionLeaderboardContext').PropsType['leaderboardPaginationResult']
+       * >}
+       */
+      type: Object,
+      required: true,
+    },
+    metricLeaderboardPaginationResult: {
+      /**
+       * @type {import('vue').PropType<
+       *   import('~/app/vue/contexts/competition/SectionLeaderboardContext').PropsType['metricLeaderboardPaginationResult']
        * >}
        */
       type: Object,

--- a/pages/(competitions)/competitions/[competitionId]/CompetitionTradingMetricsFetcher.js
+++ b/pages/(competitions)/competitions/[competitionId]/CompetitionTradingMetricsFetcher.js
@@ -1,0 +1,123 @@
+export default class CompetitionTradingMetricsFetcher {
+  /**
+   * Constructor.
+   *
+   * @param {CompetitionTradingMetricsFetcherParams} params - Parameters.
+   */
+  constructor ({
+    graphqlClientHash,
+    statusReactive,
+  }) {
+    this.graphqlClientHash = graphqlClientHash
+    this.statusReactive = statusReactive
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof CompetitionTradingMetricsFetcher ? X : never} T, X
+   * @param {CompetitionTradingMetricsFetcherFactoryParams} params - Parameters.
+   * @returns {InstanceType<T>}
+   * @this {T}
+   */
+  static create ({
+    graphqlClientHash,
+    statusReactive,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        graphqlClientHash,
+        statusReactive,
+      })
+    )
+  }
+
+  /**
+   * get: competitionTradingMetricsCapsule
+   *
+   * @returns {import('~/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlCapsule').default}
+   */
+  get competitionTradingMetricsCapsule () {
+    return this.graphqlClientHash
+      .competitionTradingMetrics
+      .capsuleRef
+      .value
+  }
+
+  /**
+   * Fetch `competitionTradingMetrics` on event.
+   *
+   * @param {{
+   *   valueHash: import('~/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlPayload').CompetitionTradingMetricsQueryRequestVariables['input']
+   * }} params - Parameters.
+   * @returns {Promise<void>}
+   */
+  async fetchCompetitionTradingMetricsOnEvent ({
+    valueHash,
+  }) {
+    await this.graphqlClientHash
+      .competitionTradingMetrics
+      .invokeRequestOnEvent({
+        variables: {
+          input: valueHash,
+        },
+        hooks: this.competitionTradingMetricsLauncherHooks,
+      })
+  }
+
+  /**
+   * Fetch `competitionTradingMetrics` on mounted.
+   *
+   * @param {{
+   *   valueHash: import('~/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlPayload').CompetitionTradingMetricsQueryRequestVariables['input']
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  fetchCompetitionTradingMetricsOnMounted ({
+    valueHash,
+  }) {
+    this.graphqlClientHash
+      .competitionTradingMetrics
+      .invokeRequestOnMounted({
+        variables: {
+          input: valueHash,
+        },
+        hooks: this.competitionTradingMetricsLauncherHooks,
+      })
+  }
+
+  /**
+   * get: competitionTradingMetricsLauncherHooks
+   *
+   * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
+   */
+  get competitionTradingMetricsLauncherHooks () {
+    return {
+      beforeRequest: async payload => {
+        this.statusReactive.isLoadingCompetitionTradingMetrics = true
+
+        return false
+      },
+      afterRequest: async capsule => {
+        this.statusReactive.isLoadingCompetitionTradingMetrics = false
+      },
+    }
+  }
+}
+
+/**
+ * @typedef {{
+ *   graphqlClientHash: {
+ *     competitionTradingMetrics: GraphqlClient
+ *   }
+ *   statusReactive: import('~/app/vue/contexts/CompetitionDetailsPageContext').StatusReactive
+ * }} CompetitionTradingMetricsFetcherParams
+ */
+
+/**
+ * @typedef {CompetitionTradingMetricsFetcherParams} CompetitionTradingMetricsFetcherFactoryParams
+ */
+
+/**
+ * @typedef {ReturnType<import('@openreachtech/furo-nuxt').useGraphqlClient>} GraphqlClient
+ */

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -21,9 +21,12 @@ import CompetitionLeaderboardQueryGraphqlLauncher from '~/app/graphql/client/que
 import CompetitionFinalOutcomeQueryGraphqlLauncher from '~/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlLauncher'
 import CompetitionParticipantsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlLauncher'
 import CompetitionEnrolledParticipantsNumberQueryGraphqlLauncher from '~/app/graphql/client/queries/competitionEnrolledParticipantsNumber/CompetitionEnrolledParticipantsNumberQueryGraphqlLauncher'
+import CompetitionTradingMetricsQueryGraphqlLauncher from '~/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlLauncher'
 import UnregisterFromCompetitionMutationGraphqlLauncher from '~/app/graphql/client/mutations/unregisterFromCompetition/UnregisterFromCompetitionMutationGraphqlLauncher'
 
 import JoinCompetitionFormElementClerk from '~/app/domClerk/JoinCompetitionFormElementClerk'
+
+import CompetitionTradingMetricsFetcher from '~/pages/(competitions)/competitions/[competitionId]/CompetitionTradingMetricsFetcher'
 
 import {
   useRoute,
@@ -78,6 +81,7 @@ export default defineComponent({
     const competitionFinalOutcomeGraphqlClient = useGraphqlClient(CompetitionFinalOutcomeQueryGraphqlLauncher)
     const competitionParticipantsGraphqlClient = useGraphqlClient(CompetitionParticipantsQueryGraphqlLauncher)
     const competitionEnrolledParticipantsNumberGraphqlClient = useGraphqlClient(CompetitionEnrolledParticipantsNumberQueryGraphqlLauncher)
+    const competitionTradingMetricsGraphqlClient = useGraphqlClient(CompetitionTradingMetricsQueryGraphqlLauncher)
     const unregisterFromCompetitionGraphqlClient = useGraphqlClient(UnregisterFromCompetitionMutationGraphqlLauncher)
 
     const joinCompetitionFormClerk = useAppFormClerk({
@@ -91,6 +95,7 @@ export default defineComponent({
     const statusReactive = reactive({
       isLoading: false,
       isLoadingLeaderboard: true,
+      isLoadingCompetitionTradingMetrics: true,
       isLoadingTopThree: true,
       isLoadingParticipant: true,
       isLoadingEnrolledParticipantsNumber: true,
@@ -98,6 +103,13 @@ export default defineComponent({
     })
     const mutationStatusReactive = reactive({
       isJoining: false,
+    })
+
+    const competitionTradingMetricsFetcher = CompetitionTradingMetricsFetcher.create({
+      graphqlClientHash: {
+        competitionTradingMetrics: competitionTradingMetricsGraphqlClient,
+      },
+      statusReactive,
     })
 
     const args = {
@@ -118,6 +130,9 @@ export default defineComponent({
         competitionParticipants: competitionParticipantsGraphqlClient,
         competitionEnrolledParticipantsNumber: competitionEnrolledParticipantsNumberGraphqlClient,
         unregisterFromCompetition: unregisterFromCompetitionGraphqlClient,
+      },
+      fetcherHash: {
+        competitionTradingMetrics: competitionTradingMetricsFetcher,
       },
       statusReactive,
     }

--- a/pages/(competitions)/competitions/[competitionId]/index.vue
+++ b/pages/(competitions)/competitions/[competitionId]/index.vue
@@ -204,8 +204,12 @@ export default defineComponent({
       :top-three-leaderboard-entries="context.topThreeLeaderboardEntries"
       :leaderboard-table-entries="context.leaderboardEntries"
       :leaderboard-table-header-entries="context.generateLeaderboardHeaderEntries()"
+      :metric-leaderboard-table-header-entries="context.metricLeaderboardHeaderEntries"
+      :metric-leaderboard-table-entries="context.generateMetricLeaderboardEntries()"
       :is-loading-leaderboard="context.isLoadingLeaderboard"
+      :is-loading-metric-leaderboard="context.isLoadingCompetitionTradingMetrics"
       :leaderboard-pagination-result="context.generateLeaderboardPaginationResult()"
+      :metric-leaderboard-pagination-result="context.generateMetricLeaderboardPaginationResult()"
       :last-leaderboard-update-timestamp="context.extractLastLeaderboardUpdateTimestamp()"
       :outcome-csv-url="context.competitionOutcomeCsvUrl"
     />


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/3720

# How

* Fetch trading metrics with `competitionTradingMetrics` query and display them as table.
* Add tab buttons in leaderboard section to switch between pnl and trading volume rankings.

# Screenshots

![image](https://github.com/user-attachments/assets/8bfc7011-035b-4978-8951-56a357c94039)

