### PR TITLE
Add missing ticker (_market_) to trades table in mobile view

### DIFF
--- a/components/profile/ProfileTrades.vue
+++ b/components/profile/ProfileTrades.vue
@@ -208,8 +208,14 @@ export default defineComponent({
           <span class="type">
             {{ row.type.toLowerCase() }}
           </span>
-          <span class="size">
-            {{ row.size }}
+
+          <span class="fill">
+            <span class="size">
+              {{ row.size }}
+            </span>
+            <span class="market">
+              {{ row.market }}
+            </span>
           </span>
         </span>
       </template>
@@ -338,10 +344,25 @@ export default defineComponent({
   text-transform: capitalize;
 }
 
-.unit-column.mobile.type-size > .size {
+.unit-column.mobile.type-size > .fill > .size {
   font-size: var(--font-size-small);
 
   color: var(--color-text-tertiary);
+}
+
+.unit-column.mobile.type-size > .fill > .market {
+  --color-background-market: var(--palette-layer-6);
+
+  margin-inline-start: 0.25rem;
+
+  border-radius: 0.25rem;
+
+  padding-block: 0.125rem;
+  padding-inline: 0.25rem;
+
+  font-size: var(--font-size-mini);
+
+  background-color: var(--color-background-market);
 }
 
 .unit-column.mobile.price-fee {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4161

# How

* Add missing ticker (_market_) to trades table in mobile view

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/af819881-6d86-4de2-a75e-9ad9c05d91e5)

## After

![image](https://github.com/user-attachments/assets/d69c5fbd-1b52-4350-ad94-c644c8ef03e9)
 
