### PR TITLE
Fix incorrect relative time in profile page

### DIFF
--- a/components/profile/ProfileOrdersContext.js
+++ b/components/profile/ProfileOrdersContext.js
@@ -1,5 +1,7 @@
 import BaseAppContext from '~/app/vue/contexts/BaseAppContext'
 
+import RelativeTimeFormatter from '~/app/RelativeTimeFormatter'
+
 const ORDER_SIDE = {
   BUY: 'BUY',
   SELL: 'SELL',
@@ -290,45 +292,16 @@ export default class ProfileOrdersContext extends BaseAppContext {
       return '--'
     }
 
-    const date = new Date(timestamp)
-    const remainingTime = date.getTime() - Date.now()
-    const remainingDayCount = Math.floor(remainingTime / (1000 * 60 * 60 * 24))
-
-    const formatter = new Intl.RelativeTimeFormat('en-US', {
-      numeric: 'always',
-      style: 'narrow',
-    })
-    const unit = this.generateRelativeTimeUnit({
-      remainingDayCount,
+    const relativeTimeFormatter = RelativeTimeFormatter.create({
+      targetTime: timestamp,
+      formatOptions: {
+        style: 'narrow',
+        numeric: 'auto',
+      },
     })
 
-    return formatter.format(
-      remainingDayCount,
-      unit
-    )
+    return relativeTimeFormatter.formatRelativeTime()
       .replace('in ', '')
-  }
-
-  /**
-   * Generate relative time unit.
-   *
-   * @param {{
-   *   remainingDayCount: number
-   * }} params - Parameters.
-   * @returns {Intl.RelativeTimeFormatUnit}
-   */
-  generateRelativeTimeUnit ({
-    remainingDayCount,
-  }) {
-    if (remainingDayCount >= 30) {
-      return 'month'
-    }
-
-    if (remainingDayCount >= 7) {
-      return 'week'
-    }
-
-    return 'day'
   }
 
   /**

--- a/components/profile/ProfileTradesContext.js
+++ b/components/profile/ProfileTradesContext.js
@@ -1,5 +1,7 @@
 import BaseAppContext from '~/app/vue/contexts/BaseAppContext'
 
+import RelativeTimeFormatter from '~/app/RelativeTimeFormatter'
+
 const ORDER_SIDE = {
   BUY: 'BUY',
   SELL: 'SELL',
@@ -217,44 +219,15 @@ export default class ProfileTradesContext extends BaseAppContext {
       return '--'
     }
 
-    const date = new Date(timestamp)
-    const remainingTime = date.getTime() - Date.now()
-    const remainingDayCount = Math.floor(remainingTime / (1000 * 60 * 60 * 24))
-
-    const formatter = new Intl.RelativeTimeFormat('en-US', {
-      numeric: 'always',
-      style: 'narrow',
-    })
-    const unit = this.generateRelativeTimeUnit({
-      remainingDayCount,
+    const relativeTimeFormatter = RelativeTimeFormatter.create({
+      targetTime: timestamp,
+      formatOptions: {
+        style: 'narrow',
+        numeric: 'auto',
+      },
     })
 
-    return formatter.format(
-      remainingDayCount,
-      unit
-    )
-  }
-
-  /**
-   * Generate relative time unit.
-   *
-   * @param {{
-   *   remainingDayCount: number
-   * }} params - Parameters.
-   * @returns {Intl.RelativeTimeFormatUnit}
-   */
-  generateRelativeTimeUnit ({
-    remainingDayCount,
-  }) {
-    if (remainingDayCount >= 30) {
-      return 'month'
-    }
-
-    if (remainingDayCount >= 7) {
-      return 'week'
-    }
-
-    return 'day'
+    return relativeTimeFormatter.formatRelativeTime()
   }
 
   /**


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4190

# How

* Previous calculation of relative time in profile page was incorrect.
* This pull request uses `RelativeTimeFormatter` to display the proper relative time.

# Screenshots

<details>
<summary>Show screenshots</summary>

![image](https://github.com/user-attachments/assets/c0879a7d-3390-43d0-9f67-440ffcc23cde)

![image](https://github.com/user-attachments/assets/297cbab5-c36f-49e8-8f39-3bd84f704d2f)

</details>
