### PR TITLE
⚒️ Make `#formatNumber()` a method of `BaseAppContext` for reusability

### DIFF
--- a/app/vue/contexts/AppLeagueCardContext.js
+++ b/app/vue/contexts/AppLeagueCardContext.js
@@ -200,36 +200,14 @@ export default class AppLeagueCardContext extends BaseAppContext {
    * @returns {string} Normalized minimum deposit.
    */
   normalizeMinimumDeposit () {
-    const normalizedFigure = this.normalizeNumber({
+    const normalizedFigure = this.formatNumber({
       value: this.minimumDeposit,
+      options: {
+        trailingZeroDisplay: 'stripIfInteger',
+      },
     })
 
     return `${normalizedFigure} USDC`
-  }
-
-  /**
-   * Normalize number.
-   *
-   * @param {{
-   *   value: number | null
-   *   options?: Intl.NumberFormatOptions
-   * }} params - Parameters.
-   * @returns {string} Normalized number string.
-   */
-  normalizeNumber ({
-    value,
-    options = {},
-  }) {
-    if (!value) {
-      return '--'
-    }
-
-    const formatter = new Intl.NumberFormat('en-US', {
-      trailingZeroDisplay: 'stripIfInteger',
-      ...options,
-    })
-
-    return formatter.format(value)
   }
 
   /**
@@ -245,11 +223,12 @@ export default class AppLeagueCardContext extends BaseAppContext {
     value,
     options = {},
   }) {
-    return this.normalizeNumber({
+    return this.formatNumber({
       value,
       options: {
         style: 'currency',
         currency: 'USD',
+        trailingZeroDisplay: 'stripIfInteger',
         ...options,
       },
     })

--- a/app/vue/contexts/BaseAppContext.js
+++ b/app/vue/contexts/BaseAppContext.js
@@ -11,5 +11,40 @@ import {
  * @extends {BaseFuroContext<A, P, EE>}
  */
 export default class BaseAppContext extends BaseFuroContext {
+  /**
+   * Format number.
+   *
+   * @param {{
+   *   value: string | number | null
+   *   fallbackValue?: string
+   *   locale?: string
+   *   options?: Intl.NumberFormatOptions
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  formatNumber ({
+    value,
+    fallbackValue = '--',
+    locale = 'en-US',
+    options = {},
+  }) {
+    if (value === null) {
+      return fallbackValue
+    }
 
+    const parsedValue = typeof value === 'string'
+      ? parseFloat(value)
+      : value
+
+    if (isNaN(parsedValue)) {
+      return fallbackValue
+    }
+
+    const formatter = new Intl.NumberFormat(
+      locale,
+      options
+    )
+
+    return formatter.format(parsedValue)
+  }
 }

--- a/app/vue/contexts/LeagueHeroSectionContext.js
+++ b/app/vue/contexts/LeagueHeroSectionContext.js
@@ -159,44 +159,6 @@ export default class LeagueHeroSectionContext extends BaseAppContext {
 
     await this.router.push('/competitions/add')
   }
-
-  /**
-   * Format number.
-   *
-   * @param {{
-   *   value: string | number | null
-   *   options?: Intl.NumberFormatOptions
-   *   fallbackValue?: string
-   * }} params - Parameters.
-   * @returns {string} Formatted number string.
-   */
-  formatNumber ({
-    value,
-    options = {},
-    fallbackValue = '--',
-  }) {
-    if (
-      value === null
-      || value === undefined
-    ) {
-      return fallbackValue
-    }
-
-    const parsedValue = typeof value === 'string'
-      ? parseFloat(value)
-      : value
-
-    if (isNaN(parsedValue)) {
-      return fallbackValue
-    }
-
-    const formatter = new Intl.NumberFormat('en-US', {
-      trailingZeroDisplay: 'stripIfInteger',
-      ...options,
-    })
-
-    return formatter.format(parsedValue)
-  }
 }
 
 /**

--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -177,8 +177,11 @@ export default class SectionLeagueContext extends BaseAppContext {
    * @returns {string}
    */
   normalizeEnrolledParticipantsNumber () {
-    return this.normalizeNumber({
+    return this.formatNumber({
       value: this.enrolledParticipantsNumber,
+      options: {
+        trailingZeroDisplay: 'stripIfInteger',
+      },
     })
   }
 
@@ -287,8 +290,11 @@ export default class SectionLeagueContext extends BaseAppContext {
    * @returns {string}
    */
   normalizeParticipantUpperLimit () {
-    return this.normalizeNumber({
+    return this.formatNumber({
       value: this.participantUpperLimit,
+      options: {
+        trailingZeroDisplay: 'stripIfInteger',
+      },
     })
   }
 
@@ -564,37 +570,14 @@ export default class SectionLeagueContext extends BaseAppContext {
    * @returns {string} Normalized minimum deposit.
    */
   normalizeMinimumDeposit () {
-    const normalizedFigure = this.normalizeNumber({
+    const normalizedFigure = this.formatNumber({
       value: this.minimumDeposit,
+      options: {
+        trailingZeroDisplay: 'stripIfInteger',
+      },
     })
 
     return `${normalizedFigure} USDC`
-  }
-
-  /**
-   * Normalize number.
-   *
-   * @param {{
-   *   value: number | null
-   *   options?: Intl.NumberFormatOptions
-   * }} params - Parameters.
-   * @returns {string} Normalized number string.
-   * @todo Put this method inside BaseAppContext
-   */
-  normalizeNumber ({
-    value,
-    options = {},
-  }) {
-    if (value === null) {
-      return '--'
-    }
-
-    const formatter = new Intl.NumberFormat('en-US', {
-      trailingZeroDisplay: 'stripIfInteger',
-      ...options,
-    })
-
-    return formatter.format(value)
   }
 
   /**
@@ -610,11 +593,12 @@ export default class SectionLeagueContext extends BaseAppContext {
     value,
     options = {},
   }) {
-    return this.normalizeNumber({
+    return this.formatNumber({
       value,
       options: {
         style: 'currency',
         currency: 'USD',
+        trailingZeroDisplay: 'stripIfInteger',
         ...options,
       },
     })

--- a/components/profile/ProfileFinancialOverviewContext.js
+++ b/components/profile/ProfileFinancialOverviewContext.js
@@ -109,46 +109,42 @@ export default class ProfileFinancialOverviewContext extends BaseAppContext {
     return Object.values(openPerpetualPositions)
       .map(it => ({
         ...it,
-        entryPrice: this.normalizeNumber({
-          numberString: it.entryPrice,
+        entryPrice: this.formatNumber({
+          value: it.entryPrice,
+          options: {
+            minimumFractionDigits: 1,
+            maximumFractionDigits: 2,
+          },
         }),
-        size: this.normalizeNumber({
-          numberString: it.size,
+        size: this.formatNumber({
+          value: it.size,
+          options: {
+            minimumFractionDigits: 1,
+            maximumFractionDigits: 2,
+          },
         }),
-        realizedPnl: this.normalizeNumber({
-          numberString: it.realizedPnl,
+        realizedPnl: this.formatNumber({
+          value: it.realizedPnl,
+          options: {
+            minimumFractionDigits: 1,
+            maximumFractionDigits: 2,
+          },
         }),
-        unrealizedPnl: this.normalizeNumber({
-          numberString: it.unrealizedPnl,
+        unrealizedPnl: this.formatNumber({
+          value: it.unrealizedPnl,
+          options: {
+            minimumFractionDigits: 1,
+            maximumFractionDigits: 2,
+          },
         }),
-        netFunding: this.normalizeNumber({
-          numberString: it.netFunding,
+        netFunding: this.formatNumber({
+          value: it.netFunding,
+          options: {
+            minimumFractionDigits: 1,
+            maximumFractionDigits: 2,
+          },
         }),
       }))
-  }
-
-  /**
-   * Normalize number.
-   *
-   * @param {{
-   *   numberString: string | null
-   * }} params - Parameters.
-   * @returns {string} Normalized number string.
-   */
-  normalizeNumber ({
-    numberString,
-  }) {
-    if (!numberString) {
-      return '--'
-    }
-
-    const figure = parseFloat(numberString)
-    const formatter = new Intl.NumberFormat('en-US', {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 2,
-    })
-
-    return formatter.format(figure)
   }
 
   /**

--- a/components/units/AppLeagueCard.vue
+++ b/components/units/AppLeagueCard.vue
@@ -107,7 +107,14 @@ export default defineComponent({
             />
 
             <span class="count">
-              {{ context.normalizeNumber({ value: context.participantUpperLimit }) }}
+              {{
+                context.formatNumber({
+                  value: context.participantUpperLimit,
+                  options: {
+                    trailingZeroDisplay: 'stripIfInteger',
+                  },
+                })
+              }}
             </span>
           </span>
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4363

# How

* Make `#formatNumber()` a method of `BaseAppContext` for reusability.
* Replace identical with the newly created `#formatNumber()`.
