### PR TITLE
Use green as text color of ROI in leaderboard table

### DIFF
--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -534,6 +534,8 @@ export default defineComponent({
 
 <style scoped>
 .unit-section {
+  --color-text-roi: var(--palette-green);
+
   margin-block-start: 0;
   margin-inline: calc(-1 * var(--size-body-padding-inline-mobile));
 
@@ -827,6 +829,10 @@ export default defineComponent({
 
 .unit-status.participant.canceled {
   color: var(--color-text-participant-status-canceled);
+}
+
+.unit-roi {
+  color: var(--color-text-roi);
 }
 
 /***************** Trading volume leaderboard ****************/


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4433

# How

* Use green as text color of ROI in leaderboard table.

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/4d88e889-0040-4370-b58d-3ed75d91c809)

## After

![image](https://github.com/user-attachments/assets/e9e35108-8bf7-4fa6-a099-cd2e3779600b)