### PR TITLE
Define href prop of LinkTooltipButton as nullable

### DIFF
--- a/components/buttons/LinkTooltipButton.vue
+++ b/components/buttons/LinkTooltipButton.vue
@@ -32,7 +32,10 @@ export default defineComponent({
       default: 'top',
     },
     href: {
-      type: String,
+      type: [
+        String,
+        null,
+      ],
       required: true,
     },
     iconName: {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4436

# How

* Define href prop of LinkTooltipButton as nullable.
