### PR TITLE
Use empty string for disabled link to avoid type issue

### DIFF
--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -381,13 +381,13 @@ export default class SectionLeagueContext extends BaseAppContext {
   /**
    * Generate host's address url.
    *
-   * @returns {string | null} The host's wallet address URL on Mintscan.
+   * @returns {string} The host's wallet address URL on Mintscan.
    */
   generateHostAddressUrl () {
     const { address } = this.host ?? {}
 
     if (!address) {
-      return null
+      return ''
     }
 
     return `https://www.mintscan.io/dydx/address/${address}`


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4436

# How

* `href` prop of `<LinkTooltipButton>` can't be null because of the type of `href` in HTML is `string | undefined`. When a null value is used for this prop, a warning will be added to console tab.
* This pull request solved the type issue by using an empty string to disable a link instead of using `null`.
