### PR TITLE
Display arena's description in markdown format

### DIFF
--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -14,6 +14,7 @@ import AppBadge from '~/components/units/AppBadge.vue'
 import AppIconBadge from '~/components/badges/AppIconBadge.vue'
 import AppButton from '~/components/units/AppButton.vue'
 import AppLeagueCountdown from '~/components/units/AppLeagueCountdown.vue'
+import AppMarkdownViewer from '~/components/units/AppMarkdownViewer.vue'
 import CopyButton from '~/components/buttons/CopyButton.vue'
 import LinkTooltipButton from '~/components/buttons/LinkTooltipButton.vue'
 import OnboardingDialogs from '~/components/dialogs/OnboardingDialogs.vue'
@@ -36,6 +37,7 @@ export default defineComponent({
     AppIconBadge,
     AppButton,
     AppLeagueCountdown,
+    AppMarkdownViewer,
     CopyButton,
     LinkTooltipButton,
     OnboardingDialogs,
@@ -193,9 +195,15 @@ export default defineComponent({
         </div>
 
         <p class="description">
-          <span>
-            {{ context.normalizeDescription() }}
-          </span> <button
+          <AppMarkdownViewer
+            :content="context.normalizeDescription()"
+            :class="[
+              $style.markdown,
+              $style['arena-description'],
+            ]"
+          />
+
+          <button
             class="button"
             @click="context.toggleDescriptionExpansion()"
           >
@@ -843,5 +851,30 @@ export default defineComponent({
 .unit-statistics > .entry > .details.prize > .note {
   font-size: var(--font-size-base);
   font-weight: 500;
+}
+</style>
+
+<style module>
+.markdown.arena-description {
+  font-size: var(--font-size-base);
+
+  line-height: var(--size-line-height-base);
+}
+
+.markdown.arena-description * {
+  font-size: inherit;
+}
+
+.markdown.markdown.arena-description h1,
+.markdown.markdown.arena-description h2,
+.markdown.markdown.arena-description h3,
+.markdown.markdown.arena-description h4,
+.markdown.markdown.arena-description h5,
+.markdown.markdown.arena-description h6 {
+  margin-block: 0;
+}
+
+.markdown.arena-description hr {
+  margin-block: 0;
 }
 </style>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4616

# How

* Display arena's description in markdown format.

> [!note]
> There is a small issue with css of markdown, which makes `<li>` look broken in the below screenshot. I will fix it in another pull request.

# Screenshots

<img width="1303" height="854" alt="image" src="https://github.com/user-attachments/assets/40a37657-d9ab-415d-9575-833374b14340" />

