### PR TITLE
Update the appearance of collapsed/expanded arena description

### DIFF
--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -686,7 +686,7 @@ export default class SectionLeagueContext extends BaseAppContext {
    */
   generateLeagueDetailClasses () {
     return {
-      'expandable-description': this.hasDescriptionExceededPreviewLength(),
+      'expandable-description': this.isDescriptionExpandable,
     }
   }
 

--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -1,4 +1,8 @@
 import {
+  nextTick,
+} from 'vue'
+
+import {
   useRoute,
 } from 'vue-router'
 
@@ -50,6 +54,7 @@ export default class SectionLeagueContext extends BaseAppContext {
 
     walletStore,
     onboardingDialogsComponentRef,
+    descriptionElementShallowRef,
     statusReactive,
   }) {
     super({
@@ -59,6 +64,7 @@ export default class SectionLeagueContext extends BaseAppContext {
 
     this.walletStore = walletStore
     this.onboardingDialogsComponentRef = onboardingDialogsComponentRef
+    this.descriptionElementShallowRef = descriptionElementShallowRef
     this.statusReactive = statusReactive
   }
 
@@ -76,6 +82,7 @@ export default class SectionLeagueContext extends BaseAppContext {
     componentContext,
     walletStore,
     onboardingDialogsComponentRef,
+    descriptionElementShallowRef,
     statusReactive,
   }) {
     return /** @type {InstanceType<T>} */ (
@@ -84,6 +91,7 @@ export default class SectionLeagueContext extends BaseAppContext {
         componentContext,
         walletStore,
         onboardingDialogsComponentRef,
+        descriptionElementShallowRef,
         statusReactive,
       })
     )
@@ -98,12 +106,79 @@ export default class SectionLeagueContext extends BaseAppContext {
   }
 
   /**
+   * Setup component.
+   *
+   * @template {X extends SectionLeagueContext ? X : never} T, X
+   * @override
+   * @this {T}
+   */
+  setupComponent () {
+    this.watch(
+      () => this.description,
+      () => {
+        nextTick(() => {
+          this.statusReactive.isDescriptionExpandable = this.descriptionElementScrollHeight > this.descriptionElementClientHeight
+        })
+      },
+      {
+        immediate: true,
+      }
+    )
+
+    return this
+  }
+
+  /**
+   * get: isDescriptionExpandable
+   *
+   * @returns {boolean}
+   */
+  get isDescriptionExpandable () {
+    return this.statusReactive.isDescriptionExpandable
+  }
+
+  /**
    * get: isDescriptionExpanded
    *
    * @returns {boolean}
    */
   get isDescriptionExpanded () {
     return this.statusReactive.isDescriptionExpanded
+  }
+
+  /**
+   * get: descriptionElement
+   *
+   * @returns {HTMLDivElement | null}
+   */
+  get descriptionElement () {
+    return this.descriptionElementShallowRef.value
+  }
+
+  /**
+   * get: descriptionElementScrollHeight
+   *
+   * @returns {number}
+   */
+  get descriptionElementScrollHeight () {
+    if (this.descriptionElement === null) {
+      return 0
+    }
+
+    return this.descriptionElement.scrollHeight
+  }
+
+  /**
+   * get: descriptionElementClientHeight
+   *
+   * @returns {number}
+   */
+  get descriptionElementClientHeight () {
+    if (this.descriptionElement === null) {
+      return 0
+    }
+
+    return this.descriptionElement.clientHeight
   }
 
   /**
@@ -924,7 +999,9 @@ export default class SectionLeagueContext extends BaseAppContext {
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<PropsType> & {
  *   walletStore: import('~/stores/wallet').WalletStore
  *   onboardingDialogsComponentRef: import('vue').Ref<import('~/components/dialogs/OnboardingDialogs.vue').default | null>
+ *   descriptionElementShallowRef: import('vue').ShallowRef<HTMLDivElement | null>
  *   statusReactive: import('vue').Reactive<{
+ *     isDescriptionExpandable: boolean
  *     isDescriptionExpanded: boolean
  *   }>
  * }} SectionLeagueContextParams

--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -35,8 +35,6 @@ const ENROLLMENT_ACTION_TEXT = {
  * @import { CompetitionEntity } from '~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule'
  */
 
-const MAX_DESCRIPTION_PREVIEW_LENGTH = 180
-
 /**
  * Context class for SectionLeague component.
  *
@@ -415,14 +413,7 @@ export default class SectionLeagueContext extends BaseAppContext {
       return '----'
     }
 
-    if (
-      !this.hasDescriptionExceededPreviewLength()
-      || this.isDescriptionExpanded
-    ) {
-      return this.description
-    }
-
-    return `${this.description.slice(0, MAX_DESCRIPTION_PREVIEW_LENGTH)}...`
+    return this.description
   }
 
   /**
@@ -851,19 +842,6 @@ export default class SectionLeagueContext extends BaseAppContext {
       COMPETITION_STATUS.CANCELED.ID,
     ]
       .includes(this.competitionStatusId)
-  }
-
-  /**
-   * Whether description is expandable or not.
-   *
-   * @returns {boolean} `true` if description is long enough to be expandable.
-   */
-  hasDescriptionExceededPreviewLength () {
-    if (!this.description) {
-      return false
-    }
-
-    return this.description.length > MAX_DESCRIPTION_PREVIEW_LENGTH
   }
 
   /**

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -194,7 +194,7 @@ export default defineComponent({
           </div>
         </div>
 
-        <p class="description">
+        <div class="description">
           <AppMarkdownViewer
             :content="context.normalizeDescription()"
             :class="[
@@ -202,14 +202,23 @@ export default defineComponent({
               $style['arena-description'],
             ]"
           />
+        </div>
 
-          <button
-            class="button"
-            @click="context.toggleDescriptionExpansion()"
-          >
+        <AppButton
+          class="button expand"
+          @click="context.toggleDescriptionExpansion()"
+        >
+          <template #startIcon>
+            <Icon
+              name="heroicons:chevron-up-down"
+              size="1.5rem"
+            />
+          </template>
+
+          <template #default>
             {{ context.generateDescriptionExpansionButtonLabel() }}
-          </button>
-        </p>
+          </template>
+        </AppButton>
 
         <span class="balance">
           <Icon
@@ -533,20 +542,31 @@ export default defineComponent({
   color: var(--color-text-tertiary);
 }
 
-.unit-details > .description > .button {
-  font-size: inherit;
+.unit-details > .button.expand {
+  --color-text-hover: var(--palette-purple-lighter);
+
+  display: block;
+
+  border: none;
+
+  padding-block: 0.5rem;
+  padding-inline: 0;
+
+  font-size: var(--font-size-base);
   font-weight: 500;
 
   color: inherit;
+  background-color: transparent;
 
   transition: color 250ms var(--transition-timing-base);
 }
 
-.unit-details > .description > .button:not(:disabled):hover {
-  color: var(--color-text-primary);
+.unit-details > .button.expand:not(:disabled):hover {
+  color: var(--color-text-hover);
+  background-color: transparent;
 }
 
-.unit-details:not(.expandable-description) > .description > .button {
+.unit-details:not(.expandable-description) > .button.expand {
   display: none;
 }
 

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -1,8 +1,9 @@
 <script>
 import {
   defineComponent,
-  ref,
   reactive,
+  ref,
+  shallowRef,
 } from 'vue'
 
 import {
@@ -103,7 +104,11 @@ export default defineComponent({
 
     /** @type {import('vue').Ref<import('~/components/dialogs/OnboardingDialogs.vue').default | null>} */
     const onboardingDialogsComponentRef = ref(null)
+    /** @type {import('vue').ShallowRef<HTMLDivElement | null>} */
+    const descriptionElementShallowRef = shallowRef(null)
+
     const statusReactive = reactive({
+      isDescriptionExpandable: false,
       isDescriptionExpanded: false,
     })
 
@@ -112,6 +117,7 @@ export default defineComponent({
       componentContext,
       walletStore,
       onboardingDialogsComponentRef,
+      descriptionElementShallowRef,
       statusReactive,
     }
     const context = SectionLeagueContext.create(args)
@@ -194,14 +200,24 @@ export default defineComponent({
           </div>
         </div>
 
-        <div class="description">
-          <AppMarkdownViewer
-            :content="context.normalizeDescription()"
-            :class="[
-              $style.markdown,
-              $style['arena-description'],
-            ]"
-          />
+        <div
+          class="description"
+          :class="{
+            expanded: context.isDescriptionExpanded,
+          }"
+        >
+          <div
+            :ref="context.descriptionElementShallowRef"
+            class="content"
+          >
+            <AppMarkdownViewer
+              :content="context.normalizeDescription()"
+              :class="[
+                $style.markdown,
+                $style['arena-description'],
+              ]"
+            />
+          </div>
         </div>
 
         <AppButton
@@ -535,11 +551,29 @@ export default defineComponent({
 }
 
 .unit-details > .description {
+  display: grid;
+
   margin-block-start: 1.5rem;
 
   font-size: var(--font-size-medium);
 
   color: var(--color-text-tertiary);
+}
+
+.unit-details > .description > * {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+}
+
+.unit-details > .description > .content {
+  --size-description-collapsed-max-height: 12rem;
+
+  max-block-size: var(--size-description-collapsed-max-height);
+  overflow: hidden;
+}
+
+.unit-details > .description.expanded > .content {
+  max-block-size: 100%;
 }
 
 .unit-details > .button.expand {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4671

# How

* Collapse and expand arena's description by height instead of by the amount of characters.

# Screenshots

## Before

<img width="867" height="221" alt="image" src="https://github.com/user-attachments/assets/63e09343-f826-44ac-a26c-c5ee1d8d7b0d" />

## After

<img width="878" height="333" alt="image" src="https://github.com/user-attachments/assets/a2867c2c-ef7a-46d3-95e6-e01076d11f15" />

