### PR TITLE
Use correct colors for ROI in leaderboard

### DIFF
--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -511,7 +511,7 @@ export default class SectionLeaderboardContext extends BaseAppContext {
    * }} params - Parameters.
    * @returns {boolean}
    */
-  isRoiPositive ({
+  isPositiveRoi ({
     value,
   }) {
     if (value === null) {
@@ -529,7 +529,7 @@ export default class SectionLeaderboardContext extends BaseAppContext {
    * }} params - Parameters.
    * @returns {boolean}
    */
-  isRoiNegative ({
+  isNegativeRoi ({
     value,
   }) {
     if (value === null) {

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -504,6 +504,42 @@ export default class SectionLeaderboardContext extends BaseAppContext {
   }
 
   /**
+   * Check if ROI is negative.
+   *
+   * @param {{
+   *   value: number | null
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isRoiPositive ({
+    value,
+  }) {
+    if (value === null) {
+      return false
+    }
+
+    return value > 0
+  }
+
+  /**
+   * Check if ROI is negative.
+   *
+   * @param {{
+   *   value: number | null
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isRoiNegative ({
+    value,
+  }) {
+    if (value === null) {
+      return false
+    }
+
+    return value < 0
+  }
+
+  /**
    * Generate section heading CSS classes.
    *
    * @returns {Record<string, boolean>}

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -305,7 +305,17 @@ export default defineComponent({
               </template>
 
               <template #body-ongoingRoi="{ value }">
-                <span class="unit-roi ongoing">
+                <span
+                  class="unit-roi ongoing"
+                  :class="{
+                    positive: context.isRoiPositive({
+                      value,
+                    }),
+                    negative: context.isRoiNegative({
+                      value,
+                    }),
+                  }"
+                >
                   {{
                     context.normalizeRoi({
                       figure: value,
@@ -374,7 +384,17 @@ export default defineComponent({
               </template>
 
               <template #body-outcomeRoi="{ value }">
-                <span class="unit-roi outcome">
+                <span
+                  class="unit-roi outcome"
+                  :class="{
+                    positive: context.isRoiPositive({
+                      value,
+                    }),
+                    negative: context.isRoiNegative({
+                      value,
+                    }),
+                  }"
+                >
                   {{
                     context.normalizeRoi({
                       figure: value,
@@ -534,8 +554,6 @@ export default defineComponent({
 
 <style scoped>
 .unit-section {
-  --color-text-roi: var(--palette-green);
-
   margin-block-start: 0;
   margin-inline: calc(-1 * var(--size-body-padding-inline-mobile));
 
@@ -832,7 +850,16 @@ export default defineComponent({
 }
 
 .unit-roi {
-  color: var(--color-text-roi);
+  --color-text-roi-positive: var(--palette-green);
+  --color-text-roi-negative: var(--palette-red);
+}
+
+.unit-roi.positive {
+  color: var(--color-text-roi-positive);
+}
+
+.unit-roi.negative {
+  color: var(--color-text-roi-negative);
 }
 
 /***************** Trading volume leaderboard ****************/

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -308,10 +308,10 @@ export default defineComponent({
                 <span
                   class="unit-roi ongoing"
                   :class="{
-                    positive: context.isRoiPositive({
+                    positive: context.isPositiveRoi({
                       value,
                     }),
-                    negative: context.isRoiNegative({
+                    negative: context.isNegativeRoi({
                       value,
                     }),
                   }"
@@ -387,10 +387,10 @@ export default defineComponent({
                 <span
                   class="unit-roi outcome"
                   :class="{
-                    positive: context.isRoiPositive({
+                    positive: context.isPositiveRoi({
                       value,
                     }),
-                    negative: context.isRoiNegative({
+                    negative: context.isNegativeRoi({
                       value,
                     }),
                   }"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/4708

# How

* Use green for positive ROI.
* Use red for negative ROI.
* If ROI is null or is equal to `0`, use normal text color.

# Screenshots

## Before

<img width="253" height="558" alt="image" src="https://github.com/user-attachments/assets/01b8d6a3-37bc-4a51-a449-446650dc083f" />

## After

<img width="294" height="481" alt="image" src="https://github.com/user-attachments/assets/bf3aa7a4-cf2b-4b0c-96c8-6cb6a6e2c6a5" />

