### PR TITLE
Fetch `addressProfile` on mounted in profile page

### DIFF
--- a/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlCapsule.js
@@ -1,0 +1,78 @@
+import BaseAppGraphqlCapsule from '~/app/graphql/client/BaseAppGraphqlCapsule'
+
+/**
+ * AddressProfile query graphql capsule.
+ *
+ * @extends {BaseAppGraphqlCapsule<AddressProfileQueryResponseContent>}
+ */
+export default class AddressProfileQueryGraphqlCapsule extends BaseAppGraphqlCapsule {
+  /**
+   * Extract `addressProfile` response content as value hash.
+   *
+   * @returns {AddressProfile | null} `addressProfile` value hash.
+   */
+  extractAddressProfileValueHash () {
+    return this.extractContent()
+      ?.addressProfile
+      ?? null
+  }
+
+  /**
+   * get: address
+   *
+   * @returns {string | null} Address.
+   */
+  get address () {
+    return this.extractAddressProfileValueHash()
+      ?.address
+      ?? null
+  }
+
+  /**
+   * get: name
+   *
+   * @returns {string | null} Name.
+   */
+  get name () {
+    return this.extractAddressProfileValueHash()
+      ?.name
+      ?? null
+  }
+
+  /**
+   * get: addressImageUrl
+   *
+   * @returns {string | null} Address image URL.
+   */
+  get addressImageUrl () {
+    return this.extractAddressProfileValueHash()
+      ?.addressImageUrl
+      ?? null
+  }
+
+  /**
+   * get: xAccountUserName
+   *
+   * @returns {string | null} X account user's name.
+   */
+  get xAccountUserName () {
+    return this.extractAddressProfileValueHash()
+      ?.xAccountUserName
+      ?? null
+  }
+}
+
+/**
+ * @typedef {{
+ *   addressProfile: AddressProfile
+ * }} AddressProfileQueryResponseContent
+ */
+
+/**
+ * @typedef {{
+ *   address: string
+ *   name?: string
+ *   addressImageUrl?: string
+ *   xAccountUserName?: string
+ * }} AddressProfile
+ */

--- a/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlLauncher.js
+++ b/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlLauncher.js
@@ -1,0 +1,21 @@
+import BaseAppGraphqlLauncher from '~/app/graphql/client/BaseAppGraphqlLauncher'
+
+import AddressProfileQueryGraphqlPayload from './AddressProfileQueryGraphqlPayload'
+import AddressProfileQueryGraphqlCapsule from './AddressProfileQueryGraphqlCapsule'
+
+/**
+ * AddressProfile query graphql launcher.
+ *
+ * @extends {BaseAppGraphqlLauncher}
+ */
+export default class AddressProfileQueryGraphqlLauncher extends BaseAppGraphqlLauncher {
+  /** @override */
+  static get Payload () {
+    return AddressProfileQueryGraphqlPayload
+  }
+
+  /** @override */
+  static get Capsule () {
+    return AddressProfileQueryGraphqlCapsule
+  }
+}

--- a/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlPayload.js
@@ -1,0 +1,30 @@
+import BaseAppGraphqlPayload from '~/app/graphql/client/BaseAppGraphqlPayload'
+
+/**
+ * AddressProfile query GraphQL payload.
+ *
+ * @extends {BaseAppGraphqlPayload<AddressProfileQueryRequestVariables>}
+ */
+export default class AddressProfileQueryGraphqlPayload extends BaseAppGraphqlPayload {
+  /** @override */
+  static get document () {
+    return /* GraphQL */ `
+      query AddressProfileQuery ($input: AddressProfileInput!) {
+        addressProfile (input: $input) {
+          address
+          name
+          addressImageUrl
+          xAccountUserName
+        }
+      }
+    `
+  }
+}
+
+/**
+ * @typedef {{
+ *   input: {
+ *     address: string
+ *   }
+ * }} AddressProfileQueryRequestVariables
+ */

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -744,6 +744,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
  *   isLoadingProfileOverview: boolean
  *   isLoadingProfileOrders: boolean
  *   isLoadingProfileTrades: boolean
+ *   isFetchingAddressProfile: boolean
  * }} StatusReactive
  */
 

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -32,6 +32,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
     route,
     router,
     graphqlClientHash,
+    fetcherHash,
     profileOverviewRef,
     profileOrdersRef,
     profileTradesRef,
@@ -46,6 +47,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
     this.route = route
     this.router = router
     this.graphqlClientHash = graphqlClientHash
+    this.fetcherHash = fetcherHash
     this.profileOverviewRef = profileOverviewRef
     this.profileOrdersRef = profileOrdersRef
     this.profileTradesRef = profileTradesRef
@@ -68,6 +70,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
     route,
     router,
     graphqlClientHash,
+    fetcherHash,
     profileOverviewRef,
     profileOrdersRef,
     profileTradesRef,
@@ -81,6 +84,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
         route,
         router,
         graphqlClientHash,
+        fetcherHash,
         profileOverviewRef,
         profileOrdersRef,
         profileTradesRef,
@@ -141,6 +145,27 @@ export default class ProfileDetailsContext extends BaseAppContext {
     }
 
     return activeTabKey
+  }
+
+  /**
+   * Extract `address` from route.
+   *
+   * @returns {string | null}
+   */
+  extractAddressFromRoute () {
+    const {
+      address,
+    } = this.route.params
+
+    const addressFromRoute = Array.isArray(address)
+      ? address.at(0)
+      : address
+
+    if (!addressFromRoute) {
+      return null
+    }
+
+    return addressFromRoute
   }
 
   /**
@@ -226,6 +251,21 @@ export default class ProfileDetailsContext extends BaseAppContext {
           hooks: this.addressNameLauncherHooks,
         },
       })
+
+    onMounted(async () => {
+      const address = this.extractAddressFromRoute()
+      if (address === null) {
+        return
+      }
+
+      await this.fetcherHash
+        .addressProfile
+        .fetchAddressProfileOnEvent({
+          valueHash: {
+            address,
+          },
+        })
+    })
 
     this.watch(
       () => this.route.params.address,
@@ -714,6 +754,9 @@ export default class ProfileDetailsContext extends BaseAppContext {
  *   route: ReturnType<import('vue-router').useRoute>
  *   router: ReturnType<import('vue-router').useRouter>
  *   graphqlClientHash: Record<GraphqlClientHashKeys, GraphqlClient>
+ *   fetcherHash: {
+ *     addressProfile: import('~/pages/(profiles)/profiles/[address]/AddressProfileFetcher').default
+ *   }
  *   profileOverviewRef: import('vue').Ref<ProfileOverview | null>
  *   profileOrdersRef: import('vue').Ref<Array<ProfileOrder>>
  *   profileTradesRef: import('vue').Ref<Array<ProfileTradeFill>>

--- a/pages/(profiles)/profiles/[address]/AddressProfileFetcher.js
+++ b/pages/(profiles)/profiles/[address]/AddressProfileFetcher.js
@@ -1,0 +1,126 @@
+export default class AddressProfileFetcher {
+  /**
+   * @param {AddressProfileFetcherParams} params - Parameters.
+   */
+  constructor ({
+    statusReactive,
+    graphqlClientHash,
+  }) {
+    this.statusReactive = statusReactive
+    this.graphqlClientHash = graphqlClientHash
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof AddressProfileFetcher ? X : never} T, X
+   * @param {AddressProfileFetcherFactoryParams} params - Parameters.
+   * @returns {InstanceType<T>}
+   * @this {T}
+   */
+  static create ({
+    statusReactive,
+    graphqlClientHash,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        statusReactive,
+        graphqlClientHash,
+      })
+    )
+  }
+
+  /**
+   * get: addressProfileCapsule
+   *
+   * @returns {import('~/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlCapsule').default}
+   */
+  get addressProfileCapsule () {
+    return this.graphqlClientHash
+      .addressProfile
+      .capsuleRef
+      .value
+  }
+
+  /**
+   * get: addressProfileLauncherHooks
+   *
+   * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
+   */
+  get addressProfileLauncherHooks () {
+    return {
+      /**
+       * @type {(payload: import('~/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlPayload').default) => Promise<boolean>}
+       */
+      beforeRequest: async payload => {
+        this.statusReactive.isFetchingAddressProfile = true
+
+        return false
+      },
+      /**
+       * @type {(capsule: import('~/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlCapsule').default) => Promise<void>}
+       */
+      // @ts-expect-error
+      afterRequest: async capsule => {
+        this.statusReactive.isFetchingAddressProfile = false
+      },
+    }
+  }
+
+  /**
+   * Fetch address profile.
+   *
+   * @param {{
+   *   valueHash: import('~/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlPayload')
+   *     .AddressProfileQueryRequestVariables['input']
+   * }} params - Parameters.
+   * @returns {Promise<void>}
+   */
+  async fetchAddressProfileOnEvent ({
+    valueHash,
+  }) {
+    await this.graphqlClientHash
+      .addressProfile
+      .invokeRequestOnEvent({
+        variables: {
+          input: valueHash,
+        },
+        hooks: this.addressProfileLauncherHooks,
+      })
+  }
+
+  /**
+   * Fetch `addressProfile` on mounted.
+   *
+   * @param {{
+   *   valueHash: import('~/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlPayload')
+   *     .AddressProfileQueryRequestVariables['input']
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  fetchAddressProfileOnMounted ({
+    valueHash,
+  }) {
+    this.graphqlClientHash
+      .addressProfile
+      .invokeRequestOnMounted({
+        variables: {
+          input: valueHash,
+        },
+        hooks: this.addressProfileLauncherHooks,
+      })
+  }
+}
+
+/**
+ * @typedef {{
+ *   statusReactive: import('~/app/vue/contexts/profile/ProfileDetailsPageContext').StatusReactive
+ *   graphqlClientHash: {
+ *     addressProfile: ReturnType<typeof import('@openreachtech/furo-nuxt').useGraphqlClient>
+ *   }
+ * }} AddressProfileFetcherParams
+ */
+
+/**
+ * @typedef {AddressProfileFetcherParams} AddressProfileFetcherFactoryParams
+ */

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -28,10 +28,13 @@ import useAppFormClerk from '~/composables/useAppFormClerk'
 
 import AddressCurrentCompetitionQueryGraphqlLauncher from '~/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlLauncher'
 import AddressNameQueryGraphqlLauncher from '~/app/graphql/client/queries/addressName/AddressNameQueryGraphqlLauncher'
+import AddressProfileQueryGraphqlLauncher from '~/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlLauncher'
 import CompetitionParticipantQueryGraphqlLauncher from '~/app/graphql/client/queries/competitionParticipant/CompetitionParticipantQueryGraphqlLauncher'
 import PutAddressNameMutationGraphqlLauncher from '~/app/graphql/client/mutations/putAddressName/PutAddressNameMutationGraphqlLauncher'
 
 import PutAddressNameFormElementClerk from '~/app/domClerk/PutAddressNameFormElementClerk'
+
+import AddressProfileFetcher from './AddressProfileFetcher'
 
 import ProfileDetailsContext from '~/app/vue/contexts/profile/ProfileDetailsPageContext'
 import ProfileDetailsPageMutationContext from './ProfileDetailsPageMutationContext'
@@ -58,6 +61,7 @@ export default defineComponent({
 
     const addressCurrentCompetitionGraphqlClient = useGraphqlClient(AddressCurrentCompetitionQueryGraphqlLauncher)
     const addressNameGraphqlClient = useGraphqlClient(AddressNameQueryGraphqlLauncher)
+    const addressProfileGraphqlClient = useGraphqlClient(AddressProfileQueryGraphqlLauncher)
     const competitionParticipantGraphqlClient = useGraphqlClient(CompetitionParticipantQueryGraphqlLauncher)
     const putAddressNameGraphqlClient = useGraphqlClient(PutAddressNameMutationGraphqlLauncher)
     const putAddressNameFormClerk = useAppFormClerk({
@@ -90,6 +94,13 @@ export default defineComponent({
       isRenaming: false,
     })
 
+    const addressProfileFetcher = AddressProfileFetcher.create({
+      statusReactive,
+      graphqlClientHash: {
+        addressProfile: addressProfileGraphqlClient,
+      },
+    })
+
     const args = {
       props,
       componentContext,
@@ -99,6 +110,9 @@ export default defineComponent({
         addressCurrentCompetition: addressCurrentCompetitionGraphqlClient,
         addressName: addressNameGraphqlClient,
         competitionParticipant: competitionParticipantGraphqlClient,
+      },
+      fetcherHash: {
+        addressProfile: addressProfileFetcher,
       },
       profileOverviewRef,
       profileOrdersRef,

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -84,6 +84,7 @@ export default defineComponent({
       isLoadingProfileOverview: true,
       isLoadingProfileOrders: true,
       isLoadingProfileTrades: true,
+      isFetchingAddressProfile: false,
     })
     const mutationStatusReactive = reactive({
       isRenaming: false,


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5081

# How

* Create GraphQL definitions for `addressProfile` query.
* Create fetcher for `addressProfile` query.
* Fetch `addressProfile` on mounted in profile page.
