### PR TITLE
Move arena history into a dedicated section

### DIFF
--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -754,6 +754,15 @@ export default class ProfileDetailsContext extends BaseAppContext {
       },
     ]
   }
+
+  /**
+   * Check if the user is currently participating in an arena.
+   *
+   * @returns {boolean}
+   */
+  isParticipatingInArena () {
+    return this.currentCompetitionId !== null
+  }
 }
 
 /**

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -113,10 +113,6 @@ export default class ProfileDetailsContext extends BaseAppContext {
         label: 'Transfer History',
       },
       {
-        tabKey: 'past-competitions',
-        label: 'Arena History',
-      },
-      {
         tabKey: 'orders',
         label: 'Orders',
       },

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -193,33 +193,38 @@ export default defineComponent({
 
     <SectionProfileFinancialMetrics :metrics="context.generateFinancialMetrics()" />
 
-    <AppTabLayout
-      class="tabs"
-      :tabs="context.profileTabs"
-      :active-tab-key="context.extractActiveTabKeyFromRoute()"
-      @change-tab="context.changeTab({
-        fromTab: $event.fromTab,
-        toTab: $event.toTab,
-      })"
-    >
-      <template #contents>
-        <ProfileFinancialOverview :profile-overview="context.profileOverview" />
+    <section class="section">
+      <h1 class="heading">
+        Current Arena
+      </h1>
 
-        <ProfileTransferHistory />
+      <AppTabLayout
+        :tabs="context.profileTabs"
+        :active-tab-key="context.extractActiveTabKeyFromRoute()"
+        @change-tab="context.changeTab({
+          fromTab: $event.fromTab,
+          toTab: $event.toTab,
+        })"
+      >
+        <template #contents>
+          <ProfileFinancialOverview :profile-overview="context.profileOverview" />
 
-        <ProfileLeagueHistory />
+          <ProfileTransferHistory />
 
-        <ProfileOrders
-          :profile-orders="context.profileOrders"
-          :is-loading="context.isLoadingProfileOrders"
-        />
+          <ProfileLeagueHistory />
 
-        <ProfileTrades
-          :profile-trades="context.profileTrades"
-          :is-loading="context.isLoadingProfileTrades"
-        />
-      </template>
-    </AppTabLayout>
+          <ProfileOrders
+            :profile-orders="context.profileOrders"
+            :is-loading="context.isLoadingProfileOrders"
+          />
+
+          <ProfileTrades
+            :profile-trades="context.profileTrades"
+            :is-loading="context.isLoadingProfileTrades"
+          />
+        </template>
+      </AppTabLayout>
+    </section>
 
     <ProfileRenameDialog
       ref="profileRenameDialogRef"
@@ -234,6 +239,11 @@ export default defineComponent({
 </template>
 
 <style scoped>
+/* Reset base furo stylesheet. */
+section + section {
+  margin-block-start: 0;
+}
+
 .unit-page {
   margin-inline: calc(-1 * var(--size-body-padding-inline-mobile));
 
@@ -242,7 +252,7 @@ export default defineComponent({
   }
 }
 
-.unit-page > .tabs {
+.unit-page > .section {
   margin-inline: auto;
 
   padding-block: 2.5rem;
@@ -253,5 +263,12 @@ export default defineComponent({
   @media (30rem < width) {
     padding-inline: var(--size-body-padding-inline-desktop);
   }
+}
+
+.unit-page > .section > .heading {
+  font-size: var(--font-size-extra);
+  font-weight: 700;
+
+  line-height: var(--size-line-height-extra);
 }
 </style>

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -226,6 +226,12 @@ export default defineComponent({
       </AppTabLayout>
     </section>
 
+    <section class="section">
+      <h1 class="heading">
+        Arena History
+      </h1>
+    </section>
+
     <ProfileRenameDialog
       ref="profileRenameDialogRef"
       :initial-username="context.addressName"

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -211,8 +211,6 @@ export default defineComponent({
 
           <ProfileTransferHistory />
 
-          <ProfileLeagueHistory />
-
           <ProfileOrders
             :profile-orders="context.profileOrders"
             :is-loading="context.isLoadingProfileOrders"
@@ -230,6 +228,8 @@ export default defineComponent({
       <h1 class="heading">
         Arena History
       </h1>
+
+      <ProfileLeagueHistory />
     </section>
 
     <ProfileRenameDialog

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -193,7 +193,12 @@ export default defineComponent({
 
     <SectionProfileFinancialMetrics :metrics="context.generateFinancialMetrics()" />
 
-    <section class="section">
+    <section
+      class="section"
+      :class="{
+        hidden: !context.isParticipatingInArena(),
+      }"
+    >
       <h1 class="heading">
         Current Arena
       </h1>
@@ -269,6 +274,10 @@ section + section {
   @media (30rem < width) {
     padding-inline: var(--size-body-padding-inline-desktop);
   }
+}
+
+.unit-page > .section.hidden {
+  display: none;
 }
 
 .unit-page > .section > .heading {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5164

# How

* Moved arena history into a dedicated section.
* Hide "Current Arena" section if the user is not participating in any arena.

# Screenshots

## Before

<details><summary>Click to see screenshots</summary>
<p>

<img width="1902" height="969" alt="image" src="https://github.com/user-attachments/assets/794fa377-c9ad-4859-8d96-4f68d731d9fa" />

</p>
</details> 

## After

<details><summary>Click to see screenshots</summary>
<p>

<img width="1907" height="968" alt="image" src="https://github.com/user-attachments/assets/c777a579-e55b-48cd-bb79-defaee840fdc" />

</p>
</details> 
