### PR TITLE
Update styles of profile avatar to match actual design

### DIFF
--- a/components/units/ProfileAvatar.vue
+++ b/components/units/ProfileAvatar.vue
@@ -139,6 +139,7 @@ export default defineComponent({
 <style scoped>
 .unit-avatar-container {
   --size-avatar: 6rem;
+  --size-avatar-content: calc(var(--size-avatar) - (var(--size-avatar-border) * 2));
   --size-icon-fallback: 3.75rem;
   --size-icon-loader: 1.5rem;
   --size-avatar-border: 0.1rem;
@@ -163,12 +164,8 @@ export default defineComponent({
   display: grid;
   grid-template-areas: 'stack';
 
-  width: calc(
-    var(--size-avatar) - (var(--size-avatar-border) * 2)
-  );
-  height: calc(
-    var(--size-avatar) - (var(--size-avatar-border) * 2)
-  );
+  width: var(--size-avatar-content);
+  height: var(--size-avatar-content);
 
   background-color: var(--color-background-avatar);
 
@@ -180,8 +177,8 @@ export default defineComponent({
 }
 
 .unit-avatar > .image {
-  width: var(--size-avatar);
-  height: var(--size-avatar);
+  width: var(--size-avatar-content);
+  height: var(--size-avatar-content);
 
   object-fit: cover;
 }


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5357

# How

* Add border to profile avatar. Since we use mask-image, the border is made with an additional wrapper.
* Don't break the aspect ratio of uploaded image.

# Screenshots

## Before

<img width="441" height="302" alt="image" src="https://github.com/user-attachments/assets/4ea08fea-83b5-4bd3-abc6-3eb02ae6ee48" />

## After

<img width="437" height="296" alt="image" src="https://github.com/user-attachments/assets/e931a090-9de1-463a-b315-c21752f5d259" />

