### PR TITLE
Disallow updating profile avatar if is not own profile

### DIFF
--- a/components/profile/SectionProfileOverview.vue
+++ b/components/profile/SectionProfileOverview.vue
@@ -126,6 +126,7 @@ export default defineComponent({
           <ProfileAvatar
             :default-image-url="context.addressImageUrl"
             :is-uploading-image="context.isUploadingAvatar"
+            :can-update-image="context.isOwnProfile()"
             @upload-image="context.emitUploadImage({
               file: $event.file,
             })"

--- a/components/units/ProfileAvatar.vue
+++ b/components/units/ProfileAvatar.vue
@@ -40,6 +40,11 @@ export default defineComponent({
       required: false,
       default: null,
     },
+    canUpdateImage: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 
   emits: [
@@ -77,6 +82,7 @@ export default defineComponent({
       class="unit-avatar"
       :class="{
         loading: context.isUploadingImage,
+        'can-update': context.canUpdateImage,
       }"
     >
       <img
@@ -247,5 +253,13 @@ export default defineComponent({
   opacity: 0;
 
   pointer-events: none;
+}
+
+.unit-avatar:not(.can-update) > .button {
+  display: none;
+}
+
+.unit-avatar:not(.can-update) > .input {
+  display: none;
 }
 </style>

--- a/components/units/ProfileAvatarContext.js
+++ b/components/units/ProfileAvatarContext.js
@@ -101,6 +101,15 @@ export default class ProfileAvatarContext extends BaseFuroContext {
   }
 
   /**
+   * get: canUpdateImage
+   *
+   * @returns {PropsType['canUpdateImage']}
+   */
+  get canUpdateImage () {
+    return this.props.canUpdateImage
+  }
+
+  /**
    * Setup component.
    *
    * @template {X extends ProfileAvatarContext ? X : never} T, X
@@ -128,6 +137,10 @@ export default class ProfileAvatarContext extends BaseFuroContext {
   onInputChange ({
     changeEvent,
   }) {
+    if (!this.canUpdateImage) {
+      return
+    }
+
     if (!(changeEvent.target instanceof HTMLInputElement)) {
       return
     }
@@ -225,6 +238,7 @@ export default class ProfileAvatarContext extends BaseFuroContext {
  *   alt: string
  *   isUploadingImage: boolean
  *   defaultImageUrl: string | null
+ *   canUpdateImage: boolean
  * }} PropsType
  */
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5356

# How

* Disallow user to update a profile image that is not theirs.
