### PR TITLE
Display address profile based on route's param

### DIFF
--- a/app/vue/contexts/profile/SectionProfileOverviewContext.js
+++ b/app/vue/contexts/profile/SectionProfileOverviewContext.js
@@ -411,12 +411,13 @@ export default class SectionProfileOverviewContext extends BaseAppContext {
    * @returns {string} Address first half.
    */
   generateAddressFirstHalf () {
-    if (!this.address) {
+    const address = this.extractAddressFromRoute()
+
+    if (!address) {
       return '--'
     }
 
-    return this.address
-      .slice(0, -5)
+    return address.slice(0, -5)
   }
 
   /**
@@ -425,12 +426,13 @@ export default class SectionProfileOverviewContext extends BaseAppContext {
    * @returns {string} Address last five.
    */
   generateAddressLastFive () {
-    if (!this.address) {
+    const address = this.extractAddressFromRoute()
+
+    if (!address) {
       return '--'
     }
 
-    return this.address
-      .slice(-5)
+    return address.slice(-5)
   }
 
   /**
@@ -543,6 +545,24 @@ export default class SectionProfileOverviewContext extends BaseAppContext {
    */
   hasConnectedXAccount () {
     return Boolean(this.xAccountUserName)
+  }
+
+  /**
+   * Extract `address` from website's URL.
+   *
+   * @returns {string | null}
+   */
+  extractAddressFromRoute () {
+    const {
+      address,
+    } = this.route.params
+
+    const addressFromRoute = Array.isArray(address)
+      ? address.at(0)
+      : address
+
+    return addressFromRoute
+      ?? null
   }
 
   /**


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5359

# How

* Before this pull request, address is displayed based on the result of the API. However, for user that has not registered their address to our database by creating a username, we can't query for their address through Backend API just yet.
* This pull request displays one's wallet address in their profile page by extracting the address from route's param.

> [!note]
> This pull request is actually just reverting to the old behavior. My mistake from here https://github.com/openreachtech/dydx-trading-competition-frontend/commit/ad71ac4692fae0864d02b0e53b04bedab0b634d6

# Screenshots

## Before

<img width="650" height="282" alt="image" src="https://github.com/user-attachments/assets/f2a82be9-d47b-461d-8e9c-98b9cd4b5b1d" />

## After

<img width="818" height="280" alt="image" src="https://github.com/user-attachments/assets/6f1a2ac2-6af2-41de-aebd-58b3febb4ee7" />
