### PR TITLE
Use correct icon for minimum trading volume

### DIFF
--- a/components/competition-add/AddCompetitionFormStepParticipation.vue
+++ b/components/competition-add/AddCompetitionFormStepParticipation.vue
@@ -136,7 +136,7 @@ export default defineComponent({
         <Icon
           class="icon"
           size="1.25rem"
-          name="heroicons:wallet"
+          name="heroicons:chart-bar-square"
         />
 
         <span>Minimum Trading Volume</span>


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5369

# How

* Use correct icon for minimum trading volume.

# Screenshots

## Before

<img width="266" height="248" alt="image" src="https://github.com/user-attachments/assets/d5ac88c4-34a0-47da-93c9-90b4722458d9" />

## After

<img width="277" height="253" alt="image" src="https://github.com/user-attachments/assets/78e8669c-ea5c-4d4d-a688-deffb48f8c14" />

