### PR TITLE
Fix unwanted event when using `vOnClickOutside`

### DIFF
--- a/app/vue/directives/vOnClickOutside.js
+++ b/app/vue/directives/vOnClickOutside.js
@@ -52,7 +52,7 @@ export function handleClickOutside ({
     callback,
   })
 
-  document.addEventListener('click', listener)
+  document.addEventListener('mousedown', listener)
 
   const listenerCleaner = createListenerCleaner({
     listener,
@@ -136,7 +136,7 @@ export function createListenerCleaner ({
    * @returns {void}
    */
   function cleaner () {
-    document.removeEventListener('click', listener)
+    document.removeEventListener('mousedown', listener)
   }
 }
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5857

# How

* Using click event to determine outside-click seems to be problematic in some scenerios, in which even though the user clicks inside the element, the event is still fired. This pull request used `mousedown` instead of `click` to address the issue.

> [!note]
> Honestly, I'm not sure why this happens. Somehow `click` event is fired on the wrong element?
> Tested with `mousedown` and the issue is addressed. Behaviors except for the bug work the same.
