### PR TITLE
Refactor `<DatePicker>` to have more control on selected date

### DIFF
--- a/components/competition-add/AddCompetitionFormStepTimeline.vue
+++ b/components/competition-add/AddCompetitionFormStepTimeline.vue
@@ -300,9 +300,13 @@ export default defineComponent({
 .unit-pickers {
   margin-block-start: 0.5rem;
 
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: 2rem;
+
+  @media (width < 60rem) {
+    grid-template-columns: 1fr;
+  }
 }
 
 .unit-pickers > .fieldset > .date {

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -62,7 +62,6 @@ export default defineComponent({
     props,
     componentContext
   ) {
-    const displayedInputValueRef = ref(generateInitialInputValue())
     const isDropdownOpenRef = ref(false)
     /** @type {import('vue').Ref<import('./AppDatePickerContext').SelectedDate | null>} */
     const selectedDateRef = ref(null)
@@ -72,7 +71,6 @@ export default defineComponent({
     const args = {
       props,
       componentContext,
-      displayedInputValueRef,
       isDropdownOpenRef,
       selectedDateRef,
       currentViewDateReactive,
@@ -83,23 +81,6 @@ export default defineComponent({
 
     return {
       context,
-    }
-
-    /**
-     * Generate initial input value.
-     *
-     * @returns {string}
-     */
-    function generateInitialInputValue () {
-      if (props.initialDate === null) {
-        return ''
-      }
-
-      return new Date(props.initialDate)
-        .toISOString()
-        .split('T')
-        .at(0)
-        ?? ''
     }
   },
 })
@@ -115,7 +96,7 @@ export default defineComponent({
       <input
         type="text"
         class="input"
-        :value="context.displayedInputValue"
+        :value="context.formatDisplayedDate()"
         @click="context.openDropdown()"
       >
 

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -87,39 +87,43 @@ export default defineComponent({
 </script>
 
 <template>
-  <button
+  <div
     v-on-click-outside="() => context.closeDropdown()"
-    type="button"
     class="unit-picker"
     :class="context.generateDatePickerClasses()"
-    @click="context.toggleDropdown()"
   >
-    <span class="unit-input">
-      <span
-        class="date"
-        :class="{
-          selected: context.hasSelectedDate(),
-        }"
-      >
-        {{ context.formatDisplayedDate() }}
-      </span>
+    <button
+      type="button"
+      class="button"
+      @click="context.toggleDropdown()"
+    >
+      <span class="unit-input">
+        <span
+          class="date"
+          :class="{
+            selected: context.hasSelectedDate(),
+          }"
+        >
+          {{ context.formatDisplayedDate() }}
+        </span>
 
-      <input
-        type="text"
-        class="input hidden"
-        :value="context.normalizeInputValue()"
-        v-bind="$attrs"
-      >
+        <input
+          type="text"
+          class="input hidden"
+          :value="context.normalizeInputValue()"
+          v-bind="$attrs"
+        >
 
-      <span class="icon picker">
-        <slot name="inputIcon">
-          <Icon
-            name="heroicons:calendar"
-            size="1rem"
-          />
-        </slot>
+        <span class="icon picker">
+          <slot name="inputIcon">
+            <Icon
+              name="heroicons:calendar"
+              size="1rem"
+            />
+          </slot>
+        </span>
       </span>
-    </span>
+    </button>
 
     <div class="unit-dropdown">
       <div class="header">
@@ -187,7 +191,7 @@ export default defineComponent({
         </button>
       </div>
     </div>
-  </button>
+  </div>
 </template>
 
 <style scoped>
@@ -195,6 +199,10 @@ export default defineComponent({
   --color-background-picker: var(--color-background-input);
   --color-background-picker-hover: var(--palette-layer-4);
 
+  position: relative;
+}
+
+.unit-picker > .button {
   outline-width: 0;
   outline-color: transparent;
 
@@ -207,9 +215,9 @@ export default defineComponent({
 
   background-color: var(--color-background-picker);
 
-  position: relative;
-
   display: inline-block;
+
+  width: 100%;
 
   transition:
     border-color 150ms var(--transition-timing-base),
@@ -217,11 +225,11 @@ export default defineComponent({
     outline-color 150ms var(--transition-timing-base);
 }
 
-.unit-picker:hover {
+.unit-picker > .button:hover {
   background-color: var(--color-background-picker-hover);
 }
 
-.unit-picker.open {
+.unit-picker.open > .button {
   outline-width: var(--size-thinnest);
   outline-style: solid;
   outline-color: var(--color-border-input-focus);
@@ -267,7 +275,7 @@ export default defineComponent({
   transition: color 250ms var(--transition-timing-base);
 }
 
-.unit-picker:hover > .unit-input > .icon.picker {
+.unit-picker > .button:hover > .unit-input > .icon.picker {
   color: var(--color-text-primary);
 }
 

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -115,9 +115,15 @@ export default defineComponent({
       <input
         type="text"
         class="input"
-        v-bind="$attrs"
         :value="context.displayedInputValue"
         @click="context.openDropdown()"
+      >
+
+      <input
+        type="text"
+        class="input hidden"
+        :value="context.normalizeInputValue()"
+        v-bind="$attrs"
       >
 
       <button
@@ -253,6 +259,10 @@ export default defineComponent({
 
 .unit-input > .input::placeholder {
   color: var(--color-text-placeholder);
+}
+
+.unit-input > .input.hidden {
+  display: none;
 }
 
 .unit-input > .button {

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -87,10 +87,12 @@ export default defineComponent({
 </script>
 
 <template>
-  <span
+  <button
     v-on-click-outside="() => context.closeDropdown()"
+    type="button"
     class="unit-picker"
     :class="context.generateDatePickerClasses()"
+    @click="context.toggleDropdown()"
   >
     <span class="unit-input">
       <span
@@ -98,7 +100,6 @@ export default defineComponent({
         :class="{
           selected: context.hasSelectedDate(),
         }"
-        @click="context.openDropdown()"
       >
         {{ context.formatDisplayedDate() }}
       </span>
@@ -110,18 +111,14 @@ export default defineComponent({
         v-bind="$attrs"
       >
 
-      <button
-        class="button"
-        type="button"
-        @click="context.toggleDropdown()"
-      >
+      <span class="icon picker">
         <slot name="inputIcon">
           <Icon
             name="heroicons:calendar"
             size="1rem"
           />
         </slot>
-      </button>
+      </span>
     </span>
 
     <div class="unit-dropdown">
@@ -190,11 +187,14 @@ export default defineComponent({
         </button>
       </div>
     </div>
-  </span>
+  </button>
 </template>
 
 <style scoped>
 .unit-picker {
+  --color-background-picker: var(--color-background-input);
+  --color-background-picker-hover: var(--palette-layer-4);
+
   outline-width: 0;
   outline-color: transparent;
 
@@ -205,14 +205,20 @@ export default defineComponent({
 
   padding-inline-end: 0.75rem;
 
-  background-color: var(--color-background-input);
+  background-color: var(--color-background-picker);
 
   position: relative;
 
   display: inline-block;
 
-  transition: border-color 150ms var(--transition-timing-base),
+  transition:
+    border-color 150ms var(--transition-timing-base),
+    background-color 150ms var(--transition-timing-base),
     outline-color 150ms var(--transition-timing-base);
+}
+
+.unit-picker:hover {
+  background-color: var(--color-background-picker-hover);
 }
 
 .unit-picker.open {
@@ -224,7 +230,10 @@ export default defineComponent({
 .unit-input {
   display: grid;
   grid-template-columns: 1fr auto;
+  align-items: center;
   gap: 0.5rem;
+
+  text-align: start;
 }
 
 .unit-input > .date {
@@ -248,7 +257,7 @@ export default defineComponent({
   display: none;
 }
 
-.unit-input > .button {
+.unit-input > .icon.picker {
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -258,7 +267,7 @@ export default defineComponent({
   transition: color 250ms var(--transition-timing-base);
 }
 
-.unit-input > .button:hover {
+.unit-picker:hover > .unit-input > .icon.picker {
   color: var(--color-text-primary);
 }
 

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -65,7 +65,7 @@ export default defineComponent({
     const displayedInputValueRef = ref(generateInitialInputValue())
     const isDropdownOpenRef = ref(false)
     /** @type {import('./AppDatePickerContext').CurrentViewDate} */
-    const currentViewDateReactive = reactive(generateInitialDateReactive())
+    const currentViewDateReactive = reactive(AppDatePickerContext.generateInitialCurrentViewDate())
 
     const args = {
       props,
@@ -97,22 +97,6 @@ export default defineComponent({
         .split('T')
         .at(0)
         ?? ''
-    }
-
-    /**
-     * Generate initial `dateReactive`.
-     *
-     * @returns {import('./AppDatePickerContext').CurrentViewDate}
-     */
-    function generateInitialDateReactive () {
-      const date = props.initialDate === null
-        ? new Date()
-        : new Date(props.initialDate)
-
-      return {
-        year: date.getFullYear(),
-        month: date.getMonth(),
-      }
     }
   },
 })

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -64,15 +64,15 @@ export default defineComponent({
   ) {
     const displayedInputValueRef = ref(generateInitialInputValue())
     const isDropdownOpenRef = ref(false)
-    /** @type {import('./AppDatePickerContext').DateReactive} */
-    const dateReactive = reactive(generateInitialDateReactive())
+    /** @type {import('./AppDatePickerContext').CurrentViewDate} */
+    const currentViewDateReactive = reactive(generateInitialDateReactive())
 
     const args = {
       props,
       componentContext,
       displayedInputValueRef,
       isDropdownOpenRef,
-      dateReactive,
+      currentViewDateReactive,
     }
     // @ts-expect-error - Type of emit should take a generic. Needs to resolve in furo-nuxt.
     const context = AppDatePickerContext.create(args)
@@ -102,7 +102,7 @@ export default defineComponent({
     /**
      * Generate initial `dateReactive`.
      *
-     * @returns {import('./AppDatePickerContext').DateReactive}
+     * @returns {import('./AppDatePickerContext').CurrentViewDate}
      */
     function generateInitialDateReactive () {
       const date = props.initialDate === null
@@ -110,8 +110,8 @@ export default defineComponent({
         : new Date(props.initialDate)
 
       return {
-        currentMonth: date.getMonth(),
-        currentYear: date.getFullYear(),
+        year: date.getFullYear(),
+        month: date.getMonth(),
       }
     }
   },

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -93,12 +93,15 @@ export default defineComponent({
     :class="context.generateDatePickerClasses()"
   >
     <span class="unit-input">
-      <input
-        type="text"
-        class="input"
-        :value="context.formatDisplayedDate()"
+      <span
+        class="date"
+        :class="{
+          selected: context.hasSelectedDate(),
+        }"
         @click="context.openDropdown()"
       >
+        {{ context.formatDisplayedDate() }}
+      </span>
 
       <input
         type="text"
@@ -219,26 +222,25 @@ export default defineComponent({
 }
 
 .unit-input {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
   gap: 0.5rem;
 }
 
-.unit-input > .input {
-  border-width: 0;
-  outline-width: 0;
-
+.unit-input > .date {
   padding-block: 0.625rem;
   padding-inline-start: 0.75rem;
 
-  flex: 1;
-
-  background-color: inherit;
-
   font-size: var(--font-size-base);
+
   line-height: var(--size-line-height-base);
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.unit-input > .input::placeholder {
+.unit-input > .date:not(.selected) {
   color: var(--color-text-placeholder);
 }
 

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -62,7 +62,7 @@ export default defineComponent({
     props,
     componentContext
   ) {
-    const inputValueRef = ref(generateInitialInputValue())
+    const displayedInputValueRef = ref(generateInitialInputValue())
     const isDropdownOpenRef = ref(false)
     /** @type {import('./AppDatePickerContext').DateReactive} */
     const dateReactive = reactive(generateInitialDateReactive())
@@ -70,7 +70,7 @@ export default defineComponent({
     const args = {
       props,
       componentContext,
-      inputValueRef,
+      displayedInputValueRef,
       isDropdownOpenRef,
       dateReactive,
     }
@@ -129,7 +129,7 @@ export default defineComponent({
         type="text"
         class="input"
         v-bind="$attrs"
-        :value="context.inputValue"
+        :value="context.displayedInputValue"
         @click="context.openDropdown()"
       >
 

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -64,7 +64,9 @@ export default defineComponent({
   ) {
     const displayedInputValueRef = ref(generateInitialInputValue())
     const isDropdownOpenRef = ref(false)
-    /** @type {import('./AppDatePickerContext').CurrentViewDate} */
+    /** @type {import('vue').Ref<import('./AppDatePickerContext').SelectedDate | null>} */
+    const selectedDateRef = ref(null)
+    /** @type {import('vue').Reactive<import('./AppDatePickerContext').CurrentViewDate>} */
     const currentViewDateReactive = reactive(AppDatePickerContext.generateInitialCurrentViewDate())
 
     const args = {
@@ -72,6 +74,7 @@ export default defineComponent({
       componentContext,
       displayedInputValueRef,
       isDropdownOpenRef,
+      selectedDateRef,
       currentViewDateReactive,
     }
     // @ts-expect-error - Type of emit should take a generic. Needs to resolve in furo-nuxt.

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -17,7 +17,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     props,
     componentContext,
 
-    inputValueRef,
+    displayedInputValueRef,
     isDropdownOpenRef,
     dateReactive,
   }) {
@@ -26,7 +26,7 @@ export default class AppDatePickerContext extends BaseAppContext {
       componentContext,
     })
 
-    this.inputValueRef = inputValueRef
+    this.displayedInputValueRef = displayedInputValueRef
     this.isDropdownOpenRef = isDropdownOpenRef
     this.dateReactive = dateReactive
   }
@@ -43,7 +43,7 @@ export default class AppDatePickerContext extends BaseAppContext {
   static create ({
     props,
     componentContext,
-    inputValueRef,
+    displayedInputValueRef,
     isDropdownOpenRef,
     dateReactive,
   }) {
@@ -51,7 +51,7 @@ export default class AppDatePickerContext extends BaseAppContext {
       new this({
         props,
         componentContext,
-        inputValueRef,
+        displayedInputValueRef,
         isDropdownOpenRef,
         dateReactive,
       })
@@ -127,8 +127,8 @@ export default class AppDatePickerContext extends BaseAppContext {
    *
    * @returns {string} Input value.
    */
-  get inputValue () {
-    return this.inputValueRef.value
+  get displayedInputValue () {
+    return this.displayedInputValueRef.value
   }
 
   /**
@@ -151,7 +151,7 @@ export default class AppDatePickerContext extends BaseAppContext {
       return
     }
 
-    this.inputValueRef.value = dateString
+    this.displayedInputValueRef.value = dateString
   }
 
   /**
@@ -420,7 +420,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     selectedDate.setUTCMonth(date.month)
     selectedDate.setUTCDate(date.day)
 
-    this.inputValueRef.value = selectedDate.toISOString()
+    this.displayedInputValueRef.value = selectedDate.toISOString()
       .split('T')
       .at(0)
       ?? ''
@@ -428,7 +428,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     this.emit(
       this.EMIT_EVENT_NAME.CHANGE_DATE,
       {
-        date: this.inputValue,
+        date: this.displayedInputValueRef.value,
       }
     )
 
@@ -514,7 +514,7 @@ export default class AppDatePickerContext extends BaseAppContext {
       selectedYear,
       selectedMonth,
       selectedDate,
-    ] = this.inputValue
+    ] = this.displayedInputValue
       .split('-')
       .map(it => Number(it))
 
@@ -607,7 +607,7 @@ export default class AppDatePickerContext extends BaseAppContext {
 
 /**
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<AppDatePickerProps> & {
- *   inputValueRef: import('vue').Ref<string>
+ *   displayedInputValueRef: import('vue').Ref<string>
  *   isDropdownOpenRef: import('vue').Ref<boolean>
  *   dateReactive: DateReactive
  * }} AppDatePickerContextParams

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -17,7 +17,6 @@ export default class AppDatePickerContext extends BaseAppContext {
     props,
     componentContext,
 
-    displayedInputValueRef,
     isDropdownOpenRef,
     selectedDateRef,
     currentViewDateReactive,
@@ -28,7 +27,6 @@ export default class AppDatePickerContext extends BaseAppContext {
       componentContext,
     })
 
-    this.displayedInputValueRef = displayedInputValueRef
     this.isDropdownOpenRef = isDropdownOpenRef
     this.selectedDateRef = selectedDateRef
     this.currentViewDateReactive = currentViewDateReactive
@@ -47,7 +45,6 @@ export default class AppDatePickerContext extends BaseAppContext {
   static create ({
     props,
     componentContext,
-    displayedInputValueRef,
     isDropdownOpenRef,
     selectedDateRef,
     currentViewDateReactive,
@@ -65,7 +62,6 @@ export default class AppDatePickerContext extends BaseAppContext {
       new this({
         props,
         componentContext,
-        displayedInputValueRef,
         isDropdownOpenRef,
         selectedDateRef,
         currentViewDateReactive,
@@ -108,7 +104,6 @@ export default class AppDatePickerContext extends BaseAppContext {
       () => {
         this.syncInitialSelectedDate()
         this.syncInitialCurrentViewDate()
-        this.syncInitialInputValue()
       },
       {
         once: true,
@@ -155,15 +150,6 @@ export default class AppDatePickerContext extends BaseAppContext {
   }
 
   /**
-   * get: inputValue
-   *
-   * @returns {string} Input value.
-   */
-  get displayedInputValue () {
-    return this.displayedInputValueRef.value
-  }
-
-  /**
    * Sync the initial value of `selectedDateRef`.
    *
    * @returns {void}
@@ -196,29 +182,6 @@ export default class AppDatePickerContext extends BaseAppContext {
 
     this.currentViewDateReactive.year = normalizedDate.getFullYear()
     this.currentViewDateReactive.month = normalizedDate.getMonth()
-  }
-
-  /**
-   * Sync the initial value of date picker.
-   *
-   * @returns {void}
-   */
-  syncInitialInputValue () {
-    if (this.initialDate === null) {
-      return
-    }
-
-    const dateString = new Date(this.initialDate)
-      .toISOString()
-      .split('T')
-      .at(0)
-      ?? null
-
-    if (!dateString) {
-      return
-    }
-
-    this.displayedInputValueRef.value = dateString
   }
 
   /**
@@ -503,12 +466,6 @@ export default class AppDatePickerContext extends BaseAppContext {
   selectDate ({
     date,
   }) {
-    const selectedDate = new Date(
-      date.year,
-      date.month,
-      date.day
-    )
-
     const lastSelectedDate = this.selectedDateRef.value
       ? this.selectedDateRef.value
       : this.generateSelectedDateAsToday()
@@ -520,15 +477,10 @@ export default class AppDatePickerContext extends BaseAppContext {
       day: date.day,
     }
 
-    this.displayedInputValueRef.value = selectedDate.toISOString()
-      .split('T')
-      .at(0)
-      ?? ''
-
     this.emit(
       this.EMIT_EVENT_NAME.CHANGE_DATE,
       {
-        date: this.displayedInputValueRef.value,
+        date: this.normalizeInputValue(),
       }
     )
 
@@ -650,17 +602,19 @@ export default class AppDatePickerContext extends BaseAppContext {
   isSelectedDate ({
     date,
   }) {
-    const [
-      selectedYear,
-      selectedMonth,
-      selectedDate,
-    ] = this.displayedInputValue
-      .split('-')
-      .map(it => Number(it))
+    if (!this.selectedDateRef.value) {
+      return false
+    }
 
-    return date.day === selectedDate
-      && date.month === selectedMonth - 1
-      && date.year === selectedYear
+    const {
+      year,
+      month,
+      day,
+    } = this.selectedDateRef.value
+
+    return date.year === year
+      && date.month === month
+      && date.day === day
   }
 
   /**
@@ -747,7 +701,6 @@ export default class AppDatePickerContext extends BaseAppContext {
 
 /**
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<AppDatePickerProps> & {
- *   displayedInputValueRef: import('vue').Ref<string>
  *   isDropdownOpenRef: import('vue').Ref<boolean>
  *   selectedDateRef: import('vue').Ref<SelectedDate | null>
  *   currentViewDateReactive: CurrentViewDate

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -90,6 +90,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     this.watch(
       () => this.initialDate,
       () => {
+        this.syncInitialCurrentViewDate()
         this.syncInitialInputValue()
       },
       {
@@ -143,6 +144,22 @@ export default class AppDatePickerContext extends BaseAppContext {
    */
   get displayedInputValue () {
     return this.displayedInputValueRef.value
+  }
+
+  /**
+   * Sync the initial value of `currentViewDateReactive`.
+   *
+   * @returns {void}
+   */
+  syncInitialCurrentViewDate () {
+    if (this.initialDate === null) {
+      return
+    }
+
+    const normalizedDate = new Date(this.initialDate)
+
+    this.currentViewDateReactive.year = normalizedDate.getFullYear()
+    this.currentViewDateReactive.month = normalizedDate.getMonth()
   }
 
   /**

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -21,6 +21,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     isDropdownOpenRef,
     selectedDateRef,
     currentViewDateReactive,
+    displayedDateFormatter,
   }) {
     super({
       props,
@@ -31,6 +32,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     this.isDropdownOpenRef = isDropdownOpenRef
     this.selectedDateRef = selectedDateRef
     this.currentViewDateReactive = currentViewDateReactive
+    this.displayedDateFormatter = displayedDateFormatter
   }
 
   /**
@@ -50,6 +52,15 @@ export default class AppDatePickerContext extends BaseAppContext {
     selectedDateRef,
     currentViewDateReactive,
   }) {
+    const displayedDateFormatter = new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+
     return /** @type {InstanceType<T>} */ (
       new this({
         props,
@@ -58,6 +69,7 @@ export default class AppDatePickerContext extends BaseAppContext {
         isDropdownOpenRef,
         selectedDateRef,
         currentViewDateReactive,
+        displayedDateFormatter,
       })
     )
   }
@@ -561,6 +573,31 @@ export default class AppDatePickerContext extends BaseAppContext {
   }
 
   /**
+   * Format date to display.
+   *
+   * @returns {string}
+   */
+  formatDisplayedDate () {
+    if (!this.selectedDateRef.value) {
+      return '__/__/____'
+    }
+
+    const {
+      year,
+      month,
+      day,
+    } = this.selectedDateRef.value
+
+    const date = new Date(
+      year,
+      month,
+      day
+    )
+
+    return this.displayedDateFormatter.format(date)
+  }
+
+  /**
    * Toggle dropdown.
    *
    * @returns {void}
@@ -714,11 +751,12 @@ export default class AppDatePickerContext extends BaseAppContext {
  *   isDropdownOpenRef: import('vue').Ref<boolean>
  *   selectedDateRef: import('vue').Ref<SelectedDate | null>
  *   currentViewDateReactive: CurrentViewDate
+ *   displayedDateFormatter: InstanceType<typeof Intl.DateTimeFormat>
  * }} AppDatePickerContextParams
  */
 
 /**
- * @typedef {AppDatePickerContextParams} AppDatePickerContextFactoryParams
+ * @typedef {Omit<AppDatePickerContextParams, 'displayedDateFormatter'>} AppDatePickerContextFactoryParams
  */
 
 /**

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -66,6 +66,20 @@ export default class AppDatePickerContext extends BaseAppContext {
   }
 
   /**
+   * Generate initial value for `currentViewDateReactive`.
+   *
+   * @returns {CurrentViewDate}
+   */
+  static generateInitialCurrentViewDate () {
+    const today = new Date()
+
+    return {
+      year: today.getFullYear(),
+      month: today.getMonth(),
+    }
+  }
+
+  /**
    * Setup component.
    *
    * @template {X extends AppDatePickerContext ? X : never} T, X

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -19,6 +19,7 @@ export default class AppDatePickerContext extends BaseAppContext {
 
     displayedInputValueRef,
     isDropdownOpenRef,
+    selectedDateRef,
     currentViewDateReactive,
   }) {
     super({
@@ -28,6 +29,7 @@ export default class AppDatePickerContext extends BaseAppContext {
 
     this.displayedInputValueRef = displayedInputValueRef
     this.isDropdownOpenRef = isDropdownOpenRef
+    this.selectedDateRef = selectedDateRef
     this.currentViewDateReactive = currentViewDateReactive
   }
 
@@ -45,6 +47,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     componentContext,
     displayedInputValueRef,
     isDropdownOpenRef,
+    selectedDateRef,
     currentViewDateReactive,
   }) {
     return /** @type {InstanceType<T>} */ (
@@ -53,6 +56,7 @@ export default class AppDatePickerContext extends BaseAppContext {
         componentContext,
         displayedInputValueRef,
         isDropdownOpenRef,
+        selectedDateRef,
         currentViewDateReactive,
       })
     )
@@ -442,14 +446,22 @@ export default class AppDatePickerContext extends BaseAppContext {
   selectDate ({
     date,
   }) {
-    this.currentViewDateReactive.year = date.year
-    this.currentViewDateReactive.month = date.month
+    const selectedDate = new Date(
+      date.year,
+      date.month,
+      date.day
+    )
 
-    const selectedDate = new Date()
+    const lastSelectedDate = this.selectedDateRef.value
+      ? this.selectedDateRef.value
+      : this.generateSelectedDateAsToday()
 
-    selectedDate.setUTCFullYear(date.year)
-    selectedDate.setUTCMonth(date.month)
-    selectedDate.setUTCDate(date.day)
+    this.selectedDateRef.value = {
+      ...lastSelectedDate,
+      year: date.year,
+      month: date.month,
+      day: date.day,
+    }
 
     this.displayedInputValueRef.value = selectedDate.toISOString()
       .split('T')
@@ -468,6 +480,21 @@ export default class AppDatePickerContext extends BaseAppContext {
     }
 
     this.closeDropdown()
+  }
+
+  /**
+   * Generate selected date with the value of today.
+   *
+   * @returns {SelectedDate}
+   */
+  generateSelectedDateAsToday () {
+    const today = new Date()
+
+    return {
+      year: today.getFullYear(),
+      month: today.getMonth(),
+      day: today.getDate(),
+    }
   }
 
   /**
@@ -640,6 +667,7 @@ export default class AppDatePickerContext extends BaseAppContext {
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<AppDatePickerProps> & {
  *   displayedInputValueRef: import('vue').Ref<string>
  *   isDropdownOpenRef: import('vue').Ref<boolean>
+ *   selectedDateRef: import('vue').Ref<SelectedDate | null>
  *   currentViewDateReactive: CurrentViewDate
  * }} AppDatePickerContextParams
  */
@@ -653,6 +681,14 @@ export default class AppDatePickerContext extends BaseAppContext {
  *   year: number
  *   month: number
  * }} CurrentViewDate
+ */
+
+/**
+ * @typedef {{
+ *   year: number
+ *   month: number
+ *   day: number
+ * }} SelectedDate
  */
 
 /**

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -19,7 +19,7 @@ export default class AppDatePickerContext extends BaseAppContext {
 
     displayedInputValueRef,
     isDropdownOpenRef,
-    dateReactive,
+    currentViewDateReactive,
   }) {
     super({
       props,
@@ -28,7 +28,7 @@ export default class AppDatePickerContext extends BaseAppContext {
 
     this.displayedInputValueRef = displayedInputValueRef
     this.isDropdownOpenRef = isDropdownOpenRef
-    this.dateReactive = dateReactive
+    this.currentViewDateReactive = currentViewDateReactive
   }
 
   /**
@@ -45,7 +45,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     componentContext,
     displayedInputValueRef,
     isDropdownOpenRef,
-    dateReactive,
+    currentViewDateReactive,
   }) {
     return /** @type {InstanceType<T>} */ (
       new this({
@@ -53,7 +53,7 @@ export default class AppDatePickerContext extends BaseAppContext {
         componentContext,
         displayedInputValueRef,
         isDropdownOpenRef,
-        dateReactive,
+        currentViewDateReactive,
       })
     )
   }
@@ -216,8 +216,8 @@ export default class AppDatePickerContext extends BaseAppContext {
    */
   generateDisplayedDays () {
     const currentMonthYear = {
-      month: this.dateReactive.currentMonth,
-      year: this.dateReactive.currentYear,
+      year: this.currentViewDateReactive.year,
+      month: this.currentViewDateReactive.month,
     }
     const previousMonthYear = this.calculatePreviousMonthYear(currentMonthYear)
     const nextMonthYear = this.calculateNextMonthYear(currentMonthYear)
@@ -374,12 +374,12 @@ export default class AppDatePickerContext extends BaseAppContext {
       month,
       year,
     } = this.calculatePreviousMonthYear({
-      month: this.dateReactive.currentMonth,
-      year: this.dateReactive.currentYear,
+      year: this.currentViewDateReactive.year,
+      month: this.currentViewDateReactive.month,
     })
 
-    this.dateReactive.currentMonth = month
-    this.dateReactive.currentYear = year
+    this.currentViewDateReactive.year = year
+    this.currentViewDateReactive.month = month
   }
 
   /**
@@ -392,12 +392,12 @@ export default class AppDatePickerContext extends BaseAppContext {
       month,
       year,
     } = this.calculateNextMonthYear({
-      month: this.dateReactive.currentMonth,
-      year: this.dateReactive.currentYear,
+      year: this.currentViewDateReactive.year,
+      month: this.currentViewDateReactive.month,
     })
 
-    this.dateReactive.currentMonth = month
-    this.dateReactive.currentYear = year
+    this.currentViewDateReactive.year = year
+    this.currentViewDateReactive.month = month
   }
 
   /**
@@ -411,8 +411,8 @@ export default class AppDatePickerContext extends BaseAppContext {
   selectDate ({
     date,
   }) {
-    this.dateReactive.currentMonth = date.month
-    this.dateReactive.currentYear = date.year
+    this.currentViewDateReactive.year = date.year
+    this.currentViewDateReactive.month = date.month
 
     const selectedDate = new Date()
 
@@ -446,8 +446,8 @@ export default class AppDatePickerContext extends BaseAppContext {
    */
   generateDisplayedCurrentMonthYear () {
     const date = new Date(
-      this.dateReactive.currentYear,
-      this.dateReactive.currentMonth
+      this.currentViewDateReactive.year,
+      this.currentViewDateReactive.month
     )
     const formatter = new Intl.DateTimeFormat('en-US', {
       month: 'long',
@@ -552,8 +552,8 @@ export default class AppDatePickerContext extends BaseAppContext {
   isInThisMonth ({
     date,
   }) {
-    return date.month === this.dateReactive.currentMonth
-      && date.year === this.dateReactive.currentYear
+    return date.year === this.currentViewDateReactive.year
+      && date.month === this.currentViewDateReactive.month
   }
 
   /**
@@ -609,7 +609,7 @@ export default class AppDatePickerContext extends BaseAppContext {
  * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<AppDatePickerProps> & {
  *   displayedInputValueRef: import('vue').Ref<string>
  *   isDropdownOpenRef: import('vue').Ref<boolean>
- *   dateReactive: DateReactive
+ *   currentViewDateReactive: CurrentViewDate
  * }} AppDatePickerContextParams
  */
 
@@ -619,9 +619,9 @@ export default class AppDatePickerContext extends BaseAppContext {
 
 /**
  * @typedef {{
- *   currentMonth: number
- *   currentYear: number
- * }} DateReactive
+ *   year: number
+ *   month: number
+ * }} CurrentViewDate
  */
 
 /**

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -700,6 +700,15 @@ export default class AppDatePickerContext extends BaseAppContext {
 
     return targetDate < today
   }
+
+  /**
+   * Check if a date has been selected.
+   *
+   * @returns {boolean}
+   */
+  hasSelectedDate () {
+    return Boolean(this.selectedDateRef.value)
+  }
 }
 
 /**

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -94,6 +94,7 @@ export default class AppDatePickerContext extends BaseAppContext {
     this.watch(
       () => this.initialDate,
       () => {
+        this.syncInitialSelectedDate()
         this.syncInitialCurrentViewDate()
         this.syncInitialInputValue()
       },
@@ -148,6 +149,25 @@ export default class AppDatePickerContext extends BaseAppContext {
    */
   get displayedInputValue () {
     return this.displayedInputValueRef.value
+  }
+
+  /**
+   * Sync the initial value of `selectedDateRef`.
+   *
+   * @returns {void}
+   */
+  syncInitialSelectedDate () {
+    if (this.initialDate === null) {
+      return
+    }
+
+    const normalizedDate = new Date(this.initialDate)
+
+    this.selectedDateRef.value = {
+      year: normalizedDate.getFullYear(),
+      month: normalizedDate.getMonth(),
+      day: normalizedDate.getDate(),
+    }
   }
 
   /**
@@ -433,6 +453,31 @@ export default class AppDatePickerContext extends BaseAppContext {
 
     this.currentViewDateReactive.year = year
     this.currentViewDateReactive.month = month
+  }
+
+  /**
+   * Normalize the value of underlying hidden input.
+   *
+   * @returns {string | null} ISO string or null if unset.
+   */
+  normalizeInputValue () {
+    if (this.selectedDateRef.value === null) {
+      return null
+    }
+
+    const {
+      year,
+      month,
+      day,
+    } = this.selectedDateRef.value
+
+    const date = new Date(
+      year,
+      month,
+      day
+    )
+
+    return date.toISOString()
   }
 
   /**

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -436,23 +436,13 @@ export default class AppDatePickerContext extends BaseAppContext {
    * @returns {string | null} ISO string or null if unset.
    */
   normalizeInputValue () {
-    if (this.selectedDateRef.value === null) {
+    const selectedDate = this.generateSelectedDateInstance()
+
+    if (!selectedDate) {
       return null
     }
 
-    const {
-      year,
-      month,
-      day,
-    } = this.selectedDateRef.value
-
-    const date = new Date(
-      year,
-      month,
-      day
-    )
-
-    return date.toISOString()
+    return selectedDate.toISOString()
   }
 
   /**
@@ -530,8 +520,23 @@ export default class AppDatePickerContext extends BaseAppContext {
    * @returns {string}
    */
   formatDisplayedDate () {
-    if (!this.selectedDateRef.value) {
+    const selectedDate = this.generateSelectedDateInstance()
+
+    if (!selectedDate) {
       return '__/__/____'
+    }
+
+    return this.displayedDateFormatter.format(selectedDate)
+  }
+
+  /**
+   * Generate a date instance from selected date.
+   *
+   * @returns {Date | null} A 'Date' instance, or null if unset.
+   */
+  generateSelectedDateInstance () {
+    if (!this.selectedDateRef.value) {
+      return null
     }
 
     const {
@@ -540,13 +545,11 @@ export default class AppDatePickerContext extends BaseAppContext {
       day,
     } = this.selectedDateRef.value
 
-    const date = new Date(
+    return new Date(
       year,
       month,
       day
     )
-
-    return this.displayedDateFormatter.format(date)
   }
 
   /**


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5790

# How

This pull request did a few things to change the structure of date picker. The main purpose is to make it easier to add time picker to this component:
- Keep "currently being viewed date" and "selected date" in separate reactive values.
- Turn date picker into a button, make its input readonly. Direct edit logic is more complex so I leave it for later.
- The input we send to Backend is converted to an ISO string. We can now add precise clock time to it (_Previous format is similar to the native `input[type="date"]` element, which is `YYYY-MM-DD`.
- The displayed date string is now formatted with Intl.DateTimeFormat, it will match the user's time zone. (_This also fixed mismatch time zone because previously the string is substracted from UTC string_)

# Screencasts

## Before

https://github.com/user-attachments/assets/88847c0e-fd67-4548-a656-3a2a0b7e6b71

## After

https://github.com/user-attachments/assets/6eed095f-cdc5-4aa9-bb2e-b6bda2ab2385
