### PR TITLE
Add logic to pick clock time in `<AppDatePicker>`

### DIFF
--- a/components/competition-add/AddCompetitionFormStepTimeline.vue
+++ b/components/competition-add/AddCompetitionFormStepTimeline.vue
@@ -136,6 +136,7 @@ export default defineComponent({
 
                 <AppDatePicker
                   should-disable-past-dates
+                  can-pick-time
                   name="scheduledDatetime"
                   :initial-date="phase.initialStartDate"
                 />
@@ -161,6 +162,7 @@ export default defineComponent({
 
                 <AppDatePicker
                   should-disable-past-dates
+                  can-pick-time
                   name="scheduledDatetime"
                   :initial-date="phase.initialEndDate"
                   :disabled="!phase.endDateInputId"

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -190,6 +190,55 @@ export default defineComponent({
           </span>
         </button>
       </div>
+
+      <div class="time">
+        <template
+          v-for="it of context.createDatePickerTimeItemContexts()"
+          :key="it.key"
+        >
+          <div class="control">
+            <button
+              type="button"
+              class="button increment"
+              @click="it.incrementClockTime()"
+            >
+              <Icon
+                name="heroicons:chevron-up"
+                size="1rem"
+              />
+            </button>
+
+            <input
+              type="text"
+              inputmode="numeric"
+              class="input"
+              size="2"
+              :value="it.formatClockTime()"
+              @input="it.onInputChange({
+                inputEvent: $event,
+              })"
+            >
+
+            <button
+              type="button"
+              class="button decrement"
+              @click="it.decrementClockTime()"
+            >
+              <Icon
+                name="heroicons:chevron-down"
+                size="1rem"
+              />
+            </button>
+          </div>
+
+          <span
+            class="connector"
+            aria-hidden="true"
+          >
+            :
+          </span>
+        </template>
+      </div>
     </div>
   </div>
 </template>
@@ -431,6 +480,70 @@ export default defineComponent({
 
   cursor: not-allowed;
 }
+
+.unit-dropdown > .time {
+  display: grid;
+  grid-auto-flow: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+
+  margin-block-start: 0.5rem;
+
+  border-block-start-color: var(--color-border-dropdown);
+  border-block-start-width: var(--size-thinnest);
+  border-block-start-style: solid;
+
+  padding-block-start: 0.5rem;
+}
+
+.unit-dropdown > .time > .control {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 0.25rem;
+}
+
+.unit-dropdown > .time > .control > .button {
+  border-radius: 0.25rem;
+
+  padding-block: 0.25rem;
+  padding-inline: 0.25rem;
+
+  transition: background-color 250ms var(--transition-timing-base);
+}
+
+.unit-dropdown > .time > .control > .button:hover {
+  background-color: var(--color-background-date-picker-hover);
+}
+
+.unit-dropdown > .time > .control > .input {
+  border-width: 0;
+
+  padding-block: 0;
+
+  font-size: var(--font-size-small);
+  font-weight: 500;
+
+  line-height: var(--size-line-height-small);
+
+  text-align: center;
+
+  color: var(--color-text-secondary);
+  background-color: transparent;
+
+  transition: color 250ms var(--transition-timing-base);
+}
+
+.unit-dropdown > .time > .control > .input:focus-visible {
+  outline-width: 0;
+
+  color: var(--color-text-primary);
+}
+
+.unit-dropdown > .time > .connector:last-of-type {
+  display: none;
+}
+
 /********** Animation **********/
 
 /* TODO: Unify fade-in animation */

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -225,6 +225,9 @@ export default defineComponent({
               class="input"
               size="2"
               :value="it.formatClockTime()"
+              @keydown="it.onKeyDown({
+                keyboardEvent: $event,
+              })"
               @input="it.onInputChange({
                 inputEvent: $event,
               })"

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -25,6 +25,11 @@ export default defineComponent({
   inheritAttrs: false,
 
   props: {
+    canPickTime: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     initialDate: {
       type: [
         Date,
@@ -125,7 +130,12 @@ export default defineComponent({
       </span>
     </button>
 
-    <div class="unit-dropdown">
+    <div
+      class="unit-dropdown"
+      :class="{
+        'can-pick-time': context.canPickTime,
+      }"
+    >
       <div class="header">
         <button
           class="button"
@@ -497,6 +507,10 @@ export default defineComponent({
   border-block-start-style: solid;
 
   padding-block-start: 0.5rem;
+}
+
+.unit-dropdown:not(.can-pick-time) > .time {
+  display: none;
 }
 
 .unit-dropdown > .time > .control {

--- a/components/units/AppDatePicker.vue
+++ b/components/units/AppDatePicker.vue
@@ -200,6 +200,7 @@ export default defineComponent({
             <button
               type="button"
               class="button increment"
+              :aria-label="it.generateIncrementAriaLabel()"
               @click="it.incrementClockTime()"
             >
               <Icon
@@ -222,6 +223,7 @@ export default defineComponent({
             <button
               type="button"
               class="button decrement"
+              :aria-label="it.generateDecrementAriaLabel()"
               @click="it.decrementClockTime()"
             >
               <Icon

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -206,7 +206,7 @@ export default class AppDatePickerContext extends BaseAppContext {
       month: normalizedDate.getMonth(),
       day: normalizedDate.getDate(),
       hour: normalizedDate.getHours(),
-      minute: normalizedDate.getHours(),
+      minute: normalizedDate.getMinutes(),
     }
   }
 

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -1,6 +1,21 @@
 import BaseAppContext from '~/app/vue/contexts/BaseAppContext'
+import DatePickerTimeItemContext from './DatePickerTimeItemContext'
 
 const MAX_DISPLAYED_DAYS_PER_MONTH = 42
+
+/** @type {Array<ClockTimeMeta>} */
+const CLOCK_TIMES = [
+  {
+    KEY: 'hour',
+    MAX_CLOCK_TIME: 23,
+    MIN_CLOCK_TIME: 0,
+  },
+  {
+    KEY: 'minute',
+    MAX_CLOCK_TIME: 59,
+    MIN_CLOCK_TIME: 0,
+  },
+]
 
 /**
  * AppDatePickerContext
@@ -150,6 +165,22 @@ export default class AppDatePickerContext extends BaseAppContext {
   }
 
   /**
+   * Create an array of `DatePickerTimeItemContext` instances.
+   *
+   * @returns {Array<InstanceType<typeof DatePickerTimeItemContext>>}
+   */
+  createDatePickerTimeItemContexts () {
+    return CLOCK_TIMES.map(it =>
+      DatePickerTimeItemContext.create({
+        selectedDateRef: this.selectedDateRef,
+        key: it.KEY,
+        maxClockTime: it.MAX_CLOCK_TIME,
+        minClockTime: it.MIN_CLOCK_TIME,
+      })
+    )
+  }
+
+  /**
    * Sync the initial value of `selectedDateRef`.
    *
    * @returns {void}
@@ -165,6 +196,8 @@ export default class AppDatePickerContext extends BaseAppContext {
       year: normalizedDate.getFullYear(),
       month: normalizedDate.getMonth(),
       day: normalizedDate.getDate(),
+      hour: normalizedDate.getHours(),
+      minute: normalizedDate.getHours(),
     }
   }
 
@@ -493,6 +526,8 @@ export default class AppDatePickerContext extends BaseAppContext {
       year: today.getFullYear(),
       month: today.getMonth(),
       day: today.getDate(),
+      hour: 0,
+      minute: 0,
     }
   }
 
@@ -543,12 +578,16 @@ export default class AppDatePickerContext extends BaseAppContext {
       year,
       month,
       day,
+      hour,
+      minute,
     } = this.selectedDateRef.value
 
     return new Date(
       year,
       month,
-      day
+      day,
+      hour,
+      minute
     )
   }
 
@@ -736,6 +775,8 @@ export default class AppDatePickerContext extends BaseAppContext {
  *   year: number
  *   month: number
  *   day: number
+ *   hour: number
+ *   minute: number
  * }} SelectedDate
  */
 
@@ -754,4 +795,12 @@ export default class AppDatePickerContext extends BaseAppContext {
  *   shouldStayOnSelect: boolean
  *   rootClass: string
  * }} AppDatePickerProps
+ */
+
+/**
+ * @typedef {{
+ *   KEY: 'hour' | 'minute'
+ *   MAX_CLOCK_TIME: number
+ *   MIN_CLOCK_TIME: number
+ * }} ClockTimeMeta
  */

--- a/components/units/AppDatePickerContext.js
+++ b/components/units/AppDatePickerContext.js
@@ -129,6 +129,15 @@ export default class AppDatePickerContext extends BaseAppContext {
   }
 
   /**
+   * get: canPickTime
+   *
+   * @returns {boolean}
+   */
+  get canPickTime () {
+    return this.props.canPickTime
+  }
+
+  /**
    * get: initialDate
    *
    * @returns {Date | string | null}
@@ -790,6 +799,7 @@ export default class AppDatePickerContext extends BaseAppContext {
 
 /**
  * @typedef {{
+ *   canPickTime: boolean
  *   initialDate: Date | string | null
  *   shouldDisablePastDates: boolean
  *   shouldStayOnSelect: boolean

--- a/components/units/DatePickerTimeItemContext.js
+++ b/components/units/DatePickerTimeItemContext.js
@@ -1,0 +1,200 @@
+export default class DatePickerTimeItemContext {
+  /**
+   * Constructor
+   *
+   * @param {DatePickerTimeItemContextParams} params - Parameters.
+   */
+  constructor ({
+    selectedDateRef,
+    key,
+    maxClockTime,
+    minClockTime,
+  }) {
+    this.selectedDateRef = selectedDateRef
+    this.key = key
+    this.maxClockTime = maxClockTime
+    this.minClockTime = minClockTime
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof DatePickerTimeItemContext ? X : never} T, X
+   * @param {DatePickerTimeItemContextFactoryParams} params - Parameters.
+   * @returns {InstanceType<T>} An instance of this class.
+   * @this {T}
+   */
+  static create ({
+    selectedDateRef,
+    key,
+    maxClockTime,
+    minClockTime,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        selectedDateRef,
+        key,
+        maxClockTime,
+        minClockTime,
+      })
+    )
+  }
+
+  /**
+   * Extract clock time.
+   *
+   * @returns {number}
+   */
+  extractCurrentClockTime () {
+    return this.selectedDateRef.value
+      ?.[this.key]
+      ?? 0
+  }
+
+  /**
+   * Increment clock time.
+   *
+   * @returns {void}
+   */
+  incrementClockTime () {
+    const currentClockTime = this.extractCurrentClockTime()
+
+    if (currentClockTime === this.maxClockTime) {
+      this.updateClockTime({
+        clockTime: this.minClockTime,
+      })
+
+      return
+    }
+
+    this.updateClockTime({
+      clockTime: currentClockTime + 1,
+    })
+  }
+
+  /**
+   * Decrement clock time.
+   */
+  decrementClockTime () {
+    const currentClockTime = this.extractCurrentClockTime()
+
+    if (currentClockTime === this.minClockTime) {
+      this.updateClockTime({
+        clockTime: this.maxClockTime,
+      })
+
+      return
+    }
+
+    this.updateClockTime({
+      clockTime: currentClockTime - 1,
+    })
+  }
+
+  /**
+   * Handle event on input change.
+   *
+   * @param {{
+   *   inputEvent: Event
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  onInputChange ({
+    inputEvent,
+  }) {
+    if (!(inputEvent.target instanceof HTMLInputElement)) {
+      return
+    }
+
+    const numericNewValue = parseFloat(inputEvent.target.value)
+
+    if (isNaN(numericNewValue)) {
+      this.updateClockTime({
+        clockTime: this.minClockTime,
+      })
+
+      return
+    }
+
+    this.updateClockTime({
+      clockTime: numericNewValue,
+    })
+  }
+
+  /**
+   * Update clock time.
+   *
+   * @param {{
+   *   clockTime: number
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  updateClockTime ({
+    clockTime,
+  }) {
+    const lastSelectedDate = this.extractLastSelectedDate()
+    const clampedTime = Math.max(
+      this.minClockTime,
+      Math.min(clockTime, this.maxClockTime)
+    )
+
+    this.selectedDateRef.value = {
+      ...lastSelectedDate,
+      [this.key]: clampedTime,
+    }
+  }
+
+  /**
+   * Extract last selected date.
+   *
+   * @returns {import('./AppDatePickerContext').SelectedDate}
+   */
+  extractLastSelectedDate () {
+    if (!this.selectedDateRef.value) {
+      return this.generateSelectedDateAsToday()
+    }
+
+    return this.selectedDateRef.value
+  }
+
+  /**
+   * Generate selected date with the value of today.
+   *
+   * @returns {import('./AppDatePickerContext').SelectedDate}
+   */
+  generateSelectedDateAsToday () {
+    const today = new Date()
+
+    return {
+      year: today.getFullYear(),
+      month: today.getMonth(),
+      day: today.getDate(),
+      hour: 0,
+      minute: 0,
+    }
+  }
+
+  /**
+   * Format clock time.
+   *
+   * @returns {string}
+   */
+  formatClockTime () {
+    return this.extractCurrentClockTime()
+      .toString()
+      .padStart(2, '0')
+  }
+}
+
+/**
+ * @typedef {{
+ *   selectedDateRef: import('vue').Ref<import('./AppDatePickerContext').SelectedDate | null>
+ *   key: 'hour' | 'minute'
+ *   maxClockTime: number
+ *   minClockTime: number
+ * }} DatePickerTimeItemContextParams
+ */
+
+/**
+ * @typedef {DatePickerTimeItemContextParams} DatePickerTimeItemContextFactoryParams
+ */

--- a/components/units/DatePickerTimeItemContext.js
+++ b/components/units/DatePickerTimeItemContext.js
@@ -175,6 +175,24 @@ export default class DatePickerTimeItemContext {
   }
 
   /**
+   * Generate aria-label for increment button.
+   *
+   * @returns {string}
+   */
+  generateIncrementAriaLabel () {
+    return `Increment ${this.key} by one.`
+  }
+
+  /**
+   * Generate aria-label for decrement button.
+   *
+   * @returns {string}
+   */
+  generateDecrementAriaLabel () {
+    return `Decrement ${this.key} by one.`
+  }
+
+  /**
    * Format clock time.
    *
    * @returns {string}

--- a/components/units/DatePickerTimeItemContext.js
+++ b/components/units/DatePickerTimeItemContext.js
@@ -41,6 +41,37 @@ export default class DatePickerTimeItemContext {
   }
 
   /**
+   * Handle event when a key is pressed.
+   *
+   * @param {{
+   *   keyboardEvent: KeyboardEvent
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  onKeyDown ({
+    keyboardEvent,
+  }) {
+    if (keyboardEvent.key === 'Enter') {
+      // Prevent form submission by mistake.
+      keyboardEvent.preventDefault()
+
+      return
+    }
+
+    if (keyboardEvent.key === 'ArrowUp') {
+      keyboardEvent.preventDefault()
+      this.incrementClockTime()
+
+      return
+    }
+
+    if (keyboardEvent.key === 'ArrowDown') {
+      keyboardEvent.preventDefault()
+      this.decrementClockTime()
+    }
+  }
+
+  /**
    * Extract clock time.
    *
    * @returns {number}


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/1718

# How

* Add time picker for `<AppDatePicker>`.
* Add a prop (`canPickTime`) to conditionally show time picker.
* Clock time can be edit directly, or modify using the increment/decrement buttons.
* Keyboard support for arrow up and down keys.

# Screencasts

https://github.com/user-attachments/assets/e1e04277-8224-4570-a6d5-a668eb72faaa