### PR TITLE
Add drop-shadow for profile avatar component

### DIFF
--- a/components/units/ProfileAvatar.vue
+++ b/components/units/ProfileAvatar.vue
@@ -153,6 +153,7 @@ export default defineComponent({
   --color-background-backdrop: rgba(0, 0, 0, 0.4);
   --color-background-avatar: var(--palette-layer-4);
   --color-border-avatar: var(--palette-layer-4);
+  --color-drop-shadow: #00000099;
 
   display: grid;
   justify-content: center;
@@ -160,6 +161,8 @@ export default defineComponent({
 
   width: var(--size-avatar);
   height: var(--size-avatar);
+
+  filter: drop-shadow(0 0.125rem 1.25rem var(--color-drop-shadow));
 }
 
 .unit-avatar {

--- a/components/units/ProfileAvatar.vue
+++ b/components/units/ProfileAvatar.vue
@@ -160,10 +160,6 @@ export default defineComponent({
 
   width: var(--size-avatar);
   height: var(--size-avatar);
-
-  background-color: var(--color-background-avatar);
-
-  mask: url('~/assets/img/masks/hexagon-mask.svg') center / contain no-repeat;
 }
 
 .unit-avatar {
@@ -175,7 +171,7 @@ export default defineComponent({
 
   background-color: var(--color-background-avatar);
 
-  mask: inherit;
+  mask: url('~/assets/img/masks/hexagon-mask.svg') center / contain no-repeat;
 }
 
 .unit-avatar > * {

--- a/components/units/ProfileAvatar.vue
+++ b/components/units/ProfileAvatar.vue
@@ -78,65 +78,67 @@ export default defineComponent({
 
 <template>
   <div class="unit-avatar-container">
-    <div
-      class="unit-avatar"
-      :class="{
-        loading: context.isUploadingImage,
-        'can-update': context.canUpdateImage,
-      }"
-    >
-      <img
-        class="image"
-        :src="context.generateAvatarImageUrl()"
-        :alt="context.alt"
-        :class="{
-          hidden: !context.containsImage(),
-        }"
-      >
-
-      <Icon
-        name="heroicons:user-solid"
-        class="icon fallback"
-        :class="{
-          hidden: context.containsImage(),
-        }"
-      />
-
-      <input
-        :ref="context.inputElementShallowRef"
-        class="input"
-        type="file"
-        accept="image/*"
-        @change="context.onInputChange({
-          changeEvent: $event,
-        })"
-      >
-
-      <!-- Hidden input to use when submitting form. -->
-      <input
-        type="hidden"
-        :name="context.inputName"
-      >
-
-      <button
-        class="button"
-        :disabled="context.isUploadingImage"
-        @click="context.selectFile()"
-      >
-        <Icon
-          name="heroicons:photo-solid"
-          size="2rem"
-        />
-      </button>
-
+    <div class="avatar-border">
       <div
-        class="loader"
-        aria-hidden="true"
+        class="unit-avatar"
+        :class="{
+          loading: context.isUploadingImage,
+          'can-update': context.canUpdateImage,
+        }"
       >
+        <img
+          class="image"
+          :src="context.generateAvatarImageUrl()"
+          :alt="context.alt"
+          :class="{
+            hidden: !context.containsImage(),
+          }"
+        >
+
         <Icon
-          name="svg-spinners:3-dots-move"
-          class="icon"
+          name="heroicons:user-solid"
+          class="icon fallback"
+          :class="{
+            hidden: context.containsImage(),
+          }"
         />
+
+        <input
+          :ref="context.inputElementShallowRef"
+          class="input"
+          type="file"
+          accept="image/*"
+          @change="context.onInputChange({
+            changeEvent: $event,
+          })"
+        >
+
+        <!-- Hidden input to use when submitting form. -->
+        <input
+          type="hidden"
+          :name="context.inputName"
+        >
+
+        <button
+          class="button"
+          :disabled="context.isUploadingImage"
+          @click="context.selectFile()"
+        >
+          <Icon
+            name="heroicons:photo-solid"
+            size="2rem"
+          />
+        </button>
+
+        <div
+          class="loader"
+          aria-hidden="true"
+        >
+          <Icon
+            name="svg-spinners:3-dots-move"
+            class="icon"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -155,6 +157,10 @@ export default defineComponent({
   --color-border-avatar: var(--palette-layer-4);
   --color-drop-shadow: #00000099;
 
+  filter: drop-shadow(0 0.125rem 1.25rem var(--color-drop-shadow));
+}
+
+.unit-avatar-container > .avatar-border {
   display: grid;
   justify-content: center;
   align-items: center;
@@ -162,7 +168,9 @@ export default defineComponent({
   width: var(--size-avatar);
   height: var(--size-avatar);
 
-  filter: drop-shadow(0 0.125rem 1.25rem var(--color-drop-shadow));
+  background-color: var(--color-border-avatar);
+
+  mask: url('~/assets/img/masks/hexagon-mask.svg') center / contain no-repeat;
 }
 
 .unit-avatar {
@@ -174,7 +182,7 @@ export default defineComponent({
 
   background-color: var(--color-background-avatar);
 
-  mask: url('~/assets/img/masks/hexagon-mask.svg') center / contain no-repeat;
+  mask: inherit;
 }
 
 .unit-avatar > * {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5890

# How

* Add drop-shadow filter to the container div element, then remove its mask to make sure the drop-shadow does not get cut off.
* The container was working as a border for the image. This is a workaround since we are using masked element. Since we remove the container's mask to apply drop-shadow, add another div wrapper to act as the image's border.

# Screenshots

## Before

<img width="298" height="297" alt="Screenshot 2025-08-23 at 19 45 08" src="https://github.com/user-attachments/assets/b2b74147-67f1-45e3-818e-baf10cdaafd9" />

##  After

<img width="289" height="288" alt="Screenshot 2025-08-23 at 19 44 53" src="https://github.com/user-attachments/assets/ca98d86f-d285-4ba3-a898-c7c8ca5ed779" />