### PR TITLE
Show the profile trade overview even after the competition ended

### DIFF
--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -135,7 +135,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
    *   label: string
    * }>} Tabs.
    */
-  generateProfileTabs () {
+  generateFilteredProfileTabs () {
     if (this.isParticipatingInArena()) {
       return this.profileTabs
     }
@@ -156,7 +156,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
       : this.route.query.tab
 
     if (!activeTabKey) {
-      return this.generateProfileTabs()
+      return this.generateFilteredProfileTabs()
         .at(0)
         ?.tabKey
         ?? null

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -14,6 +14,10 @@ import {
   BASE_PAGE_TITLE,
 } from '~/app/constants'
 
+const POST_COMPETITION_IGNORED_TABS = [
+  'transfers',
+]
+
 /**
  * ProfileDetailsContext
  *
@@ -124,6 +128,24 @@ export default class ProfileDetailsContext extends BaseAppContext {
   }
 
   /**
+   * Generate profile tabs.
+   *
+   * @returns {Array<{
+   *   tabKey: string
+   *   label: string
+   * }>} Tabs.
+   */
+  generateProfileTabs () {
+    if (this.isParticipatingInArena()) {
+      return this.profileTabs
+    }
+
+    return this.profileTabs.filter(tab =>
+      !POST_COMPETITION_IGNORED_TABS.includes(tab.tabKey)
+    )
+  }
+
+  /**
    * Extract active tab key from route.
    *
    * @returns {import('vue-router').LocationQueryValue}
@@ -134,7 +156,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
       : this.route.query.tab
 
     if (!activeTabKey) {
-      return this.profileTabs
+      return this.generateProfileTabs()
         .at(0)
         ?.tabKey
         ?? null

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -226,12 +226,7 @@ export default defineComponent({
 
     <SectionProfileFinancialMetrics :metrics="context.generateFinancialMetrics()" />
 
-    <section
-      class="section"
-      :class="{
-        hidden: !context.isParticipatingInArena(),
-      }"
-    >
+    <section class="section">
       <h1 class="heading">
         Current Arena
       </h1>

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -232,7 +232,7 @@ export default defineComponent({
       </h1>
 
       <AppTabLayout
-        :tabs="context.profileTabs"
+        :tabs="context.generateProfileTabs()"
         :active-tab-key="context.extractActiveTabKeyFromRoute()"
         @change-tab="context.changeTab({
           fromTab: $event.fromTab,
@@ -242,7 +242,7 @@ export default defineComponent({
         <template #contents>
           <ProfileFinancialOverview :profile-overview="context.profileOverview" />
 
-          <ProfileTransferHistory />
+          <ProfileTransferHistory v-if="context.isParticipatingInArena()" />
 
           <ProfileOrders
             :profile-orders="context.profileOrders"

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -228,7 +228,7 @@ export default defineComponent({
 
     <section class="section">
       <h1 class="heading">
-        Current Arena
+        Trade Overview
       </h1>
 
       <AppTabLayout


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5894

# How

* Show the profile trade overview even after the competition ended.

# Screenshots

## Before

If competition ends, hide trade overview section.

<img width="1214" height="968" alt="image" src="https://github.com/user-attachments/assets/fd57ca3f-eeec-4787-8460-ebb7d4f5de84" />

## After

Trade overview section will be displayed normally. "Transfer history" tab is still removed.

<img width="1251" height="969" alt="image" src="https://github.com/user-attachments/assets/99be1452-8c8d-43e0-a843-e53ab9a76d2c" />
