### PR TITLE
Treat 0 as eligible value when formatting metrics

### DIFF
--- a/app/FinancialMetricNormalizer.js
+++ b/app/FinancialMetricNormalizer.js
@@ -38,7 +38,7 @@ export default class FinancialMetricNormalizer {
    * @returns {string}
    */
   normalizeAsPnl () {
-    if (!this.figure) {
+    if (this.figure === null) {
       return this.fallbackValue
     }
 
@@ -58,7 +58,7 @@ export default class FinancialMetricNormalizer {
    * @returns {string}
    */
   normalizeAsRoi () {
-    if (!this.figure) {
+    if (this.figure === null) {
       return this.fallbackValue
     }
 
@@ -79,7 +79,7 @@ export default class FinancialMetricNormalizer {
    * @returns {string} Normalized performance baseline.
    */
   normalizeAsPerformanceBaseline () {
-    if (!this.figure) {
+    if (this.figure === null) {
       return this.fallbackValue
     }
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5919

# How

* No longer use fallback value `--` when the number is `0`.

# Screenshots

## Before

![](https://chiho-production.s3.ap-northeast-1.amazonaws.com/employee/image/5/8x8hB6rFNtqGKrz50UyP3uX5Mkdq5Mmz.png)

## After

<img width="1172" height="237" alt="image" src="https://github.com/user-attachments/assets/dd56100d-7f08-4e91-8e93-c9239dad4fa4" />

