### PR TITLE
Fix incorrect method name to generate profile tabs

### DIFF
--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -232,7 +232,7 @@ export default defineComponent({
       </h1>
 
       <AppTabLayout
-        :tabs="context.generateProfileTabs()"
+        :tabs="context.generateFilteredProfileTabs()"
         :active-tab-key="context.extractActiveTabKeyFromRoute()"
         @change-tab="context.changeTab({
           fromTab: $event.fromTab,


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5963

# How

* Fix incorrect method name to generate profile tabs.
