### PR TITLE
Add "text" variant for AppButton

### DIFF
--- a/components/units/AppButton.vue
+++ b/components/units/AppButton.vue
@@ -23,6 +23,7 @@ import AppButtonContext from '~/app/vue/contexts/AppButtonContext'
  * @typedef {import('vue').PropType<
  *    'filled'
  *    | 'outlined'
+ *    | 'text'
  * >} AppearancePropType
  */
 
@@ -220,6 +221,25 @@ export default defineComponent({
 
 .unit-button.outlined.error {
   border-color: var(--color-border-button-outlined-error);
+}
+
+.unit-button.text {
+  border-width: 0;
+
+  padding-block: 0.5rem;
+  padding-inline: 0.5rem;
+
+  background-color: transparent;
+}
+
+.unit-button.text:hover {
+  --color-background-button: var(--palette-layer-5);
+
+  background-color: color-mix(
+    in srgb,
+    var(--color-background-button) var(--value-button-hover-overlay-darken-opacity),
+    var(--color-background-button-hover-overlay-darken)
+  );
 }
 
 /* Rounded */


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6055

# How

* Add "text" variant for AppButton.

# Screenshots

> [!note]
> The button is the element with the icon, the label is unrelated.

<img width="117" height="80" alt="image" src="https://github.com/user-attachments/assets/8adc70be-c427-48a8-99cd-2e527f3ad8f3" />

<img width="113" height="87" alt="image" src="https://github.com/user-attachments/assets/6aeca988-e341-4608-a855-8dc0d0d773a5" />

