### PR TITLE
Implement feature to sort table column

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -25,6 +25,14 @@ export const ORDINAL_SUFFIX_HASH = {
   OTHER: 'th',
 }
 
+// 'ASC' and 'DESC' are basic sort options of SQL.
+export const SORT_DIRECTION_OPTION = /** @type {const} */ ({
+  ASC: 'asc',
+  DESC: 'desc',
+})
+
+export const DEFAULT_TABLE_SORT_QUERY_KEY = 'q'
+
 export const COMPETITION_STATUS = {
   CREATED: {
     ID: 1,

--- a/app/constants.js
+++ b/app/constants.js
@@ -27,8 +27,8 @@ export const ORDINAL_SUFFIX_HASH = {
 
 // 'ASC' and 'DESC' are basic sort options of SQL.
 export const SORT_DIRECTION_OPTION = /** @type {const} */ ({
-  ASC: 'asc',
-  DESC: 'desc',
+  ASC: 'ASC',
+  DESC: 'DESC',
 })
 
 export const DEFAULT_TABLE_SORT_QUERY_KEY = 'q'

--- a/app/vue/contexts/AppTableContext.js
+++ b/app/vue/contexts/AppTableContext.js
@@ -140,7 +140,9 @@ export default class AppTableContext extends BaseAppContext {
         this.filterStateReactive.sortOption.orderBy = newSortOption.orderBy
       },
       {
+        deep: true,
         immediate: true,
+        once: true,
       }
     )
 

--- a/app/vue/contexts/AppTableContext.js
+++ b/app/vue/contexts/AppTableContext.js
@@ -1,3 +1,7 @@
+import {
+  SORT_DIRECTION_OPTION,
+} from '~/app/constants'
+
 import BaseAppContext from '~/app/vue/contexts/BaseAppContext'
 
 /**
@@ -6,6 +10,63 @@ import BaseAppContext from '~/app/vue/contexts/BaseAppContext'
  * @extends {BaseAppContext<null>}
  */
 export default class AppTableContext extends BaseAppContext {
+  /**
+   * Constructor
+   *
+   * @param {AppTableContextParams} params - Parameters of this constructor.
+   */
+  constructor ({
+    props,
+    componentContext,
+
+    route,
+    router,
+    filterStateReactive,
+  }) {
+    super({
+      props,
+      componentContext,
+    })
+
+    this.route = route
+    this.router = router
+    this.filterStateReactive = filterStateReactive
+  }
+
+  /**
+   * Factory method to create a new instance of this class.
+   *
+   * @template {X extends typeof AppTableContext ? X : never} T, X
+   * @override
+   * @param {AppTableContextFactoryParams} params - Parameters of this factory method.
+   * @returns {InstanceType<T>} An instance of this class.
+   * @this {T}
+   */
+  static create ({
+    props,
+    componentContext,
+    route,
+    router,
+    filterStateReactive,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        props,
+        componentContext,
+        route,
+        router,
+        filterStateReactive,
+      })
+    )
+  }
+
+  /** @override */
+  static get EMIT_EVENT_NAME () {
+    return {
+      SORT_COLUMN: 'sortColumn',
+    }
+  }
+
   /**
    * get: entries
    *
@@ -49,6 +110,15 @@ export default class AppTableContext extends BaseAppContext {
    */
   get shouldHideHeaderCells () {
     return this.props.shouldHideHeaderCells
+  }
+
+  /**
+   * get: sortQueryKey
+   *
+   * @returns {string}
+   */
+  get sortQueryKey () {
+    return this.props.sortQueryKey
   }
 
   /**
@@ -102,7 +172,79 @@ export default class AppTableContext extends BaseAppContext {
       'text-center': columnOptions.textAlign === 'center',
     }
   }
+
+  /**
+   * Sort column.
+   *
+   * @param {{
+   *   key: string
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  sortColumn ({
+    key,
+  }) {
+    const {
+      orderBy: currentSortDirection,
+    } = this.filterStateReactive.sortOption
+
+    const newSortDirection = currentSortDirection === SORT_DIRECTION_OPTION.ASC
+      ? SORT_DIRECTION_OPTION.DESC
+      : SORT_DIRECTION_OPTION.ASC
+
+    this.filterStateReactive.sortOption.targetColumn = key
+    this.filterStateReactive.sortOption.orderBy = newSortDirection
+
+    this.emitSortColumn({
+      sortOption: {
+        targetColumn: key,
+        orderBy: newSortDirection,
+      },
+    })
+
+    this.router.push({
+      query: {
+        ...this.route.query,
+        [this.sortQueryKey]: encodeURIComponent(`${key}:${newSortDirection}`),
+      },
+    })
+  }
+
+  /**
+   * Emit 'sortColumn' event.
+   *
+   * @param {{
+   *   sortOption: SortOption
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  emitSortColumn ({
+    sortOption,
+  }) {
+    this.emit(
+      this.EMIT_EVENT_NAME.SORT_COLUMN,
+      sortOption
+    )
+  }
 }
+
+/**
+ * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams & {
+ *   route: ReturnType<import('vue-router').useRoute>
+ *   router: ReturnType<import('vue-router').useRouter>
+ *   filterStateReactive: import('vue').Reactive<FilterState>
+ * }} AppTableContextParams
+ */
+
+/**
+ * @typedef {AppTableContextParams} AppTableContextFactoryParams
+ */
+
+/**
+ * @typedef {{
+ *   sortOption: SortOption
+ * }} FilterState
+ */
 
 /**
  * @typedef {{
@@ -112,4 +254,11 @@ export default class AppTableContext extends BaseAppContext {
  *     textAlign: 'start' | 'end' | 'center'
  *   }
  * }} HeaderEntry
+ */
+
+/**
+ * @typedef {{
+ *   targetColumn: string | null
+ *   orderBy: string
+ * }} SortOption
  */

--- a/app/vue/contexts/AppTableContext.js
+++ b/app/vue/contexts/AppTableContext.js
@@ -174,6 +174,20 @@ export default class AppTableContext extends BaseAppContext {
   }
 
   /**
+   * Generate slot name for filter element in header cell.
+   *
+   * @param {{
+   *   key: string
+   * }} params - Parameters
+   * @returns {string}
+   */
+  generateHeaderFilterSlotName ({
+    key,
+  }) {
+    return `head-${key}-filter`
+  }
+
+  /**
    * Sort column.
    *
    * @param {{
@@ -226,6 +240,46 @@ export default class AppTableContext extends BaseAppContext {
       sortOption
     )
   }
+
+  /**
+   * Check if the table is being sorted in ascending direction.
+   *
+   * @param {{
+   *   key: string
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isAscendinglySorted ({
+    key,
+  }) {
+    const {
+      targetColumn,
+      orderBy,
+    } = this.filterStateReactive.sortOption
+
+    return targetColumn === key
+      && orderBy === SORT_DIRECTION_OPTION.ASC
+  }
+
+  /**
+   * Check if the table is being sorted in descending direction.
+   *
+   * @param {{
+   *   key: string
+   * }} params - Parameters.
+   * @returns {boolean}
+   */
+  isDescendinglySorted ({
+    key,
+  }) {
+    const {
+      targetColumn,
+      orderBy,
+    } = this.filterStateReactive.sortOption
+
+    return targetColumn === key
+      && orderBy === SORT_DIRECTION_OPTION.DESC
+  }
 }
 
 /**
@@ -253,6 +307,7 @@ export default class AppTableContext extends BaseAppContext {
  *   columnOptions?: {
  *     textAlign: 'start' | 'end' | 'center'
  *   }
+ *   isSortable?: boolean
  * }} HeaderEntry
  */
 

--- a/app/vue/contexts/AppTableContext.js
+++ b/app/vue/contexts/AppTableContext.js
@@ -122,6 +122,32 @@ export default class AppTableContext extends BaseAppContext {
   }
 
   /**
+   * Setup component.
+   *
+   * @template {X extends AppTableContext ? X : never} T, X
+   * @override
+   * @this {T}
+   */
+  setupComponent () {
+    this.watch(
+      () => this.extractSortOptionFromRoute(),
+      newSortOption => {
+        if (!newSortOption) {
+          return
+        }
+
+        this.filterStateReactive.sortOption.targetColumn = newSortOption.targetColumn
+        this.filterStateReactive.sortOption.orderBy = newSortOption.orderBy
+      },
+      {
+        immediate: true,
+      }
+    )
+
+    return this
+  }
+
+  /**
    * Check if table is empty.
    *
    * @returns {boolean} `true` if is empty.
@@ -239,6 +265,33 @@ export default class AppTableContext extends BaseAppContext {
       this.EMIT_EVENT_NAME.SORT_COLUMN,
       sortOption
     )
+  }
+
+  /**
+   * Extract sort option from route.
+   *
+   * @returns {SortOption | null}
+   */
+  extractSortOptionFromRoute () {
+    const {
+      [this.sortQueryKey]: sortOptionFromRoute,
+    } = this.route.query
+
+    const sortOption = Array.isArray(sortOptionFromRoute)
+      ? sortOptionFromRoute.at(0)
+      : sortOptionFromRoute
+
+    if (!sortOption) {
+      return null
+    }
+
+    const decodedSortOption = decodeURIComponent(sortOption)
+    const [targetColumn, orderBy] = decodedSortOption.split(':')
+
+    return {
+      targetColumn,
+      orderBy,
+    }
   }
 
   /**

--- a/app/vue/contexts/AppTableContext.js
+++ b/app/vue/contexts/AppTableContext.js
@@ -224,13 +224,9 @@ export default class AppTableContext extends BaseAppContext {
   sortColumn ({
     key,
   }) {
-    const {
-      orderBy: currentSortDirection,
-    } = this.filterStateReactive.sortOption
-
-    const newSortDirection = currentSortDirection === SORT_DIRECTION_OPTION.ASC
-      ? SORT_DIRECTION_OPTION.DESC
-      : SORT_DIRECTION_OPTION.ASC
+    const newSortDirection = this.generateNextSortDirection({
+      columnName: key,
+    })
 
     this.filterStateReactive.sortOption.targetColumn = key
     this.filterStateReactive.sortOption.orderBy = newSortDirection
@@ -265,6 +261,31 @@ export default class AppTableContext extends BaseAppContext {
       this.EMIT_EVENT_NAME.SORT_COLUMN,
       sortOption
     )
+  }
+
+  /**
+   * Generate value of what the next sort direction is going to be.
+   *
+   * @param {{
+   *   columnName: string
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  generateNextSortDirection ({
+    columnName,
+  }) {
+    const {
+      targetColumn,
+      orderBy,
+    } = this.filterStateReactive.sortOption
+
+    if (columnName !== targetColumn) {
+      return SORT_DIRECTION_OPTION.DESC
+    }
+
+    return orderBy === SORT_DIRECTION_OPTION.ASC
+      ? SORT_DIRECTION_OPTION.DESC
+      : SORT_DIRECTION_OPTION.ASC
   }
 
   /**

--- a/components/units/AppTable.vue
+++ b/components/units/AppTable.vue
@@ -1,11 +1,22 @@
 <script>
 import {
   defineComponent,
+  reactive,
 } from 'vue'
+
+import {
+  useRoute,
+  useRouter,
+} from 'vue-router'
 
 import {
   Icon,
 } from '#components'
+
+import {
+  DEFAULT_TABLE_SORT_QUERY_KEY,
+  SORT_DIRECTION_OPTION,
+} from '~/app/constants'
 
 import AppTableContext from '~/app/vue/contexts/AppTableContext'
 
@@ -43,15 +54,38 @@ export default defineComponent({
       required: false,
       default: false,
     },
+    sortQueryKey: {
+      type: String,
+      required: false,
+      default: DEFAULT_TABLE_SORT_QUERY_KEY,
+    },
   },
+
+  emits: [
+    AppTableContext.EMIT_EVENT_NAME.SORT_COLUMN,
+  ],
 
   setup (
     props,
     componentContext
   ) {
+    const route = useRoute()
+    const router = useRouter()
+
+    /** @type {import('vue').Reactive<import('~/app/vue/contexts/AppTableContext').FilterState>} */
+    const filterStateReactive = reactive({
+      sortOption: {
+        targetColumn: null,
+        orderBy: SORT_DIRECTION_OPTION.DESC,
+      },
+    })
+
     const args = {
       props,
       componentContext,
+      route,
+      router,
+      filterStateReactive,
     }
     const context = AppTableContext.create(args)
       .setupComponent()

--- a/components/units/AppTable.vue
+++ b/components/units/AppTable.vue
@@ -13,6 +13,8 @@ import {
   Icon,
 } from '#components'
 
+import AppButton from '~/components/units/AppButton.vue'
+
 import {
   DEFAULT_TABLE_SORT_QUERY_KEY,
   SORT_DIRECTION_OPTION,
@@ -23,6 +25,7 @@ import AppTableContext from '~/app/vue/contexts/AppTableContext'
 export default defineComponent({
   components: {
     Icon,
+    AppButton,
   },
 
   props: {
@@ -131,6 +134,53 @@ export default defineComponent({
                   :name="`head-${headerEntry.key}`"
                 >
                   {{ headerEntry.label }}
+                </slot>
+
+                <slot
+                  :name="context.generateHeaderFilterSlotName({
+                    key: headerEntry.key,
+                  })"
+                >
+                  <div
+                    class="unit-filters head"
+                    :class="{
+                      hidden: !headerEntry.isSortable,
+                    }"
+                  >
+                    <AppButton
+                      type="button"
+                      appearance="text"
+                      class="button sort"
+                      :class="{
+                        asc: context.isAscendinglySorted({
+                          key: headerEntry.key,
+                        }),
+                        desc: context.isDescendinglySorted({
+                          key: headerEntry.key,
+                        }),
+                      }"
+                      is-rounded
+                      @click="context.sortColumn({
+                        key: headerEntry.key,
+                      })"
+                    >
+                      <Icon
+                        name="heroicons:arrows-up-down"
+                        class="icon"
+                        size="1rem"
+                      />
+                      <Icon
+                        name="heroicons:bars-arrow-down"
+                        class="icon desc"
+                        size="1rem"
+                      />
+                      <Icon
+                        name="heroicons:bars-arrow-up"
+                        class="icon asc"
+                        size="1rem"
+                      />
+                    </AppButton>
+                  </div>
                 </slot>
               </div>
             </th>
@@ -337,5 +387,25 @@ export default defineComponent({
   min-height: 14rem;
 
   color: var(--color-text-secondary);
+}
+
+.unit-filters.head.hidden {
+  display: none;
+}
+
+.unit-filters.head > .button.sort.desc .icon:not(.desc) {
+  display: none;
+}
+
+.unit-filters.head > .button.sort.asc .icon:not(.asc) {
+  display: none;
+}
+
+.unit-filters.head > .button.sort:not(.asc, .desc) .icon:where(.asc, .desc) {
+  display: none;
+}
+
+.unit-filters.head > .button.sort:not(.asc, .desc) .icon {
+  color: var(--color-text-tertiary);
 }
 </style>

--- a/components/units/AppTable.vue
+++ b/components/units/AppTable.vue
@@ -90,13 +90,15 @@ export default defineComponent({
                 columnOptions: headerEntry.columnOptions,
               })"
             >
-              <slot
-                :label="headerEntry.label"
-                :property="headerEntry.key"
-                :name="`head-${headerEntry.key}`"
-              >
-                {{ headerEntry.label }}
-              </slot>
+              <div class="content">
+                <slot
+                  :label="headerEntry.label"
+                  :property="headerEntry.key"
+                  :name="`head-${headerEntry.key}`"
+                >
+                  {{ headerEntry.label }}
+                </slot>
+              </div>
             </th>
           </tr>
         </thead>
@@ -198,6 +200,14 @@ export default defineComponent({
   display: none;
 }
 
+.unit-table > .thead > .row > .cell.head > .content {
+  display: grid;
+  grid-auto-flow: column;
+  justify-content: start;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .unit-table > .tbody > .row > .cell {
   padding-block: 0.75rem;
 }
@@ -223,12 +233,24 @@ export default defineComponent({
   text-align: start;
 }
 
+.unit-table > .thead > .row > .cell.text-start > .content {
+  justify-content: start;
+}
+
 .unit-table > :where(.thead, .tbody) > .row > .cell.text-end {
   text-align: end;
 }
 
+.unit-table > .thead > .row > .cell.text-end > .content {
+  justify-content: end;
+}
+
 .unit-table > :where(.thead, .tbody) > .row > .cell.text-center {
   text-align: center;
+}
+
+.unit-table > .thead > .row > .cell.text-center > .content {
+  justify-content: center;
 }
 
 .unit-table-container:not(.empty) > .empty-container {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5997

# How

* If a table header cell entry has `isSortable`, a sort button will be shown.
* Sort option will be pushed to the URL's query with this format `?queryKey=targetColumn:orderBy`.
* `queryKey` is controlled by a prop of `<AppTable>`.

# Screenshots

<img width="1185" height="212" alt="image" src="https://github.com/user-attachments/assets/b42cba59-7ca2-4c5f-a8ca-4db4b30e8814" />

