### PR TITLE
Add universal method to shorten wallet address

### DIFF
--- a/app/vue/contexts/AppWalletAccountContext.js
+++ b/app/vue/contexts/AppWalletAccountContext.js
@@ -358,7 +358,7 @@ export default class AppWalletAccountContext extends BaseAppContext {
    * @returns {string} Source account's address.
    */
   generateLocalAccountAddress () {
-    return this.shortenAddress({
+    return this.shortenWalletAddress({
       address: this.walletStore.walletStoreRef.value
         .localWallet
         ?.address
@@ -372,37 +372,12 @@ export default class AppWalletAccountContext extends BaseAppContext {
    * @returns {string} Source account's address.
    */
   generateSourceAccountAddress () {
-    return this.shortenAddress({
+    return this.shortenWalletAddress({
       address: this.walletStore.walletStoreRef.value
         .sourceAccount
         ?.address
         ?? null,
     })
-  }
-
-  /**
-   * Shorten wallet address.
-   *
-   * @param {{
-   *   address: string | null
-   * }} params - Parameters
-   * @returns {string} Shortened address.
-   */
-  shortenAddress ({
-    address,
-  }) {
-    if (!address) {
-      return '--'
-    }
-
-    if (address.length <= 12) {
-      return address
-    }
-
-    const firstSevenCharacters = address.slice(0, 7)
-    const lastFiveCharacters = address.slice(-5)
-
-    return `${firstSevenCharacters}...${lastFiveCharacters}`
   }
 
   /**

--- a/app/vue/contexts/BaseAppContext.js
+++ b/app/vue/contexts/BaseAppContext.js
@@ -47,4 +47,46 @@ export default class BaseAppContext extends BaseFuroContext {
 
     return formatter.format(parsedValue)
   }
+
+  /**
+   * Shorten wallet address.
+   *
+   * @param {{
+   *   address?: string | null
+   *   delimiter?: string
+   *   truncationThreshold?: number
+   *   firstHalfLength?: number
+   *   secondHalfLength?: number
+   *   fallbackValue?: string
+   * }} params - Parameters.
+   * @returns {string}
+   */
+  shortenWalletAddress ({
+    address,
+    delimiter = '...',
+    truncationThreshold = 12,
+    firstHalfLength = 7,
+    secondHalfLength = 5,
+    fallbackValue = '--',
+  }) {
+    const isNotString = typeof address !== 'string'
+
+    if (!address || isNotString) {
+      return fallbackValue
+    }
+
+    if (address.length <= truncationThreshold) {
+      return address
+    }
+
+    const normalizedFirstHalfLength = Math.min(firstHalfLength, address.length)
+
+    const remainingCharacters = address.length - normalizedFirstHalfLength
+    const normalizedSecondHalfLength = Math.min(secondHalfLength, remainingCharacters)
+
+    const firstHalf = address.slice(0, normalizedFirstHalfLength)
+    const secondHalf = address.slice(-1 * normalizedSecondHalfLength)
+
+    return `${firstHalf}${delimiter}${secondHalf}`
+  }
 }

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -473,27 +473,6 @@ export default class SectionLeaderboardContext extends BaseAppContext {
   }
 
   /**
-   * Shorten wallet address.
-   *
-   * @param {{
-   *   address: string
-   * }} params - Parameters
-   * @returns {string} Shortened address.
-   */
-  shortenAddress ({
-    address,
-  }) {
-    if (address.length <= 12) {
-      return address
-    }
-
-    const firstSevenCharacters = address.slice(0, 7)
-    const lastFiveCharacters = address.slice(-5)
-
-    return `${firstSevenCharacters}...${lastFiveCharacters}`
-  }
-
-  /**
    * Generate profile's url.
    *
    * @param {{

--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -459,11 +459,7 @@ export default class SectionLeagueContext extends BaseAppContext {
   generateHostAddress () {
     const { address } = this.host ?? {}
 
-    if (!address) {
-      return '--'
-    }
-
-    return this.shortenAddress({
+    return this.shortenWalletAddress({
       address,
     })
   }
@@ -631,27 +627,6 @@ export default class SectionLeagueContext extends BaseAppContext {
     })
 
     return dateFormatter.format(date)
-  }
-
-  /**
-   * Shorten wallet address.
-   *
-   * @param {{
-   *   address: string
-   * }} params - Parameters
-   * @returns {string} Shortened address.
-   */
-  shortenAddress ({
-    address,
-  }) {
-    if (address.length <= 12) {
-      return address
-    }
-
-    const firstSevenCharacters = address.slice(0, 7)
-    const lastFiveCharacters = address.slice(-5)
-
-    return `${firstSevenCharacters}...${lastFiveCharacters}`
   }
 
   /**

--- a/app/vue/contexts/profile/ProfileTransferHistoryContext.js
+++ b/app/vue/contexts/profile/ProfileTransferHistoryContext.js
@@ -303,27 +303,6 @@ export default class ProfileTransferHistoryContext extends BaseAppContext {
   }
 
   /**
-   * Shorten wallet address.
-   *
-   * @param {{
-   *   address: string
-   * }} params - Parameters
-   * @returns {string} Shortened address.
-   */
-  shortenAddress ({
-    address,
-  }) {
-    if (address.length <= 12) {
-      return address
-    }
-
-    const firstSevenCharacters = address.slice(0, 7)
-    const lastFiveCharacters = address.slice(-5)
-
-    return `${firstSevenCharacters}...${lastFiveCharacters}`
-  }
-
-  /**
    * Generate hour.
    *
    * @param {{

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -347,7 +347,7 @@ export default defineComponent({
                 <span class="unit-address ongoing">
                   <span>
                     {{
-                      context.shortenAddress({
+                      context.shortenWalletAddress({
                         address: value,
                       })
                     }}
@@ -448,7 +448,7 @@ export default defineComponent({
                 <span class="unit-address outcome">
                   <span>
                     {{
-                      context.shortenAddress({
+                      context.shortenWalletAddress({
                         address: value,
                       })
                     }}
@@ -591,7 +591,7 @@ export default defineComponent({
                 <span class="unit-column metric address">
                   <span>
                     {{
-                      context.shortenAddress({
+                      context.shortenWalletAddress({
                         address: value,
                       })
                     }}

--- a/components/hosted-competition/HostedCompetitionDetailsContext.js
+++ b/components/hosted-competition/HostedCompetitionDetailsContext.js
@@ -179,34 +179,10 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
    * @returns {string}
    */
   generateDisplayedHostAddress () {
-    if (this.hostAddress === null) {
-      return '----'
-    }
-
-    return this.shortenAddress({
+    return this.shortenWalletAddress({
       address: this.hostAddress,
+      fallbackValue: '----',
     })
-  }
-
-  /**
-   * Shorten wallet address.
-   *
-   * @param {{
-   *   address: string
-   * }} params - Parameters
-   * @returns {string} Shortened address.
-   */
-  shortenAddress ({
-    address,
-  }) {
-    if (address.length <= 12) {
-      return address
-    }
-
-    const firstSevenCharacters = address.slice(0, 7)
-    const lastFiveCharacters = address.slice(-5)
-
-    return `${firstSevenCharacters}...${lastFiveCharacters}`
   }
 
   /**

--- a/components/hosted-competition/HostedCompetitionParticipantsContext.js
+++ b/components/hosted-competition/HostedCompetitionParticipantsContext.js
@@ -199,34 +199,10 @@ export default class HostedCompetitionParticipantsContext extends BaseAppContext
   generateDisplayedParticipantAddress ({
     address,
   }) {
-    if (address === null) {
-      return '----'
-    }
-
-    return this.shortenAddress({
+    return this.shortenWalletAddress({
       address,
+      fallbackValue: '----',
     })
-  }
-
-  /**
-   * Shorten wallet address.
-   *
-   * @param {{
-   *   address: string
-   * }} params - Parameters
-   * @returns {string} Shortened address.
-   */
-  shortenAddress ({
-    address,
-  }) {
-    if (address.length <= 12) {
-      return address
-    }
-
-    const firstSevenCharacters = address.slice(0, 7)
-    const lastFiveCharacters = address.slice(-5)
-
-    return `${firstSevenCharacters}...${lastFiveCharacters}`
   }
 
   /**

--- a/components/profile/ProfileTransferHistory.vue
+++ b/components/profile/ProfileTransferHistory.vue
@@ -102,7 +102,7 @@ export default defineComponent({
 
           <span class="address">
             {{
-              context.shortenAddress({
+              context.shortenWalletAddress({
                 address: value.address,
               })
             }}
@@ -121,7 +121,7 @@ export default defineComponent({
           <span class="hash">
             <span>
               {{
-                context.shortenAddress({
+                context.shortenWalletAddress({
                   address: value,
                 })
               }}


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6129

# How

* Add universal method to shorten wallet address.
* There is a `shortAddress()` method that does not handle fallback value, which causes the app to crash. This pull request also fixed that problem.
