### PR TITLE
Make column width of leaderboard table consistent

### DIFF
--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -166,21 +166,21 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'ongoingRank',
         label: 'Rank',
         columnOptions: {
-          width: '10%',
+          width: '8%',
         },
       },
       {
         key: 'ongoingName',
         label: 'Name',
         columnOptions: {
-          width: '20%',
+          width: '19%',
         },
       },
       {
         key: 'ongoingAddress',
         label: 'Address',
         columnOptions: {
-          width: '15%',
+          width: '16%',
         },
       },
       {
@@ -238,14 +238,14 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'participantAddress',
         label: 'Address',
         columnOptions: {
-          width: '40%',
+          width: '45%',
         },
       },
       {
         key: 'participantEquity',
         label: 'Equity',
         columnOptions: {
-          width: '20%',
+          width: '15%',
         },
       },
       {
@@ -270,7 +270,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'outcomeRank',
         label: 'Rank',
         columnOptions: {
-          width: '10%',
+          width: '8%',
         },
       },
       {
@@ -284,14 +284,14 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'outcomeAddress',
         label: 'Address',
         columnOptions: {
-          width: '14%',
+          width: '16%',
         },
       },
       {
         key: 'outcomePnl',
         label: 'PnL',
         columnOptions: {
-          width: '14%',
+          width: '16%',
           textAlign: 'end',
         },
       },
@@ -299,7 +299,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'outcomeBaseline',
         label: 'Performance Baseline',
         columnOptions: {
-          width: '14%',
+          width: '16%',
           textAlign: 'end',
         },
       },
@@ -307,7 +307,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'outcomeRoi',
         label: 'ROI',
         columnOptions: {
-          width: '14%',
+          width: '16%',
           textAlign: 'end',
         },
       },
@@ -315,7 +315,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'outcomePrize',
         label: 'Prize',
         columnOptions: {
-          width: '14%',
+          width: '8%',
           textAlign: 'end',
         },
       },

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -332,23 +332,38 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
       {
         key: 'name',
         label: 'Name',
+        columnOptions: {
+          width: '20%',
+        },
       },
       {
         key: 'address',
         label: 'Address',
+        columnOptions: {
+          width: '20%',
+        },
       },
       {
         key: 'makerVolume',
         label: 'Maker Volume',
+        columnOptions: {
+          width: '20%',
+          textAlign: 'end',
+        },
       },
       {
         key: 'takerVolume',
         label: 'Taker Volume',
+        columnOptions: {
+          width: '20%',
+          textAlign: 'end',
+        },
       },
       {
         key: 'totalVolume',
         label: 'Total Volume',
         columnOptions: {
+          width: '20%',
           textAlign: 'end',
         },
       },

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -165,19 +165,29 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
       {
         key: 'ongoingRank',
         label: 'Rank',
+        columnOptions: {
+          width: '10%',
+        },
       },
       {
         key: 'ongoingName',
         label: 'Name',
+        columnOptions: {
+          width: '20%',
+        },
       },
       {
         key: 'ongoingAddress',
         label: 'Address',
+        columnOptions: {
+          width: '15%',
+        },
       },
       {
         key: 'ongoingPnl',
         label: 'PnL',
         columnOptions: {
+          width: '15%',
           textAlign: 'end',
         },
         isSortable: true,
@@ -186,6 +196,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'ongoingBaseline',
         label: 'Performance Baseline',
         columnOptions: {
+          width: '15%',
           textAlign: 'end',
         },
       },
@@ -193,6 +204,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'ongoingRoi',
         label: 'ROI',
         columnOptions: {
+          width: '12%',
           textAlign: 'end',
         },
         isSortable: true,
@@ -201,6 +213,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'ongoingTotalVolume',
         label: 'Total Volume',
         columnOptions: {
+          width: '13%',
           textAlign: 'end',
         },
       },
@@ -217,19 +230,29 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
       {
         key: 'participantName',
         label: 'Name',
+        columnOptions: {
+          width: '20%',
+        },
       },
       {
         key: 'participantAddress',
         label: 'Address',
+        columnOptions: {
+          width: '40%',
+        },
       },
       {
         key: 'participantEquity',
         label: 'Equity',
+        columnOptions: {
+          width: '20%',
+        },
       },
       {
         key: 'participantStatus',
         label: 'Status',
         columnOptions: {
+          width: '20%',
           textAlign: 'end',
         },
       },
@@ -246,19 +269,29 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
       {
         key: 'outcomeRank',
         label: 'Rank',
+        columnOptions: {
+          width: '10%',
+        },
       },
       {
         key: 'outcomeName',
         label: 'Name',
+        columnOptions: {
+          width: '20%',
+        },
       },
       {
         key: 'outcomeAddress',
         label: 'Address',
+        columnOptions: {
+          width: '14%',
+        },
       },
       {
         key: 'outcomePnl',
         label: 'PnL',
         columnOptions: {
+          width: '14%',
           textAlign: 'end',
         },
       },
@@ -266,6 +299,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'outcomeBaseline',
         label: 'Performance Baseline',
         columnOptions: {
+          width: '14%',
           textAlign: 'end',
         },
       },
@@ -273,6 +307,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'outcomeRoi',
         label: 'ROI',
         columnOptions: {
+          width: '14%',
           textAlign: 'end',
         },
       },
@@ -280,6 +315,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'outcomePrize',
         label: 'Prize',
         columnOptions: {
+          width: '14%',
           textAlign: 'end',
         },
       },

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -187,7 +187,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'ongoingPnl',
         label: 'PnL',
         columnOptions: {
-          width: '15%',
+          width: '16%',
           textAlign: 'end',
         },
         isSortable: true,
@@ -196,7 +196,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
         key: 'ongoingBaseline',
         label: 'Performance Baseline',
         columnOptions: {
-          width: '15%',
+          width: '16%',
           textAlign: 'end',
         },
       },

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -578,7 +578,7 @@ export default defineComponent({
                   }"
                   class="unit-column metric name"
                 >
-                  <span>{{ value }}</span>
+                  <span class="content">{{ value }}</span>
                   <span class="note"> (You)</span>
                 </NuxtLink>
               </template>
@@ -1039,7 +1039,17 @@ export default defineComponent({
 
 /***************** Trading volume leaderboard ****************/
 .unit-column.metric.name {
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: 0.25rem;
+
   color: inherit;
+}
+
+.unit-column.metric.name > .content {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .unit-column.metric.name > .note {

--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -242,7 +242,7 @@ export default defineComponent({
                       address: row.participantAddress,
                     })"
                   >
-                    <span>{{ value }}</span>
+                    <span class="content">{{ value }}</span>
                     <span class="note"> (You)</span>
                   </NuxtLink>
                 </span>
@@ -311,7 +311,7 @@ export default defineComponent({
                       address: row.ongoingAddress,
                     })"
                   >
-                    <span>{{ value }}</span>
+                    <span class="content">{{ value }}</span>
                     <span class="note"> (You)</span>
                   </NuxtLink>
 
@@ -438,7 +438,7 @@ export default defineComponent({
                       address: row.outcomeAddress,
                     })"
                   >
-                    <span>{{ value }}</span>
+                    <span class="content">{{ value }}</span>
                     <span class="note"> (You)</span>
                   </NuxtLink>
                 </span>
@@ -929,6 +929,18 @@ export default defineComponent({
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
+}
+
+.unit-name > .link {
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: 0.25rem;
+}
+
+.unit-name > .link > .content {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .unit-name:where(.participant, .ongoing, .outcome) > .link {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6137

# How

* Make column width of leaderboard table consistent.

# Screenshots

## Before

<img width="1248" height="502" alt="image" src="https://github.com/user-attachments/assets/16151f54-0d17-4470-a771-b29b4fd8564f" />

## After

<img width="1231" height="498" alt="image" src="https://github.com/user-attachments/assets/eceffeb3-30b9-4f06-b109-104266742c7d" />

