### PR TITLE
Fix ongoing leaderboard is refresh when unrelated changes occur in query

### DIFF
--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -414,7 +414,17 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
 
     this.watch(
       () => this.extractOngoingLeaderboardSortFromRoute(),
-      async () => {
+      async (newSortOption, oldSortOption) => {
+        // TODO: Vue's watcher triggers on all query parameter changes, not just sort changes.
+        // The manual comparison below prevents unnecessary leaderboard fetches.
+        // Consider using a more specific watcher or computed property to track only sort changes.
+        const isSameSortOption = newSortOption?.targetColumn === oldSortOption?.targetColumn
+          && newSortOption?.orderBy === oldSortOption?.orderBy
+
+        if (isSameSortOption) {
+          return
+        }
+
         // Must fetch top three first to have correct pagination result.
         await this.fetchOngoingTopThree()
         await this.fetchOngoingLeaderboard()


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6138

# How

* Add a condition to only refresh ongoing leaderboard when sort option changes.
