### PR TITLE
Fix "transfer" tab not showing correctly

### DIFF
--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -128,7 +128,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
   }
 
   /**
-   * Generate profile tabs.
+   * Generate filtered profile tabs.
    *
    * @returns {Array<{
    *   tabKey: string
@@ -136,10 +136,6 @@ export default class ProfileDetailsContext extends BaseAppContext {
    * }>} Tabs.
    */
   generateFilteredProfileTabs () {
-    if (this.isParticipatingInArena()) {
-      return this.profileTabs
-    }
-
     return this.profileTabs.filter(tab =>
       !POST_COMPETITION_IGNORED_TABS.includes(tab.tabKey)
     )

--- a/pages/(profiles)/profiles/[address]/index.vue
+++ b/pages/(profiles)/profiles/[address]/index.vue
@@ -232,7 +232,8 @@ export default defineComponent({
       </h1>
 
       <AppTabLayout
-        :tabs="context.generateFilteredProfileTabs()"
+        v-if="context.isParticipatingInArena()"
+        :tabs="context.profileTabs"
         :active-tab-key="context.extractActiveTabKeyFromRoute()"
         @change-tab="context.changeTab({
           fromTab: $event.fromTab,
@@ -242,7 +243,31 @@ export default defineComponent({
         <template #contents>
           <ProfileFinancialOverview :profile-overview="context.profileOverview" />
 
-          <ProfileTransferHistory v-if="context.isParticipatingInArena()" />
+          <ProfileTransferHistory />
+
+          <ProfileOrders
+            :profile-orders="context.profileOrders"
+            :is-loading="context.isLoadingProfileOrders"
+          />
+
+          <ProfileTrades
+            :profile-trades="context.profileTrades"
+            :is-loading="context.isLoadingProfileTrades"
+          />
+        </template>
+      </AppTabLayout>
+
+      <AppTabLayout
+        v-if="!context.isParticipatingInArena()"
+        :tabs="context.generateFilteredProfileTabs()"
+        :active-tab-key="context.extractActiveTabKeyFromRoute()"
+        @change-tab="context.changeTab({
+          fromTab: $event.fromTab,
+          toTab: $event.toTab,
+        })"
+      >
+        <template #contents>
+          <ProfileFinancialOverview :profile-overview="context.profileOverview" />
 
           <ProfileOrders
             :profile-orders="context.profileOrders"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6170

# How

* Tab contexts are not being updated in FuroTabLayout when the "tabs" prop changes.
* This pull request applies `v-if` to the two tab components with different structure to have actual dynamic tab content.

# Screenshots

## Before

<img width="1257" height="374" alt="image" src="https://github.com/user-attachments/assets/c7292ec1-44a4-4bd3-a5c7-767641fe7a31" />

## After

<img width="1254" height="395" alt="image" src="https://github.com/user-attachments/assets/a37a03e9-05c8-4781-8bab-c0fc3e8be6f4" />

