### PR TITLE
Stop displaying redundant stage in schedule

### DIFF
--- a/app/vue/contexts/competition/SectionSchedulesContext.js
+++ b/app/vue/contexts/competition/SectionSchedulesContext.js
@@ -29,17 +29,10 @@ export default class SectionSchedulesContext extends BaseAppContext {
    * @returns {ScheduleGroups} Schedule groups.
    */
   generateScheduleGroups () {
-    const registrationSchedules = this.generateRegistrationSchedules()
     const competitionSchedules = this.generateCompetitionSchedules()
     const prizeDistributeSchedules = this.generatePrizeDistributeSchedules()
 
     return [
-      {
-        title: 'Registration Stage',
-        timeline: this.extractTimeline({
-          schedules: registrationSchedules,
-        }),
-      },
       {
         title: 'Competition Stage',
         timeline: this.extractTimeline({
@@ -68,17 +61,6 @@ export default class SectionSchedulesContext extends BaseAppContext {
     return schedules.map(it => ({
       timestamp: it.scheduledDatetime,
     }))
-  }
-
-  /**
-   * Generate registration schedules.
-   *
-   * @returns {CompetitionEntity['schedules']} Registration schedules.
-   */
-  generateRegistrationSchedules () {
-    return this.schedules.filter(
-      it => SCHEDULE_ID_GROUP.REGISTRATION.includes(it.category?.categoryId)
-    )
   }
 
   /**

--- a/components/competition-id/SectionSchedules.vue
+++ b/components/competition-id/SectionSchedules.vue
@@ -147,7 +147,7 @@ export default defineComponent({
   gap: 0.5rem;
 
   @media (48rem < width) {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 

--- a/components/competition-id/SectionSchedules.vue
+++ b/components/competition-id/SectionSchedules.vue
@@ -184,6 +184,10 @@ export default defineComponent({
   @media (48rem < width) {
     margin-inline: -0.6rem;
   }
+
+  @media (60rem <= width) {
+    margin-inline: -1rem;
+  }
 }
 
 .unit-schedules > .schedule > * {
@@ -211,11 +215,11 @@ export default defineComponent({
 
     clip-path: var(--clip-path);
 
-    padding-inline: 2rem 1.25rem;
+    padding-inline: 3rem 2rem;
   }
 
   @media (60rem < width) {
-    padding-inline: 3rem 1.5rem;
+    padding-inline: 4rem 3rem;
   }
 }
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6399

# How

* Show only competition stage and reward distribution as schedules.

# Screenshots

| Before | After |
| -- | -- |
| <img width="1920" height="359" alt="image" src="https://github.com/user-attachments/assets/57d30a7c-9b7e-4ecb-8ca3-699c93d06be6" /> | <img width="1920" height="359" alt="image" src="https://github.com/user-attachments/assets/b0739d24-218a-4715-a33a-7511039b0636" /> |