### PR TITLE
Update alternative actions during competition enrollment

### DIFF
--- a/app/vue/contexts/competition/SectionLeagueContext.js
+++ b/app/vue/contexts/competition/SectionLeagueContext.js
@@ -862,19 +862,6 @@ export default class SectionLeagueContext extends BaseAppContext {
   }
 
   /**
-   * Generate CSS classes for enrollment button.
-   *
-   * @returns {Record<string, boolean>}
-   */
-  generateEnrollButtonClasses () {
-    const enrollmentStatus = this.generateEnrollmentStatus()
-
-    return {
-      enrolled: enrollmentStatus === ENROLLMENT_STATUS.ENROLLED,
-    }
-  }
-
-  /**
    * Whether to disable enroll button or not.
    *
    * @returns {boolean}

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -164,29 +164,19 @@ export default defineComponent({
             :disabled="context.shouldDisableEnrollButton()"
             :appearance="context.generateEnrollButtonAppearance()"
             :variant="context.generateEnrollButtonVariant()"
-            :class="context.generateEnrollButtonClasses()"
             @click="context.processPrimaryAction()"
           >
             <template #startIcon>
               <Icon
-                name="heroicons:check-circle"
+                :name="context.generateEnrollButtonIconName()"
                 size="1.25rem"
-                class="icon enrolled"
-              />
-
-              <Icon
-                name="heroicons:user-minus"
-                size="1.25rem"
-                class="icon unregister"
+                class="icon"
               />
             </template>
 
             <template #default>
               <span class="content">
                 {{ context.generateEnrollButtonLabel() }}
-              </span>
-              <span class="action unregister">
-                Unregister
               </span>
             </template>
           </AppButton>
@@ -716,40 +706,6 @@ export default defineComponent({
 .unit-details > .actions > .button.enroll.neutral:disabled,
 .unit-details > .actions > .button.enroll.muted:disabled {
   filter: none;
-}
-
-.unit-details > .actions > .button.enroll .icon {
-  display: none;
-}
-
-.unit-details > .actions > .button.enroll .action {
-  display: none;
-}
-
-.unit-details > .actions > .button.enroll.enrolled .icon.enrolled {
-  display: inline;
-}
-
-.unit-details > .actions > .button.enroll.enrolled:hover {
-  border-color: var(--color-border-button-highlight-hover);
-  background-color: var(--color-background-button-highlight-hover);
-  color: var(--color-text-button-highlight-hover);
-}
-
-.unit-details > .actions > .button.enroll.enrolled:hover .icon.enrolled {
-  display: none;
-}
-
-.unit-details > .actions > .button.enroll.enrolled:hover .icon.unregister {
-  display: inline;
-}
-
-.unit-details > .actions > .button.enroll.enrolled:hover .content {
-  display: none;
-}
-
-.unit-details > .actions > .button.enroll.enrolled:hover .action.unregister {
-  display: inline;
 }
 
 .unit-details > .actions > .select .slot.default {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6645

# How

Update alternative actions during competition enrollment:
- Disallow unregistration after the competition has started.
- Update icon, label and appearance of enroll button during each competition/participant state.
- Add an alternative select button to process unregistration.
- Allow to download outcome CSV through enroll button after it becomes available.

Most of them are from cdc repository, with one tweak:
- Pressing "Deposit Now" opens TDM links to `dydx.trade` instead of using deeplink.

# Screenshots

<details><summary>Click to view screenshots</summary>

<img width="834" height="308" alt="image" src="https://github.com/user-attachments/assets/145150d2-dc49-4e6f-a697-b41730c25736" />

<img width="856" height="302" alt="image" src="https://github.com/user-attachments/assets/032d0270-63eb-4de7-a3b1-f1ea6ebbcb4a" />

<img width="837" height="292" alt="image" src="https://github.com/user-attachments/assets/2788ffb1-8149-4c34-9c1a-7b4f1f68f341" />

<img width="855" height="303" alt="image" src="https://github.com/user-attachments/assets/857e1072-081d-47c1-9153-5af82d8d701b" />

</details>