### PR TITLE
Add logic to control leaderboard sort option when a competition is created

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -31,6 +31,11 @@ export const SORT_DIRECTION_OPTION = /** @type {const} */ ({
   DESC: 'DESC',
 })
 
+export const AVAILABLE_SORT_COLUMN = {
+  ROI: 'roi',
+  PNL: 'pnl',
+}
+
 export const DEFAULT_TABLE_SORT_QUERY_KEY = 'q'
 
 export const COMPETITION_STATUS = {

--- a/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class AddCompetitionMutationGraphqlCapsule extends BaseAppGraphql
 
 /**
  * @typedef {{
- *   addCompetition: {
- *     competitionId: number
- *   }
+ *   addCompetition: schema.graphql.AddCompetitionResult
  * }} AddCompetitionMutationResponseContent
  */

--- a/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlPayload.js
@@ -20,30 +20,6 @@ export default class AddCompetitionMutationGraphqlPayload extends BaseAppSignatu
 
 /**
  * @typedef {{
- *   input: {
- *     title: string
- *     description: string
- *     minimumDeposit: string
- *     minimumTradingVolume: string
- *     totalPrize: string
- *     imageUrl?: string
- *     participantUpperLimit: number
- *     participantLowerLimit: number
- *     schedules: Array<{
- *       categoryId: number
- *       scheduledDatetime: string // ISO string
- *     }>
- *     prizeRules: Array<{
- *       rankFrom: number
- *       rankTo: number
- *       amount: string
- *     }>
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.AddCompetitionInput
  * }} AddCompetitionMutationRequestVariables
  */

--- a/components/competition-add/AddCompetitionFormStepOptions.vue
+++ b/components/competition-add/AddCompetitionFormStepOptions.vue
@@ -1,0 +1,131 @@
+<script>
+import {
+  defineComponent,
+  ref,
+} from 'vue'
+
+import {
+  Icon,
+} from '#components'
+
+import AppSelect from '~/components/units/AppSelect.vue'
+
+import {
+  AVAILABLE_SORT_COLUMN,
+  SORT_DIRECTION_OPTION,
+} from '~/app/constants'
+
+import AddCompetitionFormStepOptionsContext from './AddCompetitionFormStepOptionsContext'
+
+export default defineComponent({
+  components: {
+    Icon,
+    AppSelect,
+  },
+
+  props: {
+    isEditMode: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    initialFormValueHash: {
+      /**
+       * @type {import('vue').PropType<
+       *   import('./AddCompetitionFormStepOptionsContext').PropsType['initialFormValueHash']
+       * >}
+       */
+      type: [
+        Object,
+        null,
+      ],
+      required: false,
+      default: null,
+    },
+  },
+
+  setup (
+    props,
+    componentContext
+  ) {
+    const sortOptionRef = ref({
+      targetColumn: AVAILABLE_SORT_COLUMN.PNL,
+      orderBy: SORT_DIRECTION_OPTION.DESC,
+    })
+
+    const args = {
+      props,
+      componentContext,
+      sortOptionRef,
+    }
+    const context = AddCompetitionFormStepOptionsContext.create(args)
+      .setupComponent()
+
+    return {
+      context,
+    }
+  },
+})
+</script>
+
+<template>
+  <div class="unit-options">
+    <label class="label">
+      <Icon
+        name="heroicons:arrows-up-down"
+        size="1.25rem"
+        class="icon"
+      />
+      <span>Sort Leaderboard By</span>
+    </label>
+
+    <AppSelect
+      :items="context.leaderboardSortOptions"
+      :model-value="context.selectedTargetColumn"
+      @update:model-value="context.updateSortTargetColumn({
+        targetColumn: $event,
+      })"
+    />
+
+    <input
+      type="text"
+      :name="context.generateTargetColumnInputName()"
+      :value="context.selectedTargetColumn"
+      class="input hidden"
+    >
+    <input
+      type="text"
+      :name="context.generateOrderByInputName()"
+      :value="context.selectedOrderBy"
+      class="input hidden"
+    >
+  </div>
+</template>
+
+<style scoped>
+.unit-options {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.unit-options > .label {
+  display: inline-grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.375rem;
+
+  font-size: var(--font-size-base);
+  font-weight: 700;
+
+  color: var(--color-text-secondary);
+}
+
+.unit-options > .label > .icon {
+  color: var(--color-text-tertiary);
+}
+
+.unit-options > .input.hidden {
+  display: none;
+}
+</style>

--- a/components/competition-add/AddCompetitionFormStepOptionsContext.js
+++ b/components/competition-add/AddCompetitionFormStepOptionsContext.js
@@ -1,0 +1,238 @@
+import {
+  BaseFuroContext,
+} from '@openreachtech/furo-nuxt'
+
+import {
+  AVAILABLE_SORT_COLUMN,
+  SORT_DIRECTION_OPTION,
+} from '~/app/constants'
+
+/**
+ * AddCompetitionFormStepOptionsContext
+ *
+ * @extends {BaseFuroContext<null, PropsType, null>}
+ */
+export default class AddCompetitionFormStepOptionsContext extends BaseFuroContext {
+  /**
+   * Constructor
+   *
+   * @param {AddCompetitionFormStepOptionsContextParams} params - Parameters of this constructor.
+   */
+  constructor ({
+    props,
+    componentContext,
+
+    sortOptionRef,
+  }) {
+    super({
+      props,
+      componentContext,
+    })
+
+    this.sortOptionRef = sortOptionRef
+  }
+
+  /**
+   * Factory method to create a new instance of this class.
+   *
+   * @template {X extends typeof AddCompetitionFormStepOptionsContext ? X : never} T, X
+   * @override
+   * @param {AddCompetitionFormStepOptionsContextFactoryParams} params - Parameters of this factory method.
+   * @returns {InstanceType<T>} An instance of this class.
+   * @this {T}
+   */
+  static create ({
+    props,
+    componentContext,
+    sortOptionRef,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        props,
+        componentContext,
+        sortOptionRef,
+      })
+    )
+  }
+
+  /**
+   * get: initialFormValueHash
+   *
+   * @returns {PropsType['initialFormValueHash']}
+   */
+  get initialFormValueHash () {
+    return this.props.initialFormValueHash
+  }
+
+  /**
+   * get: initialLeaderboardSortOption
+   *
+   * @returns {schema.graphql.SortOption | null}
+   */
+  get initialLeaderboardSortOption () {
+    return this.initialFormValueHash
+      ?.leaderboardSortOption
+      ?? null
+  }
+
+  /**
+   * get: isEditMode
+   *
+   * @returns {PropsType['isEditMode']}
+   */
+  get isEditMode () {
+    return this.props.isEditMode
+  }
+
+  /**
+   * get: selectedTargetColumn
+   *
+   * @returns {string}
+   */
+  get selectedTargetColumn () {
+    return this.sortOptionRef.value.targetColumn
+  }
+
+  /**
+   * get: selectedOrderBy
+   *
+   * @returns {string}
+   */
+  get selectedOrderBy () {
+    return this.sortOptionRef.value.orderBy
+  }
+
+  /**
+   * get: leaderboardSortOptions
+   *
+   * @returns {Array<import('~/components/units/AppSelectContext').SelectOption>}
+   */
+  get leaderboardSortOptions () {
+    return [
+      {
+        label: 'PnL',
+        value: 'pnl',
+      },
+      {
+        label: 'ROI',
+        value: 'roi',
+      },
+    ]
+  }
+
+  /**
+   * Setup component.
+   *
+   * @template {X extends AddCompetitionFormStepOptionsContext ? X : never} T, X
+   * @override
+   * @this {T}
+   */
+  setupComponent () {
+    this.watch(
+      () => this.initialLeaderboardSortOption,
+      newInitialLeaderboardSortOption => {
+        if (!newInitialLeaderboardSortOption) {
+          return
+        }
+
+        const {
+          orderBy,
+          targetColumn,
+        } = newInitialLeaderboardSortOption
+
+        this.sortOptionRef.value.orderBy = orderBy
+        this.sortOptionRef.value.targetColumn = targetColumn
+      }
+    )
+
+    return this
+  }
+
+  /**
+   * Update `targetColumn` in sort option.
+   *
+   * @param {{
+   *   targetColumn: string
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  updateSortTargetColumn ({
+    targetColumn,
+  }) {
+    this.sortOptionRef.value.targetColumn = targetColumn
+  }
+
+  /**
+   * Extract initial leaderboard sort option.
+   *
+   * @returns {schema.graphql.SortOption}
+   */
+  extractInitialLeaderboardSortOption () {
+    const defaultValue = {
+      targetColumn: AVAILABLE_SORT_COLUMN.PNL,
+      orderBy: SORT_DIRECTION_OPTION.DESC,
+    }
+
+    return this.initialFormValueHash
+      ?.leaderboardSortOption
+      ?? defaultValue
+  }
+
+  /**
+   * Generate input name for orderBy.
+   *
+   * @returns {string}
+   */
+  generateOrderByInputName () {
+    const sortOptionInputName = this.generateSortOptionInputName()
+
+    return `${sortOptionInputName}.orderBy`
+  }
+
+  /**
+   * Generate input name for targetColumn.
+   *
+   * @returns {string}
+   */
+  generateTargetColumnInputName () {
+    const sortOptionInputName = this.generateSortOptionInputName()
+
+    return `${sortOptionInputName}.targetColumn`
+  }
+
+  /**
+   * Generate input name for sort option.
+   *
+   * @returns {string}
+   */
+  generateSortOptionInputName () {
+    if (this.isEditMode) {
+      return 'defaultLeaderboardSortOption'
+    }
+
+    return 'leaderboardSortOption'
+  }
+}
+
+/**
+ * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext').BaseFuroContextParams<PropsType> & {
+ *   sortOptionRef: import('vue').Ref<schema.graphql.SortOption>
+ * }} AddCompetitionFormStepOptionsContextParams
+ */
+
+/**
+ * @typedef {AddCompetitionFormStepOptionsContextParams} AddCompetitionFormStepOptionsContextFactoryParams
+ */
+
+/**
+ * @typedef {{
+ *   initialFormValueHash: InitialFormValueHash | null
+ *   isEditMode: boolean
+ * }} PropsType
+ */
+
+/**
+ * @typedef {{
+ *   leaderboardSortOption: schema.graphql.SortOption
+ * }} InitialFormValueHash
+ */

--- a/components/competition-add/AddCompetitionFormStepPrize.vue
+++ b/components/competition-add/AddCompetitionFormStepPrize.vue
@@ -96,16 +96,6 @@ export default defineComponent({
 
 <template>
   <section class="unit-section">
-    <div class="headline">
-      <h2 class="heading">
-        4. Rank & Prize
-      </h2>
-
-      <p class="description">
-        Define the total prize pool and how it will be distributed
-      </p>
-    </div>
-
     <span
       class="message error"
       :class="context.generateErrorMessageClasses({
@@ -288,20 +278,6 @@ export default defineComponent({
 
 .unit-section > .message.error.hidden {
   display: none;
-}
-
-.unit-section > .headline > .heading {
-  font-size: var(--font-size-medium);
-  font-weight: 700;
-  line-height: var(--size-line-height-medium);
-}
-
-.unit-section > .headline > .description {
-  margin-block-start: 0.25rem;
-
-  font-size: var(--font-size-small);
-
-  color: var(--color-text-tertiary);
 }
 
 .unit-section > :where(.tier, .pool) > .heading {

--- a/pages/(competitions)/competitions/add.vue
+++ b/pages/(competitions)/competitions/add.vue
@@ -18,6 +18,7 @@ import AddCompetitionFormSteps from '~/components/competition-add/AddCompetition
 import AddCompetitionFormStepDetails from '~/components/competition-add/AddCompetitionFormStepDetails.vue'
 import AddCompetitionFormStepTimeline from '~/components/competition-add/AddCompetitionFormStepTimeline.vue'
 import AddCompetitionFormStepParticipation from '~/components/competition-add/AddCompetitionFormStepParticipation.vue'
+import AddCompetitionFormStepOptions from '~/components/competition-add/AddCompetitionFormStepOptions.vue'
 import AddCompetitionFormStepPrize from '~/components/competition-add/AddCompetitionFormStepPrize.vue'
 
 import AddCompetitionMutationGraphqlLauncher from '~/app/graphql/client/mutations/addCompetition/AddCompetitionMutationGraphqlLauncher'
@@ -45,6 +46,7 @@ export default defineComponent({
     AddCompetitionFormStepDetails,
     AddCompetitionFormStepTimeline,
     AddCompetitionFormStepParticipation,
+    AddCompetitionFormStepOptions,
     AddCompetitionFormStepPrize,
   },
 
@@ -139,13 +141,26 @@ export default defineComponent({
               :validation-message="context.addCompetitionValidationMessage"
             />
 
-            <AddCompetitionFormStepPrize
-              class="step"
+            <div
+              class="unit-form-group step"
               :class="context.generateStepClasses({
                 step: 4,
               })"
-              :validation-message="context.addCompetitionValidationMessage"
-            />
+            >
+              <div class="headline">
+                <h2 class="heading">
+                  4. Rank & Prize
+                </h2>
+
+                <p class="description">
+                  Define the total prize pool and how it will be distributed
+                </p>
+              </div>
+
+              <AddCompetitionFormStepOptions :validation-message="context.addCompetitionValidationMessage" />
+
+              <AddCompetitionFormStepPrize :validation-message="context.addCompetitionValidationMessage" />
+            </div>
           </div>
 
           <div class="unit-actions">
@@ -270,6 +285,30 @@ export default defineComponent({
 
 .unit-form > .steps > .content > .step.hidden {
   visibility: hidden;
+}
+
+.unit-form-group:not(.hidden) {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.unit-form-group > .headline > .heading {
+  font-size: var(--font-size-medium);
+  font-weight: 700;
+  line-height: var(--size-line-height-medium);
+}
+
+.unit-form-group > .headline > .description {
+  margin-block-start: 0.25rem;
+
+  font-size: var(--font-size-small);
+
+  color: var(--color-text-tertiary);
+}
+
+.unit-form-group > .unit-form:last-of-type {
+  flex: 1;
 }
 
 .unit-actions {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6667

# How

* Add logic to control leaderboard sort option when a competition is created.

# Screenshots

<img width="1297" height="784" alt="Screenshot 2025-09-25 at 17 50 45" src="https://github.com/user-attachments/assets/01d08948-d773-4b3e-8253-ccc9b00a01bb" />
