### PR TITLE
Make sort option editable when updating a competition's details

### DIFF
--- a/app/domClerk/UpdateCompetitionOptionsFormElementClerk.js
+++ b/app/domClerk/UpdateCompetitionOptionsFormElementClerk.js
@@ -1,0 +1,24 @@
+import BaseFilteredFormElementClerk from '~/app/domClerk/BaseFilteredFormElementClerk'
+
+/**
+ * UpdateCompetitionPrizeRulesFormElementClerk.
+ *
+ * @extends {BaseFilteredFormElementClerk<typeof UpdateCompetitionPrizeRulesFormElementClerk, UpdateCompetitionPrizeRulesFormValueHash, SchemaVariableHash>}
+ */
+export default class UpdateCompetitionPrizeRulesFormElementClerk extends BaseFilteredFormElementClerk {
+  /** @override */
+  static get rules () {
+    /**
+     * @type {Array<furo.FieldValidatorFactoryParams>}
+     */
+    return []
+  }
+}
+
+/**
+ * @typedef {{}} UpdateCompetitionPrizeRulesFormValueHash
+ */
+
+/**
+ * @typedef {{}} SchemaVariableHash
+ */

--- a/app/graphql/client/mutations/updateCompetitionOptions/UpdateCompetitionOptionsMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/updateCompetitionOptions/UpdateCompetitionOptionsMutationGraphqlCapsule.js
@@ -1,0 +1,36 @@
+import BaseAppGraphqlCapsule from '~/app/graphql/client/BaseAppGraphqlCapsule'
+
+/**
+ * UpdateCompetitionOptions mutation graphql capsule.
+ *
+ * @extends {BaseAppGraphqlCapsule<UpdateCompetitionOptionsMutationResponseContent>}
+ */
+export default class UpdateCompetitionOptionsMutationGraphqlCapsule extends BaseAppGraphqlCapsule {
+  /**
+   * Extract updateCompetitionOptions response content.
+   *
+   * @returns {schema.graphql.UpdateCompetitionOptionsResult | null}
+   */
+  extractUpdateCompetitionOptionsValueHash () {
+    return this.extractContent()
+      ?.updateCompetitionOptions
+      ?? null
+  }
+
+  /**
+   * get: success
+   *
+   * @returns {boolean}
+   */
+  get success () {
+    return this.extractUpdateCompetitionOptionsValueHash()
+      ?.success
+      ?? false
+  }
+}
+
+/**
+ * @typedef {{
+ *   updateCompetitionOptions: schema.graphql.UpdateCompetitionOptionsResult
+ * }} UpdateCompetitionOptionsMutationResponseContent
+ */

--- a/app/graphql/client/mutations/updateCompetitionOptions/UpdateCompetitionOptionsMutationGraphqlLauncher.js
+++ b/app/graphql/client/mutations/updateCompetitionOptions/UpdateCompetitionOptionsMutationGraphqlLauncher.js
@@ -1,0 +1,21 @@
+import BaseAppGraphqlLauncher from '~/app/graphql/client/BaseAppGraphqlLauncher'
+
+import UpdateCompetitionOptionsMutationGraphqlPayload from './UpdateCompetitionOptionsMutationGraphqlPayload'
+import UpdateCompetitionOptionsMutationGraphqlCapsule from './UpdateCompetitionOptionsMutationGraphqlCapsule'
+
+/**
+ * UpdateCompetitionOptions mutation graphql launcher.
+ *
+ * @extends {BaseAppGraphqlLauncher}
+ */
+export default class UpdateCompetitionOptionsMutationGraphqlLauncher extends BaseAppGraphqlLauncher {
+  /** @override */
+  static get Payload () {
+    return UpdateCompetitionOptionsMutationGraphqlPayload
+  }
+
+  /** @override */
+  static get Capsule () {
+    return UpdateCompetitionOptionsMutationGraphqlCapsule
+  }
+}

--- a/app/graphql/client/mutations/updateCompetitionOptions/UpdateCompetitionOptionsMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/updateCompetitionOptions/UpdateCompetitionOptionsMutationGraphqlPayload.js
@@ -1,0 +1,25 @@
+import BaseAppSignatureGraphqlPayload from '~/app/graphql/client/BaseAppSignatureGraphqlPayload'
+
+/**
+ * UpdateCompetitionOptions mutation payload.
+ *
+ * @extends {BaseAppSignatureGraphqlPayload<UpdateCompetitionOptionsMutationRequestVariables>}
+ */
+export default class UpdateCompetitionOptionsMutationGraphqlPayload extends BaseAppSignatureGraphqlPayload {
+  /** @override */
+  static get document () {
+    return /* GraphQL */ `
+      mutation UpdateCompetitionOptionsMutation ($input: UpdateCompetitionOptionsInput!) {
+        updateCompetitionOptions (input: $input) {
+          success
+        }
+      }
+    `
+  }
+}
+
+/**
+ * @typedef {{
+ *   input: schema.graphql.UpdateCompetitionOptionsInput
+ * }} UpdateCompetitionOptionsMutationRequestVariables
+ */

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditMutationContext.js
@@ -24,6 +24,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseAppContex
     updateCompetitionFormShallowRef,
     updateCompetitionSchedulesFormShallowRef,
     updateCompetitionLimitsFormShallowRef,
+    updateCompetitionOptionsFormShallowRef,
     updateCompetitionPrizeRulesFormShallowRef,
   }) {
     super({
@@ -40,6 +41,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseAppContex
     this.updateCompetitionFormShallowRef = updateCompetitionFormShallowRef
     this.updateCompetitionSchedulesFormShallowRef = updateCompetitionSchedulesFormShallowRef
     this.updateCompetitionLimitsFormShallowRef = updateCompetitionLimitsFormShallowRef
+    this.updateCompetitionOptionsFormShallowRef = updateCompetitionOptionsFormShallowRef
     this.updateCompetitionPrizeRulesFormShallowRef = updateCompetitionPrizeRulesFormShallowRef
   }
 
@@ -64,6 +66,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseAppContex
     updateCompetitionFormShallowRef,
     updateCompetitionSchedulesFormShallowRef,
     updateCompetitionLimitsFormShallowRef,
+    updateCompetitionOptionsFormShallowRef,
     updateCompetitionPrizeRulesFormShallowRef,
   }) {
     return /** @type {InstanceType<T>} */ (
@@ -79,6 +82,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseAppContex
         updateCompetitionFormShallowRef,
         updateCompetitionSchedulesFormShallowRef,
         updateCompetitionLimitsFormShallowRef,
+        updateCompetitionOptionsFormShallowRef,
         updateCompetitionPrizeRulesFormShallowRef,
       })
     )
@@ -236,6 +240,15 @@ export default class CompetitionDetailsEditMutationContext extends BaseAppContex
   get updateCompetitionLimitsFormElement () {
     return this.updateCompetitionLimitsFormShallowRef
       .value
+  }
+
+  /**
+   * get: updateCompetitionOptionsFormElement
+   *
+   * @returns {HTMLFormElement | null}
+   */
+  get updateCompetitionOptionsFormElement () {
+    return this.updateCompetitionOptionsFormShallowRef.value
   }
 
   /**
@@ -459,6 +472,15 @@ export default class CompetitionDetailsEditMutationContext extends BaseAppContex
   }
 
   /**
+   * Submit the competition options form.
+   *
+   * @returns {void}
+   */
+  submitOptionsForm () {
+    this.updateCompetitionOptionsFormElement?.requestSubmit()
+  }
+
+  /**
    * get: updateCompetitionPrizeRulesLauncherHooks
    *
    * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
@@ -514,6 +536,7 @@ export default class CompetitionDetailsEditMutationContext extends BaseAppContex
  *   updateCompetitionFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
  *   updateCompetitionSchedulesFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
  *   updateCompetitionLimitsFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
+ *   updateCompetitionOptionsFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
  *   updateCompetitionPrizeRulesFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
  * }} CompetitionDetailsEditMutationContextParams
  */

--- a/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/CompetitionDetailsEditPageContext.js
@@ -156,6 +156,25 @@ export default class CompetitionDetailsEditPageContext extends BaseAppContext {
   }
 
   /**
+   * Generate initial form value hash for step options.
+   *
+   * @returns {import('~/components/competition-add/AddCompetitionFormStepOptionsContext').InitialFormValueHash | null}
+   */
+  generateStepOptionsInitialValueHash () {
+    const {
+      defaultLeaderboardSortOption,
+    } = this.competitionDetailsEditCapsule
+
+    if (!defaultLeaderboardSortOption) {
+      return null
+    }
+
+    return {
+      leaderboardSortOption: defaultLeaderboardSortOption,
+    }
+  }
+
+  /**
    * Generate initial form value hash for step prize.
    *
    * @returns {import('~/components/competition-add/AddCompetitionFormStepPrizeContext').InitialFormValueHash}

--- a/pages/(competitions)/competitions/[competitionId]/edit/UpdateCompetitionOptionsSubmitterContext.js
+++ b/pages/(competitions)/competitions/[competitionId]/edit/UpdateCompetitionOptionsSubmitterContext.js
@@ -1,0 +1,142 @@
+export default class UpdateCompetitionOptionsSubmitterContext {
+  /**
+   * Constructor
+   *
+   * @param {UpdateCompetitionOptionsSubmitterContextParams} params - Parameters.
+   */
+  constructor ({
+    toastStore,
+    statusReactive,
+    updateCompetitionOptionsFormShallowRef,
+    graphqlClientHash,
+    formClerkHash,
+  }) {
+    this.toastStore = toastStore
+    this.statusReactive = statusReactive
+    this.updateCompetitionOptionsFormShallowRef = updateCompetitionOptionsFormShallowRef
+    this.graphqlClientHash = graphqlClientHash
+    this.formClerkHash = formClerkHash
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof UpdateCompetitionOptionsSubmitterContext ? X : never} T, X
+   * @param {UpdateCompetitionOptionsSubmitterContextFactoryParams} params - Parameters.
+   * @returns {InstanceType<T>} An instance of this class.
+   * @this {T}
+   */
+  static create ({
+    toastStore,
+    statusReactive,
+    updateCompetitionOptionsFormShallowRef,
+    graphqlClientHash,
+    formClerkHash,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        toastStore,
+        statusReactive,
+        updateCompetitionOptionsFormShallowRef,
+        graphqlClientHash,
+        formClerkHash,
+      })
+    )
+  }
+
+  /**
+   * get: updateCompetitionOptionsFormElement
+   *
+   * @returns {HTMLFormElement | null}
+   */
+  get updateCompetitionOptionsFormElement () {
+    return this.updateCompetitionOptionsFormShallowRef.value
+  }
+
+  /**
+   * get: updateCompetitionOptionsLauncherHooks
+   *
+   * @returns {furo.GraphqlLauncherHooks} Launcher hooks.
+   */
+  get updateCompetitionOptionsLauncherHooks () {
+    return {
+      beforeRequest: async payload => {
+        this.statusReactive.isUpdatingCompetitionOptions = true
+
+        return false
+      },
+      /**
+       * @type {(capsule: import('~/app/graphql/client/mutations/updateCompetitionOptions/UpdateCompetitionOptionsMutationGraphqlCapsule').default) => Promise<void>}
+       */
+      // @ts-expect-error: Upstream type mismatch.
+      afterRequest: async capsule => {
+        this.statusReactive.isUpdatingCompetitionOptions = false
+
+        if (capsule.hasError()) {
+          const errorMessage = capsule.getResolvedErrorMessage()
+
+          this.toastStore.add({
+            message: errorMessage,
+            color: 'error',
+          })
+        }
+      },
+    }
+  }
+
+  /**
+   * get: updateCompetitionOptionsCapsule
+   *
+   * @returns {import('~/app/graphql/client/mutations/updateCompetitionOptions/UpdateCompetitionOptionsMutationGraphqlCapsule').default}
+   */
+  get updateCompetitionOptionsCapsule () {
+    return this.graphqlClientHash
+      .updateCompetitionOptions
+      .capsuleRef
+      .value
+  }
+
+  /**
+   * Submit form to update competition options.
+   *
+   * @returns {Promise<void>}
+   */
+  async submitUpdateCompetitionOptionsForm () {
+    if (!this.updateCompetitionOptionsFormElement) {
+      return
+    }
+
+    await this.formClerkHash
+      .updateCompetitionOptions
+      .submitForm({
+        formElement: this.updateCompetitionOptionsFormElement,
+        hooks: this.updateCompetitionOptionsLauncherHooks,
+      })
+  }
+}
+
+/**
+ * @typedef {{
+ *   toastStore: import('~/stores/toast').ToastStore
+ *   statusReactive: import('vue').Reactive<Record<string, boolean>>
+ *   updateCompetitionOptionsFormShallowRef: import('vue').ShallowRef<HTMLFormElement | null>
+ *   graphqlClientHash: {
+ *     updateCompetitionOptions: GraphqlClient
+ *   }
+ *   formClerkHash: {
+ *     updateCompetitionOptions: FormClerk
+ *   }
+ * }} UpdateCompetitionOptionsSubmitterContextParams
+ */
+
+/**
+ * @typedef {UpdateCompetitionOptionsSubmitterContextParams} UpdateCompetitionOptionsSubmitterContextFactoryParams
+ */
+
+/**
+ * @typedef {ReturnType<import('@openreachtech/furo-nuxt').useGraphqlClient>} GraphqlClient
+ */
+
+/**
+ * @typedef {ReturnType<import('~/composables/useAppFormClerk').default>} FormClerk
+ */


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6668

# How

* Make leaderboard sort option updatable by using UpdateCompetitionOptions query.

# Screenshots

<img width="1297" height="784" alt="image" src="https://github.com/user-attachments/assets/d4f1671f-32e4-4bb2-aa05-08a6b90fb095" />
