### PR TITLE
Don't invoke form submission on select

### DIFF
--- a/components/units/AppSelect.vue
+++ b/components/units/AppSelect.vue
@@ -128,6 +128,7 @@ export default defineComponent({
     >
       <slot name="default">
         <AppButton
+          type="button"
           :is-rounded="context.isRounded"
           variant="muted"
           :disabled="context.isDisabled"


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6737

# How

* Add `type="button"` to the default trigger button of `<AppSelect>` so that form is not submitted because of it.

> [!note]
> I double-checked for side effect. This is safe.
