### PR TITLE
Display minimum deposit instead of minimum trading volume during registration

### DIFF
--- a/components/dialogs/EnrollmentVerificationDialog.vue
+++ b/components/dialogs/EnrollmentVerificationDialog.vue
@@ -188,7 +188,7 @@ export default defineComponent({
             />
 
             <span class="figure">
-              {{ context.formatCurrentEquity() }} <span class="total">/ {{ context.formatMinimumTradingVolume() }} USDC</span>
+              {{ context.formatCurrentEquity() }} <span class="total">/ {{ context.formatMinimumDeposit() }} USDC</span>
             </span>
           </div>
 

--- a/components/dialogs/EnrollmentVerificationDialogContext.js
+++ b/components/dialogs/EnrollmentVerificationDialogContext.js
@@ -76,6 +76,17 @@ export default class EnrollmentVerificationDialogContext extends BaseAppContext 
   }
 
   /**
+   * get: minimumDeposit
+   *
+   * @returns {string | null}
+   */
+  get minimumDeposit () {
+    return this.competition
+      ?.minimumDeposit
+      ?? null
+  }
+
+  /**
    * get: minimumTradingVolume
    *
    * @returns {string | null}
@@ -252,6 +263,17 @@ export default class EnrollmentVerificationDialogContext extends BaseAppContext 
 
     return this.formatNumber({
       value: this.currentEquity,
+    })
+  }
+
+  /**
+   * Format minimum deposit amount.
+   *
+   * @returns {string} The formatted minimum deposit amount.
+   */
+  formatMinimumDeposit () {
+    return this.formatNumber({
+      value: this.minimumDeposit,
     })
   }
 


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/6774

# How

* Correct value to display is minimum equity, not trading volume.
