### PR TITLE
Display second ranker on the left instead of right

### DIFF
--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -824,7 +824,7 @@ export default defineComponent({
 
 .unit-leaderboard > .champions > .champion:first-of-type {
   @media (48rem < width) {
-    order: 1;
+    order: 2;
 
     margin-inline: -4rem;
   }
@@ -838,7 +838,7 @@ export default defineComponent({
   @media (48rem < width) {
     margin-block-start: 15rem;
 
-    order: 2;
+    order: 1;
   }
 
   @media (60rem < width) {
@@ -854,7 +854,7 @@ export default defineComponent({
   @media (48rem < width) {
     margin-block-start: 15.5rem;
 
-    order: 0;
+    order: 3;
   }
 
   @media (60rem < width) {


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/7059

# How

* Reverse position of top 2 and 3 rankers. Top 2 is now on the left instead of right.

# Screenshots

| Before | After |
|--------|--------|
| <img width="1216" height="490" alt="image" src="https://github.com/user-attachments/assets/430f6fa8-11c8-46da-b1d3-fe12f51ded5c" /> | <img width="1274" height="589" alt="image" src="https://github.com/user-attachments/assets/aeb58abb-ab68-4ba3-be50-682b99ee348d" /> |