### PR TITLE
Update label of pnl ranking leaderboard tab

### DIFF
--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -228,7 +228,7 @@ export default class SectionLeaderboardContext extends BaseAppContext {
     return [
       {
         tabKey: 'pnl',
-        label: 'PnL Ranking',
+        label: 'PnL/ROI Ranking',
       },
       {
         tabKey: 'metrics',


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/7058

# How

* `PnL Ranking` → `PnL/ROI Ranking`.

# Screenshots

| Before | After |
|--------|--------|
| <img width="390" height="90" alt="image" src="https://github.com/user-attachments/assets/60378fc0-6d5b-46b4-b9f5-ea051f4f0a95" /> | <img width="403" height="91" alt="image" src="https://github.com/user-attachments/assets/671d9d15-546a-40a5-b737-2fce98ef728b" /> |
