### PR TITLE
Use generated types in `schema.graphql` instead of self-declared types

### DIFF
--- a/app/graphql/client/mutations/bulkUpdateParticipantStatus/BulkUpdateParticipantStatusMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/bulkUpdateParticipantStatus/BulkUpdateParticipantStatusMutationGraphqlCapsule.js
@@ -33,8 +33,6 @@ export default class BulkUpdateParticipantStatusMutationGraphqlCapsule extends B
 
 /**
  * @typedef {{
- *   bulkUpdateParticipantStatus: {
- *     success: boolean
- *   }
+ *   bulkUpdateParticipantStatus: schema.graphql.BulkUpdateParticipantStatusResult
  * }} ResponseContent
  */

--- a/app/graphql/client/mutations/bulkUpdateParticipantStatus/BulkUpdateParticipantStatusMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/bulkUpdateParticipantStatus/BulkUpdateParticipantStatusMutationGraphqlPayload.js
@@ -20,15 +20,6 @@ export default class BulkUpdateParticipantStatusMutationGraphqlPayload extends B
 
 /**
  * @typedef {{
- *   input: {
- *     competitionParticipantIds: Array<number>
- *     statusId: number
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.BulkUpdateParticipantStatusInput
  * }} BulkUpdateParticipantStatusMutationRequestVariables
  */

--- a/app/graphql/client/mutations/generateXaccountOauthUrl/GenerateXaccountOauthUrlMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/generateXaccountOauthUrl/GenerateXaccountOauthUrlMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class GenerateXaccountOauthUrlMutationGraphqlCapsule extends Base
 
 /**
  * @typedef {{
- *   generateXaccountOauthUrl: {
- *     url: string
- *   }
+ *   generateXaccountOauthUrl: schema.graphql.GenerateXaccountOauthUrlResult
  * }} GenerateXaccountOauthUrlMutationResponseContent
  */

--- a/app/graphql/client/mutations/generateXaccountOauthUrl/GenerateXaccountOauthUrlMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/generateXaccountOauthUrl/GenerateXaccountOauthUrlMutationGraphqlPayload.js
@@ -20,13 +20,6 @@ export default class GenerateXaccountOauthUrlMutationGraphqlPayload extends Base
 
 /**
  * @typedef {{
- *   input: {
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.GenerateXaccountOauthUrlInput
  * }} GenerateXaccountOauthUrlMutationRequestVariables
  */

--- a/app/graphql/client/mutations/joinCompetition/JoinCompetitionMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/joinCompetition/JoinCompetitionMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class JoinCompetitionMutationGraphqlCapsule extends BaseAppGraphq
 
 /**
  * @typedef {{
- *   joinCompetition: {
- *     competitionId: number
- *   }
+ *   joinCompetition: schema.graphql.JoinCompetitionResult
  * }} JoinCompetitionMutationResponseContent
  */

--- a/app/graphql/client/mutations/joinCompetition/JoinCompetitionMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/joinCompetition/JoinCompetitionMutationGraphqlPayload.js
@@ -39,15 +39,6 @@ export default class JoinCompetitionMutationGraphqlPayload extends BaseAppSignat
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     name: string
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.JoinCompetitionInput
  * }} JoinCompetitionMutationRequestVariables
  */

--- a/app/graphql/client/mutations/putAddressImage/PutAddressImageMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/putAddressImage/PutAddressImageMutationGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class PutAddressImageMutationGraphqlCapsule extends BaseAppGraphq
   /**
    * Extract `putAddressImage` response content as value hash.
    *
-   * @returns {PutAddressImage | null}
+   * @returns {schema.graphql.PutAddressImageResult | null}
    */
   extractPutAddressImageValueHash () {
     return this.extractContent()
@@ -31,12 +31,6 @@ export default class PutAddressImageMutationGraphqlCapsule extends BaseAppGraphq
 
 /**
  * @typedef {{
- *   putAddressImage: PutAddressImage
+ *   putAddressImage: schema.graphql.PutAddressImageResult
  * }} PutAddressImageMutationResponseContent
- */
-
-/**
- * @typedef {{
- *   addressImageUrl: string
- * }} PutAddressImage
  */

--- a/app/graphql/client/mutations/putAddressImage/PutAddressImageMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/putAddressImage/PutAddressImageMutationGraphqlPayload.js
@@ -20,14 +20,6 @@ export default class PutAddressImageMutationGraphqlPayload extends BaseAppSignat
 
 /**
  * @typedef {{
- *   input: {
- *     file: File
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.PutAddressImageInput
  * }} PutAddressImageMutationRequestVariables
  */

--- a/app/graphql/client/mutations/putAddressName/PutAddressNameMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/putAddressName/PutAddressNameMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class PutAddressNameMutationGraphqlCapsule extends BaseAppGraphql
 
 /**
  * @typedef {{
- *   putAddressName: {
- *     addressId: number
- *   }
+ *   putAddressName: schema.graphql.putAddressNameResult
  * }} PutAddressNameMutationResponseContent
  */

--- a/app/graphql/client/mutations/putAddressName/PutAddressNameMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/putAddressName/PutAddressNameMutationGraphqlPayload.js
@@ -39,14 +39,6 @@ export default class PutAddressNameMutationGraphqlPayload extends BaseAppSignatu
 
 /**
  * @typedef {{
- *   input: {
- *     name: string
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.putAddressNameInput
  * }} PutAddressNameMutationRequestVariables
  */

--- a/app/graphql/client/mutations/revokeXaccountOauth/RevokeXaccountOauthMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/revokeXaccountOauth/RevokeXaccountOauthMutationGraphqlCapsule.js
@@ -42,9 +42,6 @@ export default class RevokeXaccountOauthMutationGraphqlCapsule extends BaseAppGr
 
 /**
  * @typedef {{
- *   revokeXaccountOauth: {
- *     success: boolean
- *     revokedTokens: Array<string>
- *   }
+ *   revokeXaccountOauth: schema.graphql.RevokeXaccountOauthResult
  * }} RevokeXaccountOauthMutationResponseContent
  */

--- a/app/graphql/client/mutations/revokeXaccountOauth/RevokeXaccountOauthMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/revokeXaccountOauth/RevokeXaccountOauthMutationGraphqlPayload.js
@@ -21,13 +21,6 @@ export default class RevokeXaccountOauthMutationGraphqlPayload extends BaseAppSi
 
 /**
  * @typedef {{
- *   input: {
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.RevokeXaccountOauthInput
  * }} RevokeXaccountOauthMutationRequestVariables
  */

--- a/app/graphql/client/mutations/unregisterFromCompetition/UnregisterFromCompetitionMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/unregisterFromCompetition/UnregisterFromCompetitionMutationGraphqlCapsule.js
@@ -40,8 +40,6 @@ export default class UnregisterFromCompetitionMutationGraphqlCapsule extends Bas
 
 /**
  * @typedef {{
- *   unregisterFromCompetition: {
- *     competitionId: number
- *   }
+ *   unregisterFromCompetition: schema.graphql.UnregisterFromCompetitionResult
  * }} ResponseContent
  */

--- a/app/graphql/client/mutations/unregisterFromCompetition/UnregisterFromCompetitionMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/unregisterFromCompetition/UnregisterFromCompetitionMutationGraphqlPayload.js
@@ -20,14 +20,6 @@ export default class UnregisterFromCompetitionMutationGraphqlPayload extends Bas
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.UnregisterFromCompetitionInput
  * }} UnregisterFromCompetitionMutationRequestVariables
  */

--- a/app/graphql/client/mutations/updateCompetition/UpdateCompetitionMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/updateCompetition/UpdateCompetitionMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class UpdateCompetitionMutationGraphqlCapsule extends BaseAppGrap
 
 /**
  * @typedef {{
- *   updateCompetition: {
- *     competitionId: number
- *   }
+ *   updateCompetition: schema.graphql.UpdateCompetitionResult
  * }} UpdateCompetitionMutationResponseContent
  */

--- a/app/graphql/client/mutations/updateCompetition/UpdateCompetitionMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/updateCompetition/UpdateCompetitionMutationGraphqlPayload.js
@@ -20,21 +20,6 @@ export default class UpdateCompetitionMutationGraphqlPayload extends BaseAppSign
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     title: string
- *     description: string
- *     minimumDeposit: string
- *     totalPrize: string
- *     imageUrl?: string
- *     participantLowerLimit: number
- *     participantUpperLimit: number
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.UpdateCompetitionInput
  * }} UpdateCompetitionMutationRequestVariables
  */

--- a/app/graphql/client/mutations/updateCompetitionLimits/UpdateCompetitionLimitsMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/updateCompetitionLimits/UpdateCompetitionLimitsMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class UpdateCompetitionLimitsMutationGraphqlCapsule extends BaseA
 
 /**
  * @typedef {{
- *   updateCompetitionLimits: {
- *     competitionId: number
- *   }
+ *   updateCompetitionLimits: schema.graphql.UpdateCompetitionLimitsResult
  * }} UpdateCompetitionLimitsMutationResponseContent
  */

--- a/app/graphql/client/mutations/updateCompetitionLimits/UpdateCompetitionLimitsMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/updateCompetitionLimits/UpdateCompetitionLimitsMutationGraphqlPayload.js
@@ -20,18 +20,6 @@ export default class UpdateCompetitionLimitsMutationGraphqlPayload extends BaseA
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     participantUpperLimit: number
- *     participantLowerLimit: number
- *     minimumDeposit: string
- *     minimumTradingVolume: string
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.UpdateCompetitionLimitsInput
  * }} UpdateCompetitionLimitsMutationRequestVariables
  */

--- a/app/graphql/client/mutations/updateCompetitionPrizeRules/UpdateCompetitionPrizeRulesMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/updateCompetitionPrizeRules/UpdateCompetitionPrizeRulesMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class UpdateCompetitionPrizeRulesMutationGraphqlCapsule extends B
 
 /**
  * @typedef {{
- *   updateCompetitionPrizeRules: {
- *     competitionId: number
- *   }
+ *   updateCompetitionPrizeRules: schema.graphql.UpdateCompetitionPrizeRulesResult
  * }} UpdateCompetitionPrizeRulesMutationResponseContent
  */

--- a/app/graphql/client/mutations/updateCompetitionPrizeRules/UpdateCompetitionPrizeRulesMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/updateCompetitionPrizeRules/UpdateCompetitionPrizeRulesMutationGraphqlPayload.js
@@ -20,19 +20,6 @@ export default class UpdateCompetitionPrizeRulesMutationGraphqlPayload extends B
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     prizeRules: Array<{
- *       rankFrom: number
- *       rankTo: number
- *       amount: string
- *     }>
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.UpdateCompetitionPrizeRulesInput
  * }} UpdateCompetitionPrizeRulesMutationRequestVariables
  */

--- a/app/graphql/client/mutations/updateCompetitionSchedules/UpdateCompetitionSchedulesMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/updateCompetitionSchedules/UpdateCompetitionSchedulesMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class UpdateCompetitionSchedulesMutationGraphqlCapsule extends Ba
 
 /**
  * @typedef {{
- *   updateCompetitionSchedules: {
- *     competitionId: number
- *   }
+ *   updateCompetitionSchedules: schema.graphql.UpdateCompetitionSchedulesResult
  * }} UpdateCompetitionSchedulesMutationResponseContent
  */

--- a/app/graphql/client/mutations/updateCompetitionSchedules/UpdateCompetitionSchedulesMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/updateCompetitionSchedules/UpdateCompetitionSchedulesMutationGraphqlPayload.js
@@ -20,18 +20,6 @@ export default class UpdateCompetitionSchedulesMutationGraphqlPayload extends Ba
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     schedules: Array<{
- *       categoryId: number
- *       scheduledDatetime: string
- *     }>
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.UpdateCompetitionSchedulesInput
  * }} UpdateCompetitionSchedulesMutationRequestVariables
  */

--- a/app/graphql/client/mutations/updateCompetitionStatus/UpdateCompetitionStatusMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/updateCompetitionStatus/UpdateCompetitionStatusMutationGraphqlCapsule.js
@@ -31,8 +31,6 @@ export default class UpdateCompetitionStatusMutationGraphqlCapsule extends BaseA
 
 /**
  * @typedef {{
- *   updateCompetitionStatus: {
- *     competitionId: number
- *   }
+ *   updateCompetitionStatus: schema.graphql.UpdateCompetitionStatusResult
  * }} UpdateCompetitionStatusMutationResponseContent
  */

--- a/app/graphql/client/mutations/updateCompetitionStatus/UpdateCompetitionStatusMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/updateCompetitionStatus/UpdateCompetitionStatusMutationGraphqlPayload.js
@@ -20,15 +20,6 @@ export default class UpdateCompetitionStatusMutationGraphqlPayload extends BaseA
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     statusId: number
- *     signature: {
- *       signDoc: string
- *       signature: string
- *       publicKey: string
- *       address: string
- *     }
- *   }
+ *   input: schema.graphql.UpdateCompetitionStatusInput
  * }} UpdateCompetitionStatusMutationRequestVariables
  */

--- a/app/graphql/client/mutations/uploadImage/UploadImageMutationGraphqlCapsule.js
+++ b/app/graphql/client/mutations/uploadImage/UploadImageMutationGraphqlCapsule.js
@@ -64,11 +64,6 @@ export default class UploadImageMutationGraphqlCapsule extends BaseAppGraphqlCap
 
 /**
  * @typedef {{
- *   uploadImage: {
- *     imageId: number
- *     contentType: string
- *     image: string
- *     imageUrl: string
- *   }
+ *   uploadImage: schema.graphql.UploadImageResult
  * }} UploadImageMutationResponseContent
  */

--- a/app/graphql/client/mutations/uploadImage/UploadImageMutationGraphqlPayload.js
+++ b/app/graphql/client/mutations/uploadImage/UploadImageMutationGraphqlPayload.js
@@ -23,8 +23,6 @@ export default class UploadImageMutationGraphqlPayload extends BaseAppGraphqlPay
 
 /**
  * @typedef {{
- *   input: {
- *     file: File
- *   }
+ *   input: schema.graphql.UploadImageInput
  * }} UploadImageMutationRequestVariables
  */

--- a/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class AddressCurrentCompetitionQueryGraphqlCapsule extends BaseAp
   /**
    * Extract addressCurrentCompetition value hash.
    *
-   * @returns {AddressCurrentCompetitionQueryResponseContent['addressCurrentCompetition'] | null}
+   * @returns {schema.graphql.AddressCurrentCompetitionResult | null}
    */
   extractAddressCurrentCompetitionValueHash () {
     const content = this.extractContent()
@@ -21,7 +21,7 @@ export default class AddressCurrentCompetitionQueryGraphqlCapsule extends BaseAp
   /**
    * get: competition
    *
-   * @returns {Competition}
+   * @returns {schema.graphql.CompetitionSummary | null}
    */
   get competition () {
     return this.extractAddressCurrentCompetitionValueHash()
@@ -43,7 +43,7 @@ export default class AddressCurrentCompetitionQueryGraphqlCapsule extends BaseAp
   /**
    * get: ranking
    *
-   * @returns {Ranking}
+   * @returns {schema.graphql.CompetitionRanking | null}
    */
   get ranking () {
     return this.extractAddressCurrentCompetitionValueHash()
@@ -54,53 +54,6 @@ export default class AddressCurrentCompetitionQueryGraphqlCapsule extends BaseAp
 
 /**
  * @typedef {{
- *   addressCurrentCompetition: {
- *     competition?: Competition
- *     ranking?: Ranking
- *   }
+ *   addressCurrentCompetition: schema.graphql.AddressCurrentCompetitionResult
  * }} AddressCurrentCompetitionQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   competitionId: number
- *   title: string
- *   description: string
- *   participantUpperLimit: number
- *   participantLowerLimit: number
- *   host: {
- *     address: string
- *     name?: string
- *   }
- *   totalPrize: string
- *   minimumDeposit: string
- *   imageUrl?: string
- *   schedules: Array<{
- *     category: {
- *       categoryId: number
- *       name: string
- *       description: string
- *     }
- *     scheduledDatetime: string
- *   }>
- *   status: {
- *     statusId: number
- *     name: string
- *     phasedAt: string // ISO String
- *   }
- * } | null} Competition
- */
-
-/**
- * @typedef {{
- *   address: Array<{
- *     address: string
- *     name: string
- *   }>
- *   performanceBaseline: number
- *   ranking: number
- *   roi: number
- *   pnl: number
- *   calculatedAt: string // ISO String
- * } | null} Ranking
  */

--- a/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlPayload.js
@@ -57,8 +57,6 @@ export default class AddressCurrentCompetitionQueryGraphqlPayload extends BaseAp
 
 /**
  * @typedef {{
- *   input: {
- *     address: string
- *   }
+ *   input: schema.graphql.AddressCurrentCompetitionInput
  * }} AddressCurrentCompetitionQueryRequestVariables
  */

--- a/app/graphql/client/queries/addressCurrentCompetitionTransfers/AddressCurrentCompetitionTransfersQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/addressCurrentCompetitionTransfers/AddressCurrentCompetitionTransfersQueryGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class AddressCurrentCompetitionTransfersQueryGraphqlCapsule exten
   /**
    * Extract addressCurrentCompetitionTransfers value hash.
    *
-   * @returns {ResponseContent['addressCurrentCompetitionTransfers'] | null}
+   * @returns {schema.graphql.AddressCurrentCompetitionTransfersResult | null}
    */
   extractAddressCurrentCompetitionTransfersValueHash () {
     const content = this.extractContent()
@@ -21,7 +21,7 @@ export default class AddressCurrentCompetitionTransfersQueryGraphqlCapsule exten
   /**
    * get: transfers
    *
-   * @returns {ResponseContent['addressCurrentCompetitionTransfers']['transfers']}
+   * @returns {Array<schema.graphql.CompetitionTransfer>}
    */
   get transfers () {
     return this.extractAddressCurrentCompetitionTransfersValueHash()
@@ -32,7 +32,7 @@ export default class AddressCurrentCompetitionTransfersQueryGraphqlCapsule exten
   /**
    * get: pagination
    *
-   * @returns {ResponseContent['addressCurrentCompetitionTransfers']['pagination'] | null}
+   * @returns {schema.graphql.Pagination | null}
    */
   get pagination () {
     return this.extractAddressCurrentCompetitionTransfersValueHash()
@@ -43,7 +43,7 @@ export default class AddressCurrentCompetitionTransfersQueryGraphqlCapsule exten
   /**
    * get: totalCount
    *
-   * @returns {ResponseContent['addressCurrentCompetitionTransfers']['pagination']['totalCount'] | null}
+   * @returns {number | null}
    */
   get totalCount () {
     return this.pagination
@@ -54,25 +54,6 @@ export default class AddressCurrentCompetitionTransfersQueryGraphqlCapsule exten
 
 /**
  * @typedef {{
- *   addressCurrentCompetitionTransfers: {
- *     transfers: Array<{
- *       blockHeight: number
- *       blockTime: string // ISO String
- *       category: {
- *         categoryId: number
- *         name: string
- *         description: string
- *       }
- *       amount: string
- *       senderAddress: string
- *       recipientAddress: string
- *       transactionHash: string
- *     }>
- *     pagination: {
- *       totalCount: number
- *       limit: number
- *       offset: number
- *     }
- *   }
+ *   addressCurrentCompetitionTransfers: schema.graphql.AddressCurrentCompetitionTransfersResult
  * }} ResponseContent
  */

--- a/app/graphql/client/queries/addressCurrentCompetitionTransfers/AddressCurrentCompetitionTransfersQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressCurrentCompetitionTransfers/AddressCurrentCompetitionTransfersQueryGraphqlPayload.js
@@ -37,16 +37,6 @@ export default class AddressCurrentCompetitionTransfersQueryGraphqlPayload exten
 
 /**
  * @typedef {{
- *   input: {
- *     address: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         targetColumn: string
- *         orderBy: string
- *       }
- *     }
- *   }
+ *   input: schema.graphql.AddressCurrentCompetitionTransfersInput
  * }} AddressCurrentCompetitionTransfersQueryRequestVariables
  */

--- a/app/graphql/client/queries/addressName/AddressNameQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/addressName/AddressNameQueryGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class AddressNameQueryGraphqlCapsule extends BaseAppGraphqlCapsul
   /**
    * Extract `addressName` value hash.
    *
-   * @returns {AddressNameQueryResponseContent['addressName'] | null}
+   * @returns {schema.graphql.AddressNameResult | null}
    */
   extractAddressNameValueHash () {
     return this.extractContent()
@@ -20,7 +20,7 @@ export default class AddressNameQueryGraphqlCapsule extends BaseAppGraphqlCapsul
   /**
    * get: name
    *
-   * @returns {AddressNameQueryResponseContent['addressName']['name']}
+   * @returns {string | null}
    */
   get name () {
     return this.extractAddressNameValueHash()
@@ -31,8 +31,6 @@ export default class AddressNameQueryGraphqlCapsule extends BaseAppGraphqlCapsul
 
 /**
  * @typedef {{
- *   addressName: {
- *     name: string | null
- *   }
+ *   addressName: schema.graphql.AddressNameResult
  * }} AddressNameQueryResponseContent
  */

--- a/app/graphql/client/queries/addressName/AddressNameQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressName/AddressNameQueryGraphqlPayload.js
@@ -20,8 +20,6 @@ export default class AddressNameQueryGraphqlPayload extends BaseAppGraphqlPayloa
 
 /**
  * @typedef {{
- *   input: {
- *     address: string
- *   }
+ *   input: schema.graphql.AddressNameInput
  * }} AddressNameQueryRequestVariables
  */

--- a/app/graphql/client/queries/addressPastCompetitions/AddressPastCompetitionsQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/addressPastCompetitions/AddressPastCompetitionsQueryGraphqlCapsule.js
@@ -43,46 +43,6 @@ export default class AddressPastCompetitionsQueryGraphqlCapsule extends BaseAppG
 
 /**
  * @typedef {{
- *   addressPastCompetitions: {
- *     competitions: Array<{
- *       competition: {
- *         competitionId: number
- *         title: string
- *         description: string
- *         participantUpperLimit: number
- *         participantLowerLimit: number
- *         host: {
- *           address: string
- *           name?: string
- *         }
- *         totalPrize: string
- *         minimumDeposit: string
- *         imageUrl?: string
- *         schedules: Array<{
- *           category: {
- *             categoryId: string
- *             name: string
- *             description: string
- *           }
- *           scheduledDatetime: string
- *         }>
- *         status: {
- *           statusId: number
- *           name: string
- *           phasedAt: string // ISO String
- *         }
- *       }
- *       rank: number
- *       prize: string
- *       performanceBaseline: number
- *       roi: number
- *       pnl: number
- *     }>
- *     pagination: {
- *       totalCount: number
- *       limit: number
- *       offset: number
- *     }
- *   }
+ *   addressPastCompetitions: schema.graphql.AddressPastCompetitionsResult
  * }} AddressPastCompetitionsQueryResponseContent
  */

--- a/app/graphql/client/queries/addressPastCompetitions/AddressPastCompetitionsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressPastCompetitions/AddressPastCompetitionsQueryGraphqlPayload.js
@@ -58,16 +58,6 @@ export default class AddressPastCompetitionsQueryGraphqlPayload extends BaseAppG
 
 /**
  * @typedef {{
- *   input: {
- *     address: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         targetColumn: string
- *         orderBy: string
- *       }
- *     }
- *   }
+ *   input: schema.graphql.AddressPastCompetitionsInput
  * }} AddressPastCompetitionsQueryRequestVariables
  */

--- a/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class AddressProfileQueryGraphqlCapsule extends BaseAppGraphqlCap
   /**
    * Extract `addressProfile` response content as value hash.
    *
-   * @returns {AddressProfile | null} `addressProfile` value hash.
+   * @returns {schema.graphql.AddressProfileResult | null} `addressProfile` value hash.
    */
   extractAddressProfileValueHash () {
     return this.extractContent()
@@ -64,15 +64,6 @@ export default class AddressProfileQueryGraphqlCapsule extends BaseAppGraphqlCap
 
 /**
  * @typedef {{
- *   addressProfile: AddressProfile
+ *   addressProfile: schema.graphql.AddressProfileResult
  * }} AddressProfileQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   address: string
- *   name?: string
- *   addressImageUrl?: string
- *   xAccountUserName?: string
- * }} AddressProfile
  */

--- a/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlPayload.js
@@ -23,8 +23,6 @@ export default class AddressProfileQueryGraphqlPayload extends BaseAppGraphqlPay
 
 /**
  * @typedef {{
- *   input: {
- *     address: string
- *   }
+ *   input: schema.graphql.AddressProfileInput
  * }} AddressProfileQueryRequestVariables
  */

--- a/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
   /**
    * Extract competition.
    *
-   * @returns {CompetitionEntity | null} Competition object.
+   * @returns {schema.graphql.Competition | null} Competition object.
    */
   extractCompetition () {
     const content = this.extractContent()
@@ -78,7 +78,7 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
   /**
    * get: schedules
    *
-   * @returns {CompetitionEntity['schedules']} Schedules as an array.
+   * @returns {Array<schema.graphql.CompetitionSchedule>} Schedules as an array.
    */
   get schedules () {
     return this.extractCompetition()
@@ -89,7 +89,7 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
   /**
    * get: prizeRules
    *
-   * @returns {CompetitionEntity['prizeRules']} Prize rules as an array.
+   * @returns {Array<schema.graphql.CompetitionPrizeRule>} Prize rules as an array.
    */
   get prizeRules () {
     return this.extractCompetition()
@@ -134,7 +134,7 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
   /**
    * get: host
    *
-   * @returns {Host | null}
+   * @returns {schema.graphql.AddressSummary | null}
    */
   get host () {
     return this.extractCompetition()
@@ -178,7 +178,7 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
   /**
    * get: defaultLeaderboardSortOption
    *
-   * @returns {SortOption | null}
+   * @returns {schema.graphql.SortOption | null}
    */
   get defaultLeaderboardSortOption () {
     return this.extractCompetition()
@@ -189,69 +189,6 @@ export default class CompetitionQueryGraphqlCapsule extends BaseAppGraphqlCapsul
 
 /**
  * @typedef {{
- *   competition: {
- *     competition: CompetitionEntity
- *   }
+ *   competition: schema.graphql.CompetitionResult
  * }} CompetitionQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   competitionId: number
- *   title: string
- *   description: string
- *   participantUpperLimit: number
- *   participantLowerLimit: number
- *   host: Host
- *   totalPrize: number
- *   minimumDeposit: string
- *   minimumTradingVolume: string
- *   imageUrl?: string
- *   schedules: Array<Schedule>
- *   status: Status
- *   prizeRules: Array<PrizeRule>
- *   outcomeCsvUrl?: string
- *   defaultLeaderboardSortOption: SortOption
- * }} CompetitionEntity
- */
-
-/**
- * @typedef {{
- *   address: string
- *   name: string
- * }} Host
- */
-
-/**
- * @typedef {{
- *   category: {
- *     categoryId: number
- *     name: string
- *     description: string
- *   }
- *   scheduledDatetime: string
- * }} Schedule
- */
-
-/**
- * @typedef {{
- *   rankFrom: number
- *   rankTo: number
- *   amount: string
- * }} PrizeRule
- */
-
-/**
- * @typedef {{
- *   statusId: number
- *   name: string
- *   phasedAt: string
- * }} Status
- */
-
-/**
- * @typedef {{
- *   targetColumn: string
- *   orderBy: string
- * }} SortOption
  */

--- a/app/graphql/client/queries/competition/CompetitionQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competition/CompetitionQueryGraphqlPayload.js
@@ -57,8 +57,6 @@ export default class CompetitionQueryGraphqlPayload extends BaseAppGraphqlPayloa
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *   }
+ *   input: schema.graphql.CompetitionInput
  * }} CompetitionQueryRequestVariables
  */

--- a/app/graphql/client/queries/competitionCurrentDynamicPrizeRule/CompetitionCurrentDynamicPrizeRuleQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionCurrentDynamicPrizeRule/CompetitionCurrentDynamicPrizeRuleQueryGraphqlCapsule.js
@@ -31,7 +31,7 @@ export default class CompetitionCurrentDynamicPrizeRuleQueryGraphqlCapsule exten
   /**
    * get: currentDynamicPrizeRule
    *
-   * @returns {Array<CompetitionDynamicPrizeRule>}
+   * @returns {Array<schema.graphql.CompetitionDynamicPrizeRule>}
    * @todo: Should be plural "rules", but keeping the same with Backend for now.
    */
   get currentDynamicPrizeRule () {
@@ -43,31 +43,6 @@ export default class CompetitionCurrentDynamicPrizeRuleQueryGraphqlCapsule exten
 
 /**
  * @typedef {{
- *   competitionCurrentDynamicPrizeRule: {
- *     currentTradingVolumeUsd: string
- *     currentDynamicPrizeRule: Array<CompetitionDynamicPrizeRule>
- *   }
+ *   competitionCurrentDynamicPrizeRule: schema.graphql.CompetitionCurrentDynamicPrizeRuleResult
  * }} CompetitionCurrentDynamicPrizeRuleQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   targetTradingVolumeUsd: string
- *   competitionPrizeCategory: {
- *     categoryId: number
- *     name: string
- *     description: string
- *   }
- *   rankFrom: number
- *   rankTo: number
- *   amount: string
- * }} CompetitionDynamicPrizeRule
- */
-
-/**
- * @typedef {{
- *   categoryId: number
- *   name: string
- *   description: string
- * }} CompetitionPrizeCategory
  */

--- a/app/graphql/client/queries/competitionCurrentDynamicPrizeRule/CompetitionCurrentDynamicPrizeRuleQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionCurrentDynamicPrizeRule/CompetitionCurrentDynamicPrizeRuleQueryGraphqlPayload.js
@@ -31,8 +31,6 @@ export default class CompetitionCurrentDynamicPrizeRuleQueryGraphqlPayload exten
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *   }
+ *   input: schema.graphql.CompetitionCurrentDynamicPrizeRuleInput
  * }} CompetitionCurrentDynamicPrizeRuleQueryRequestVariables
  */

--- a/app/graphql/client/queries/competitionEnrolledParticipantsNumber/CompetitionEnrolledParticipantsNumberQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionEnrolledParticipantsNumber/CompetitionEnrolledParticipantsNumberQueryGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class CompetitionEnrolledParticipantsNumberQueryGraphqlCapsule ex
   /**
    * Extract `competitionEnrolledParticipantsNumber`.
    *
-   * @returns {CompetitionEnrolledParticipantsNumber | null}
+   * @returns {schema.graphql.CompetitionEnrolledParticipantsNumberResult | null}
    */
   extractCompetitionEnrolledParticipantsNumber () {
     return this.extractContent()
@@ -31,12 +31,6 @@ export default class CompetitionEnrolledParticipantsNumberQueryGraphqlCapsule ex
 
 /**
  * @typedef {{
- *   competitionEnrolledParticipantsNumber: CompetitionEnrolledParticipantsNumber
+ *   competitionEnrolledParticipantsNumber: schema.graphql.CompetitionEnrolledParticipantsNumberResult
  * }} CompetitionEnrolledParticipantsNumberQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   enrolledParticipantsNumber: number
- * }} CompetitionEnrolledParticipantsNumber
  */

--- a/app/graphql/client/queries/competitionEnrolledParticipantsNumber/CompetitionEnrolledParticipantsNumberQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionEnrolledParticipantsNumber/CompetitionEnrolledParticipantsNumberQueryGraphqlPayload.js
@@ -20,8 +20,6 @@ export default class CompetitionEnrolledParticipantsNumberQueryGraphqlPayload ex
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *   }
+ *   input: schema.graphql.CompetitionEnrolledParticipantsNumberInput
  * }} CompetitionEnrolledParticipantsNumberQueryRequestVariables
  */

--- a/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlCapsule.js
@@ -20,7 +20,7 @@ export default class CompetitionFinalOutcomeQueryGraphqlCapsule extends BaseAppG
   /**
    * get: myOutcome
    *
-   * @returns {Outcome | null}
+   * @returns {schema.graphql.CompetitionFinalOutcome | null}
    */
   get myOutcome () {
     return this.extractCompetitionFinalOutcome()
@@ -31,7 +31,7 @@ export default class CompetitionFinalOutcomeQueryGraphqlCapsule extends BaseAppG
   /**
    * get: outcomes
    *
-   * @returns {Array<Outcome>} List of outcomes
+   * @returns {Array<schema.graphql.CompetitionFinalOutcome>} List of outcomes
    */
   get outcomes () {
     return this.extractCompetitionFinalOutcome()
@@ -42,7 +42,7 @@ export default class CompetitionFinalOutcomeQueryGraphqlCapsule extends BaseAppG
   /**
    * get: pagination
    *
-   * @returns {Pagination | null} Pagination information
+   * @returns {schema.graphql.Pagination | null} Pagination information
    */
   get pagination () {
     return this.extractCompetitionFinalOutcome()
@@ -86,32 +86,6 @@ export default class CompetitionFinalOutcomeQueryGraphqlCapsule extends BaseAppG
 
 /**
  * @typedef {{
- *   competitionFinalOutcome: {
- *     myOutcome: Outcome | null
- *     outcomes: Array<Outcome>
- *     pagination: Pagination
- *   }
+ *   competitionFinalOutcome: schema.graphql.CompetitionFinalOutcomeResult
  * }} CompetitionFinalOutcomeResponseContent
- */
-
-/**
- * @typedef {{
- *   address: {
- *     address: string
- *     name: string
- *   }
- *   ranking: number
- *   performanceBaseline: number
- *   prizeUsdAmount: string
- *   pnl: number
- *   roi: number
- * }} Outcome
- */
-
-/**
- * @typedef {{
- *   totalCount: number
- *   limit: number
- *   offset: number
- * }} Pagination
  */

--- a/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlPayload.js
@@ -46,17 +46,6 @@ export default class CompetitionFinalOutcomeQueryGraphqlPayload extends BaseAppG
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     address?: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         targetColumn: string
- *         orderBy: string
- *       }
- *     }
- *   }
+ *   input: schema.graphql.CompetitionFinalOutcomeInput
  * }} CompetitionFinalOutcomeRequestVariables
  */

--- a/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlCapsule.js
@@ -77,29 +77,6 @@ export default class CompetitionLeaderboardQueryGraphqlCapsule extends BaseAppGr
 
 /**
  * @typedef {{
- *   competitionLeaderboard: {
- *     myRanking: CompetitionRanking
- *     rankings: Array<CompetitionRanking>
- *     pagination: {
- *       totalCount: number
- *       limit: number
- *       offset: number
- *     }
- *   }
+ *   competitionLeaderboard: schema.graphql.CompetitionLeaderboardResult
  * }} ResponseContent
- */
-
-/**
- * @typedef {{
- *   address: {
- *     address: string
- *     name?: string
- *   }
- *   performanceBaseline: number
- *   ranking: number
- *   roi: number
- *   pnl: number
- *   calculatedAt: string // ISO string
- *   totalVolume: number
- * }} CompetitionRanking
  */

--- a/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlPayload.js
@@ -48,17 +48,6 @@ export default class CompetitionLeaderboardQueryGraphqlPayload extends BaseAppGr
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     address?: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         targetColumn: string
- *         orderBy: string
- *       }
- *     }
- *   }
+ *   input: schema.graphql.CompetitionLeaderboardInput
  * }} CompetitionLeaderboardQueryRequestVariables
  */

--- a/app/graphql/client/queries/competitionParticipant/CompetitionParticipantQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionParticipant/CompetitionParticipantQueryGraphqlCapsule.js
@@ -20,7 +20,7 @@ export default class CompetitionParticipantQueryGraphqlCapsule extends BaseAppGr
   /**
    * get: participant
    *
-   * @returns {Participant | null} Participant info
+   * @returns {schema.graphql.CompetitionParticipant | null} Participant info
    */
   get participant () {
     return this.extractCompetitionParticipantValueHash()
@@ -31,7 +31,7 @@ export default class CompetitionParticipantQueryGraphqlCapsule extends BaseAppGr
   /**
    * get: addressValueHash
    *
-   * @returns {Address | null} Participant address value hash
+   * @returns {schema.graphql.AddressSummary | null} Participant address value hash
    */
   get addressValueHash () {
     return this.participant
@@ -64,7 +64,7 @@ export default class CompetitionParticipantQueryGraphqlCapsule extends BaseAppGr
   /**
    * get: statusValueHash
    *
-   * @returns {StatusPhase | null} Participant status value hash
+   * @returns {schema.graphql.StatusPhase | null} Participant status value hash
    */
   get statusValueHash () {
     return this.participant
@@ -108,32 +108,6 @@ export default class CompetitionParticipantQueryGraphqlCapsule extends BaseAppGr
 
 /**
  * @typedef {{
- *   competitionParticipant: {
- *     participant: Participant
- *   }
+ *   competitionParticipant: schema.graphql.CompetitionParticipantResult
  * }} CompetitionParticipantQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   competitionParticipantId: number
- *   address: Address
- *   status: StatusPhase
- *   equity: number
- * }} Participant
- */
-
-/**
- * @typedef {{
- *   address: string
- *   name: string
- * }} Address
- */
-
-/**
- * @typedef {{
- *   statusId: number
- *   name: string
- *   phasedAt: string // ISO String
- * }} StatusPhase
  */

--- a/app/graphql/client/queries/competitionParticipant/CompetitionParticipantQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionParticipant/CompetitionParticipantQueryGraphqlPayload.js
@@ -32,9 +32,6 @@ export default class CompetitionParticipantQueryGraphqlPayload extends BaseAppGr
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     address: string
- *   }
+ *   input: schema.graphql.CompetitionParticipantInput
  * }} CompetitionParticipantQueryRequestVariables
  */

--- a/app/graphql/client/queries/competitionParticipantStatuses/CompetitionParticipantStatusesQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionParticipantStatuses/CompetitionParticipantStatusesQueryGraphqlCapsule.js
@@ -20,7 +20,7 @@ export default class CompetitionParticipantStatusesQueryGraphqlCapsule extends B
   /**
    * get: statuses
    *
-   * @returns {Array<Status>}
+   * @returns {Array<schema.graphql.Status>}
    */
   get statuses () {
     return this.extractCompetitionParticipantStatuses()
@@ -31,16 +31,6 @@ export default class CompetitionParticipantStatusesQueryGraphqlCapsule extends B
 
 /**
  * @typedef {{
- *   competitionParticipantStatuses: {
- *     statuses: Array<Status>
- *   }
+ *   competitionParticipantStatuses: schema.graphql.CompetitionParticipantStatusesResult
  * }} ResponseContent
- */
-
-/**
- * @typedef {{
- *   description: string
- *   name: string
- *   statusId: number
- * }} Status
  */

--- a/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class CompetitionParticipantsQueryGraphqlCapsule extends BaseAppG
   /**
    * Extract `competitionParticipants`.
    *
-   * @returns {CompetitionParticipants | null}
+   * @returns {schema.graphql.CompetitionParticipantsResult | null}
    */
   extractCompetitionParticipants () {
     return this.extractContent()
@@ -20,7 +20,7 @@ export default class CompetitionParticipantsQueryGraphqlCapsule extends BaseAppG
   /**
    * get: myParticipation
    *
-   * @returns {Participant | null}
+   * @returns {schema.graphql.CompetitionParticipant | null}
    */
   get myParticipation () {
     return this.extractCompetitionParticipants()
@@ -31,7 +31,7 @@ export default class CompetitionParticipantsQueryGraphqlCapsule extends BaseAppG
   /**
    * get: participants
    *
-   * @returns {Array<Participant>} List of participants
+   * @returns {Array<schema.graphql.CompetitionParticipant>} List of participants
    */
   get participants () {
     return this.extractCompetitionParticipants()
@@ -42,7 +42,7 @@ export default class CompetitionParticipantsQueryGraphqlCapsule extends BaseAppG
   /**
    * get: pagination
    *
-   * @returns {Pagination | null} Pagination information
+   * @returns {schema.graphql.Pagination | null} Pagination information
    */
   get pagination () {
     return this.extractCompetitionParticipants()
@@ -86,46 +86,6 @@ export default class CompetitionParticipantsQueryGraphqlCapsule extends BaseAppG
 
 /**
  * @typedef {{
- *   competitionParticipants: CompetitionParticipants
+ *   competitionParticipants: schema.graphql.CompetitionParticipantsResult
  * }} ResponseContent
- */
-
-/**
- * @typedef {{
- *   myParticipation: Participant | null
- *   participants: Array<Participant>
- *   pagination: Pagination
- * }} CompetitionParticipants
- */
-
-/**
- * @typedef {{
- *   competitionParticipantId: number
- *   address: Address
- *   status: Status
- *   equity: number
- * }} Participant
- */
-
-/**
- * @typedef {{
- *   address: string
- *   name: string
- * }} Address
- */
-
-/**
- * @typedef {{
- *   statusId: number
- *   name: string
- *   phasedAt: string
- * }} Status
- */
-
-/**
- * @typedef {{
- *   totalCount: number
- *   limit: number
- *   offset: number
- * }} Pagination
  */

--- a/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlPayload.js
@@ -50,18 +50,6 @@ export default class CompetitionParticipantsQueryGraphqlPayload extends BaseAppG
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     statusId?: number
- *     address?: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         limit: number
- *         offset: number
- *       }
- *     }
- *   }
+ *   input: schema.graphql.CompetitionParticipantsInput
  * }} CompetitionParticipantsQueryRequestVariables
  */

--- a/app/graphql/client/queries/competitionStatistics/CompetitionStatisticsQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionStatistics/CompetitionStatisticsQueryGraphqlCapsule.js
@@ -53,10 +53,6 @@ export default class CompetitionStatisticsQueryGraphqlCapsule extends BaseAppGra
 
 /**
  * @typedef {{
- *   competitionStatistics: {
- *     totalHostedCompetitionsNumber: number
- *     totalEnrolledCompetitionParticipantsNumber: number
- *     totalPaidOutPrizesUsdAmount: string
- *   }
+ *   competitionStatistics: schema.graphql.CompetitionStatisticsResult
  * }} CompetitionStatisticsQueryResponseContent
  */

--- a/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlCapsule.js
@@ -20,7 +20,7 @@ export default class CompetitionTradingMetricsQueryGraphqlCapsule extends BaseAp
   /**
    * get: myMetric
    *
-   * @returns {TradingMetric | null}
+   * @returns {schema.graphql.CompetitionTradingMetric | null}
    */
   get myMetric () {
     return this.extractCompetitionTradingMetricsValueHash()
@@ -31,7 +31,7 @@ export default class CompetitionTradingMetricsQueryGraphqlCapsule extends BaseAp
   /**
    * get: metrics
    *
-   * @returns {Array<TradingMetric>}
+   * @returns {Array<schema.graphql.CompetitionTradingMetric>}
    */
   get metrics () {
     return this.extractCompetitionTradingMetricsValueHash()
@@ -42,7 +42,7 @@ export default class CompetitionTradingMetricsQueryGraphqlCapsule extends BaseAp
   /**
    * get: pagination
    *
-   * @returns {Pagination | null}
+   * @returns {schema.graphql.Pagination | null}
    */
   get pagination () {
     return this.extractCompetitionTradingMetricsValueHash()
@@ -75,34 +75,6 @@ export default class CompetitionTradingMetricsQueryGraphqlCapsule extends BaseAp
 
 /**
  * @typedef {{
- *   competitionTradingMetrics: {
- *     myMetric: TradingMetric | null
- *     metrics: Array<TradingMetric>
- *     pagination: Pagination
- *   }
+ *   competitionTradingMetrics: schema.graphql.CompetitionTradingMetricsResult
  * }} CompetitionTradingMetricsQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   address: {
- *     address: string
- *     name: string
- *   }
- *   makerFees: number
- *   takerFees: number
- *   totalFees: number
- *   makeVolume: number
- *   takerVolume: number
- *   totalVolume: number
- *   calculatedAt: string // ISO string
- * }} TradingMetric
- */
-
-/**
- * @typedef {{
- *   totalCount: number
- *   limit: number
- *   offset: number
- * }} Pagination
  */

--- a/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlPayload.js
@@ -50,17 +50,6 @@ export default class CompetitionTradingMetricsQueryGraphqlPayload extends BaseAp
 
 /**
  * @typedef {{
- *   input: {
- *     competitionId: number
- *     address?: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         targetColumn: string
- *         orderBy: string
- *       }
- *     }
- *   }
+ *   input: schema.graphql.CompetitionTradingMetricsInput
  * }} CompetitionTradingMetricsQueryRequestVariables
  */

--- a/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule.js
@@ -48,43 +48,6 @@ export default class CompetitionsQueryGraphqlCapsule extends BaseAppGraphqlCapsu
 
 /**
  * @typedef {{
- *   competitions: {
- *     competitions: Array<CompetitionEntity>
- *     pagination: {
- *       totalCount: number
- *       limit: number
- *       offset: number
- *     }
- *   }
+ *   competitions: schema.graphql.CompetitionsResult
  * }} CompetitionsQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   competitionId: number
- *   title: string
- *   description: string
- *   participantUpperLimit: number
- *   participantLowerLimit: number
- *   host: {
- *     address: string
- *     name: string
- *   }
- *   totalPrize: number
- *   minimumDeposit: number
- *   imageUrl?: string
- *   schedules: Array<{
- *     category: {
- *       categoryId: number
- *       name: string
- *       description: string
- *     }
- *     scheduledDatetime: string
- *   }>
- *   status: {
- *     statusId: number
- *     name: string
- *     phasedAt: string
- *   }
- * }} CompetitionEntity
  */

--- a/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlPayload.js
@@ -51,18 +51,6 @@ export default class CompetitionsQueryGraphqlPayload extends BaseAppGraphqlPaylo
 
 /**
  * @typedef {{
- *   input: {
- *     title?: string
- *     statusId?: number
- *     hostAddress?: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         targetColumn: string
- *         orderBy: string
- *       }
- *     }
- *   }
+ *   input: schema.graphql.CompetitionsInput
  * }} CompetitionsQueryRequestVariables
  */

--- a/app/graphql/client/queries/participantsCurrentEquities/ParticipantsCurrentEquitiesQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/participantsCurrentEquities/ParticipantsCurrentEquitiesQueryGraphqlCapsule.js
@@ -20,7 +20,7 @@ export default class ParticipantsCurrentEquitiesQueryGraphqlCapsule extends Base
   /**
    * get: equities
    *
-   * @returns {Array<Equity>} List of equities
+   * @returns {Array<schema.graphql.ParticipantEquity>} List of equities
    */
   get equities () {
     return this.extractParticipantsCurrentEquities()
@@ -31,15 +31,6 @@ export default class ParticipantsCurrentEquitiesQueryGraphqlCapsule extends Base
 
 /**
  * @typedef {{
- *   participantsCurrentEquities: {
- *     equities: Array<Equity>
- *   }
+ *   participantsCurrentEquities: schema.graphql.ParticipantsCurrentEquitiesResult
  * }} ResponseContent
- */
-
-/**
- * @typedef {{
- *   competitionParticipantId: number
- *   equity: string
- * }} Equity
  */

--- a/app/graphql/client/queries/participantsCurrentEquities/ParticipantsCurrentEquitiesQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/participantsCurrentEquities/ParticipantsCurrentEquitiesQueryGraphqlPayload.js
@@ -23,9 +23,6 @@ export default class ParticipantsCurrentEquitiesQueryGraphqlPayload extends Base
 
 /**
  * @typedef {{
- *   input: {
- *     competitionParticipantIds: Array<number>
- *     timestamp: string
- *   }
+ *   input: schema.graphql.ParticipantsCurrentEquitiesInput
  * }} ParticipantsCurrentEquitiesQueryRequestVariables
  */

--- a/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlCapsule.js
@@ -9,7 +9,7 @@ export default class SearchAddressesQueryGraphqlCapsule extends BaseAppGraphqlCa
   /**
    * Extract `searchAddresses`.
    *
-   * @returns {SearchAddresses | null}
+   * @returns {schema.graphql.SearchAddressesResult | null}
    */
   extractSearchAddresses () {
     return this.extractContent()
@@ -20,7 +20,7 @@ export default class SearchAddressesQueryGraphqlCapsule extends BaseAppGraphqlCa
   /**
    * get: addresses
    *
-   * @returns {Array<Address>}
+   * @returns {Array<schema.graphql.AddressSummary>}
    */
   get addresses () {
     return this.extractSearchAddresses()
@@ -31,7 +31,7 @@ export default class SearchAddressesQueryGraphqlCapsule extends BaseAppGraphqlCa
   /**
    * get: pagination
    *
-   * @returns {Pagination | null}
+   * @returns {schema.graphql.Pagination | null}
    */
   get pagination () {
     return this.extractSearchAddresses()
@@ -75,28 +75,6 @@ export default class SearchAddressesQueryGraphqlCapsule extends BaseAppGraphqlCa
 
 /**
  * @typedef {{
- *   searchAddresses: SearchAddresses
+ *   searchAddresses: schema.graphql.SearchAddressesResult
  * }} SearchAddressesQueryResponseContent
- */
-
-/**
- * @typedef {{
- *   addresses: Array<Address>
- *   pagination: Pagination
- * }} SearchAddresses
- */
-
-/**
- * @typedef {{
- *   address: string
- *   name: string
- * }} Address
- */
-
-/**
- * @typedef {{
- *   totalCount: number
- *   limit: number
- *   offset: number
- * }} Pagination
  */

--- a/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlPayload.js
@@ -28,16 +28,6 @@ export default class SearchAddressesQueryGraphqlPayload extends BaseAppGraphqlPa
 
 /**
  * @typedef {{
- *   input: {
- *     query: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         targetColumn: string
- *         orderBy: string
- *       }
- *     }
- *   }
+ *   input: schema.graphql.SearchAddressesInput
  * }} SearchAddressesQueryRequestVariables
  */

--- a/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlCapsule.js
+++ b/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlCapsule.js
@@ -44,16 +44,6 @@ export default class SearchAddressesByNameQueryGraphqlCapsule extends BaseAppGra
 
 /**
  * @typedef {{
- *   searchAddressesByName: {
- *     addresses: Array<{
- *       address: string
- *       name?: string
- *     }>
- *     pagination: {
- *       totalCount: number
- *       limit: number
- *       offset: number
- *     }
- *   }
+ *   searchAddressesByName: schema.graphql.SearchAddressesByNameResult
  * }} ResponseContent
  */

--- a/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlPayload.js
+++ b/app/graphql/client/queries/searchAddressesByName/SearchAddressesByNameQueryGraphqlPayload.js
@@ -28,16 +28,6 @@ export default class SearchAddressesByNameQueryGraphqlPayload extends BaseAppGra
 
 /**
  * @typedef {{
- *   input: {
- *     query: string
- *     pagination: {
- *       limit: number
- *       offset: number
- *       sort?: {
- *         targetColumn: string
- *         orderBy: string
- *       }
- *     }
- *   }
+ *   input: schema.graphql.SearchAddressesByNameInput
  * }} SearchAddressesByNameQueryRequestVariables
  */

--- a/app/vue/contexts/CompetitionDetailsPageContext.js
+++ b/app/vue/contexts/CompetitionDetailsPageContext.js
@@ -1076,7 +1076,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
    * Format metric leaderboard entry.
    *
    * @param {{
-   *   entry: import('~/app/graphql/client/queries/competitionTradingMetrics/CompetitionTradingMetricsQueryGraphqlCapsule').TradingMetric
+   *   entry: schema.graphql.CompetitionTradingMetric
    * }} params - Parameters.
    * @returns {MetricLeaderboardEntry}
    */
@@ -1273,7 +1273,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
   /**
    * Extract ongoing leaderboard's sort option from URL.
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').SortOption | null}
+   * @returns {schema.graphql.SortOption | null}
    */
   extractOngoingLeaderboardSortFromRoute () {
     const {
@@ -1615,9 +1615,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
    * Format competition participant entry.
    *
    * @param {{
-   *   entry: import(
-   *     '~/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlCapsule'
-   *   ).Participant
+   *   entry: schema.graphql.CompetitionParticipant
    * }} params - Parameters.
    * @returns {NormalizedCompetitionParticipantEntry}
    */
@@ -1636,12 +1634,8 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
    * Normalize ongoing leaderboard entries.
    *
    * @param {{
-   *   rankings: import(
-   *     '~/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlCapsule'
-   *   ).ResponseContent['competitionLeaderboard']['rankings']
-   *   myRanking: import(
-   *     '~/app/graphql/client/queries/competitionLeaderboard/CompetitionLeaderboardQueryGraphqlCapsule'
-   *   ).CompetitionRanking | null
+   *   rankings: Array<schema.graphql.CompetitionRanking>
+   *   myRanking: schema.graphql.CompetitionRanking | null
    * }} params - Parameters.
    * @returns {Array<NormalizedOngoingLeaderboardEntry>}
    */
@@ -1722,8 +1716,8 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
    * Normalize leaderboard final outcome entries.
    *
    * @param {{
-   *   outcomes: Array<import('~/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlCapsule').Outcome>
-   *   myOutcome: import('~/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlCapsule').Outcome | null
+   *   outcomes: Array<schema.graphql.CompetitionFinalOutcome>
+   *   myOutcome: schema.graphql.CompetitionFinalOutcome | null
    * }} params - Parameters.
    * @returns {Array<NormalizedLeaderboardFinalOutcomeEntry>}
    */
@@ -1780,7 +1774,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
    * Format leaderboard final outcome entry.
    *
    * @param {{
-   *   entry: import('~/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlCapsule').Outcome
+   *   entry: schema.graphql.CompetitionFinalOutcome
    * }} params - Parameters.
    * @returns {NormalizedLeaderboardFinalOutcomeEntry}
    */
@@ -1919,7 +1913,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
    * Normalize top three in the final outcome.
    *
    * @param {{
-   *   outcomes: Array<import('~/app/graphql/client/queries/competitionFinalOutcome/CompetitionFinalOutcomeQueryGraphqlCapsule').Outcome>
+   *   outcomes: Array<schema.graphql.CompetitionFinalOutcome>
    * }} params - Parameters.
    * @returns {TopThreeLeaderboardEntries}
    */
@@ -2026,7 +2020,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
   /**
    * get: competition
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity}
+   * @returns {schema.graphql.Competition}
    */
   get competition () {
     return this.competitionCapsuleRef.value
@@ -2036,7 +2030,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
   /**
    * get: competitionHost
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity['host'] | null}
+   * @returns {schema.graphql.Competition['host'] | null}
    */
   get competitionHost () {
     return this.competition
@@ -2047,7 +2041,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
   /**
    * get: competitionHostAddress
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity['host']['address'] | null}
+   * @returns {schema.graphql.Competition['host']['address'] | null}
    */
   get competitionHostAddress () {
     return this.competitionHost
@@ -2058,7 +2052,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
   /**
    * get: competitionHostName
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity['host']['name'] | null}
+   * @returns {schema.graphql.Competition['host']['name'] | null}
    */
   get competitionHostName () {
     return this.competitionHost
@@ -2132,7 +2126,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
   /**
    * get: defaultLeaderboardSortOption
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').SortOption | null}
+   * @returns {schema.graphql.SortOption | null}
    */
   get defaultLeaderboardSortOption () {
     return this.competitionCapsuleRef
@@ -2162,7 +2156,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
   /**
    * get: schedules
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity['schedules']}
+   * @returns {schema.graphql.Competition['schedules']}
    */
   get schedules () {
     return this.competitionCapsuleRef.value
@@ -2172,7 +2166,7 @@ export default class CompetitionDetailsPageContext extends BaseAppContext {
   /**
    * get: prizeRules
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity['prizeRules']}
+   * @returns {schema.graphql.Competition['prizeRules']}
    */
   get prizeRules () {
     return this.competitionCapsuleRef.value

--- a/app/vue/contexts/CompetitionsPageContext.js
+++ b/app/vue/contexts/CompetitionsPageContext.js
@@ -289,7 +289,7 @@ export default class CompetitionsPageContext extends BaseAppContext {
   /**
    * get: competitions
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule').CompetitionEntity>}
+   * @returns {Array<schema.graphql.CompetitionSummary>}
    */
   get competitions () {
     return this.competitionsCapsuleRef.value

--- a/app/vue/contexts/competition/SectionLeaderboardContext.js
+++ b/app/vue/contexts/competition/SectionLeaderboardContext.js
@@ -772,7 +772,7 @@ export default class SectionLeaderboardContext extends BaseAppContext {
 
 /**
  * @typedef {{
- *   competition: import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity | null
+ *   competition: schema.graphql.Competition | null
  *   competitionStatusId: number | null
  *   isLoadingLeaderboard: boolean
  *   isLoadingMetricLeaderboard: boolean

--- a/app/vue/contexts/profile/ProfileDetailsPageContext.js
+++ b/app/vue/contexts/profile/ProfileDetailsPageContext.js
@@ -341,7 +341,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
   /**
    * Extract `addressProfile` response content as value hash.
    *
-   * @returns {import('~/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlCapsule').AddressProfile | null}
+   * @returns {schema.graphql.AddressProfileResult | null}
    */
   extractAddressProfileValueHash () {
     return this.fetcherHash
@@ -691,7 +691,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
   /**
    * get: currentCompetition
    *
-   * @returns {import('~/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlCapsule').Competition} Current competition.
+   * @returns {schema.graphql.CompetitionSummary | null} Current competition.
    */
   get currentCompetition () {
     return this.addressCurrentCompetitionCapsuleRef.value
@@ -712,7 +712,7 @@ export default class ProfileDetailsContext extends BaseAppContext {
   /**
    * get: currentRanking
    *
-   * @returns {import('~/app/graphql/client/queries/addressCurrentCompetition/AddressCurrentCompetitionQueryGraphqlCapsule').Ranking} Current ranking.
+   * @returns {schema.graphql.CompetitionRanking | null} Current ranking.
    */
   get currentRanking () {
     return this.addressCurrentCompetitionCapsuleRef.value

--- a/app/vue/contexts/profile/SectionProfileOverviewContext.js
+++ b/app/vue/contexts/profile/SectionProfileOverviewContext.js
@@ -774,7 +774,7 @@ export default class SectionProfileOverviewContext extends BaseAppContext {
 
 /**
  * @typedef {{
- *   addressProfile: import('~/app/graphql/client/queries/addressProfile/AddressProfileQueryGraphqlCapsule').AddressProfile | null
+ *   addressProfile: schema.graphql.AddressProfileResult | null
  *   competition: Competition | null
  *   competitionParticipantStatusId: number | null
  *   ranking: Ranking | null

--- a/app/vue/contexts/search/AddressesSearchBarContext.js
+++ b/app/vue/contexts/search/AddressesSearchBarContext.js
@@ -183,5 +183,5 @@ export default class AddressesSearchBarContext extends BaseAppContext {
  */
 
 /**
- * @typedef {Array<import('~/app/graphql/client/queries/searchAddresses/SearchAddressesQueryGraphqlCapsule').Address>} Addresses
+ * @typedef {Array<schema.graphql.AddressSummary>} Addresses
  */

--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -26,9 +26,7 @@ import useWalletStore from '~/stores/wallet'
 import SectionLeagueContext from '~/app/vue/contexts/competition/SectionLeagueContext'
 
 /**
- * @typedef {import('vue').PropType<
- *   import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity
- * >} CompetitionPropType
+ * @typedef {import('vue').PropType<schema.graphql.Competition>} CompetitionPropType
  */
 
 export default defineComponent({

--- a/components/competition-id/SectionPrizeRulesContext.js
+++ b/components/competition-id/SectionPrizeRulesContext.js
@@ -117,7 +117,7 @@ export default class SectionPrizeRulesContext extends BaseAppContext {
 
 /**
  * @typedef {{
- *   prizeRules: import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity['prizeRules']
+ *   prizeRules: schema.graphql.Competition['prizeRules']
  * }} PropsType
  */
 

--- a/components/dialogs/CompetitionEnrollmentDialogContext.js
+++ b/components/dialogs/CompetitionEnrollmentDialogContext.js
@@ -186,7 +186,7 @@ export default class CompetitionEnrollmentDialogContext extends AppDialogContext
 
 /**
  * @typedef {{
- *   competition: import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity | null
+ *   competition: schema.graphql.Competition | null
  *   initialUsername: string | null
  *   validationMessage: furo.ValidatorHashType['message']
  *   errorMessageHash: import('vue').Reactive<

--- a/components/dialogs/CompetitionTermsDialogContext.js
+++ b/components/dialogs/CompetitionTermsDialogContext.js
@@ -277,6 +277,6 @@ export default class CompetitionTermsDialogContext extends AppDialogContext {
 /**
  * @typedef {{
  *   userInterfaceState: import('~/app/vue/contexts/CompetitionDetailsPageContext.js').StatusReactive
- *   competition: import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity
+ *   competition: schema.graphql.Competition
  * }} CompetitionTermsDialogProps
  */

--- a/components/dialogs/EnrollmentVerificationDialogContext.js
+++ b/components/dialogs/EnrollmentVerificationDialogContext.js
@@ -430,7 +430,7 @@ export default class EnrollmentVerificationDialogContext extends BaseAppContext 
 
 /**
  * @typedef {{
- *   competition: import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity | null
+ *   competition: schema.graphql.Competition | null
  *   currentEquity: number | null
  *   userInterfaceState: import('~/app/vue/contexts/CompetitionDetailsPageContext.js').StatusReactive
  * }} PropsType

--- a/components/hosted-competition/HostedCompetitionDetailsContext.js
+++ b/components/hosted-competition/HostedCompetitionDetailsContext.js
@@ -23,7 +23,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
   /**
    * get: host
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').Host | null}
+   * @returns {schema.graphql.AddressSummary | null}
    */
   get host () {
     return this.competition
@@ -100,7 +100,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
   /**
    * get: prizeRules
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').PrizeRule>}
+   * @returns {Array<schema.graphql.CompetitionPrizeRule>}
    */
   get prizeRules () {
     return this.competition
@@ -111,7 +111,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
   /**
    * get: status
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').Status | null}
+   * @returns {schema.graphql.StatusPhase | null}
    */
   get status () {
     return this.competition
@@ -144,7 +144,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
   /**
    * get: schedules
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').Schedule>}
+   * @returns {Array<schema.graphql.CompetitionSchedule>}
    */
   get schedules () {
     return this.competition
@@ -375,7 +375,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
 
   /**
    * @param {{
-   *   schedules: Array<import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').Schedule>
+   *   schedules: Array<schema.graphql.CompetitionSchedule>
    * }} params - Parameters.
    * @returns {import('~/components/units/AppTimeline.vue').Timeline}
    */
@@ -390,7 +390,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
   /**
    * Generate registration schedules.
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').Schedule>} Registration schedules.
+   * @returns {Array<schema.graphql.CompetitionSchedule>} Registration schedules.
    */
   generateRegistrationSchedules () {
     return this.schedules.filter(
@@ -401,7 +401,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
   /**
    * Generate competition schedules.
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').Schedule>} Competition schedules.
+   * @returns {Array<schema.graphql.CompetitionSchedule>} Competition schedules.
    */
   generateCompetitionSchedules () {
     return this.schedules.filter(
@@ -412,7 +412,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
   /**
    * Generate prize distribution schedules.
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').Schedule>} Prize distribution schedules.
+   * @returns {Array<schema.graphql.CompetitionSchedule>} Prize distribution schedules.
    */
   generatePrizeDistributeSchedules () {
     return this.schedules.filter(
@@ -452,7 +452,7 @@ export default class HostedCompetitionDetailsContext extends BaseAppContext {
 
 /**
  * @typedef {{
- *   competition: import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity | null
+ *   competition: schema.graphql.Competition | null
  * }} PropsType
  */
 

--- a/components/hosted-competition/HostedCompetitionParticipantsContext.js
+++ b/components/hosted-competition/HostedCompetitionParticipantsContext.js
@@ -520,10 +520,10 @@ export default class HostedCompetitionParticipantsContext extends BaseAppContext
 
 /**
  * @typedef {{
- *   participants: Array<import('~/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlCapsule').Participant>
+ *   participants: Array<schema.graphql.CompetitionParticipant>
  *   pagination: Pagination
  *   isBulkUpdatingParticipantStatus: boolean
- *   competitionParticipantStatuses: Array<import('~/app/graphql/client/queries/competitionParticipantStatuses/CompetitionParticipantStatusesQueryGraphqlCapsule').Status>
+ *   competitionParticipantStatuses: Array<schema.graphql.Status>
  * }} PropsType
  */
 

--- a/components/units/AppLeagueCountdownContext.js
+++ b/components/units/AppLeagueCountdownContext.js
@@ -165,7 +165,7 @@ export default class AppLeagueCountdownContext extends BaseAppContext {
  *   shouldHideIcon: boolean
  *   iconName: string
  *   iconSize: string
- *   schedules: import('~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule').CompetitionEntity['schedules']
+ *   schedules: Array<schema.graphql.CompetitionSchedule>
  * }} AppLeagueCountdownProps
  */
 

--- a/pages/hosted-competitions/HostedCompetitionsPageContext.js
+++ b/pages/hosted-competitions/HostedCompetitionsPageContext.js
@@ -289,7 +289,7 @@ export default class HostedCompetitionsPageContext extends BaseAppContext {
   /**
    * Extract `competitions`
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competitions/CompetitionsQueryGraphqlCapsule').CompetitionEntity>}
+   * @returns {Array<schema.graphql.CompetitionSummary>}
    */
   extractCompetitions () {
     return this.competitionsCapsule.extractCompetitions()

--- a/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
+++ b/pages/hosted-competitions/[competitionId]/HostedCompetitionDetailsPageContext.js
@@ -164,7 +164,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseAppContext 
   /**
    * get: participants
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competitionParticipants/CompetitionParticipantsQueryGraphqlCapsule').Participant>}
+   * @returns {Array<schema.graphql.CompetitionParticipant>}
    */
   get participants () {
     return this.competitionParticipantsCapsule.participants
@@ -222,7 +222,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseAppContext 
   /**
    * Extract `competition.`
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').CompetitionEntity | null}
+   * @returns {schema.graphql.Competition | null}
    */
   extractCompetition () {
     return this.competitionCapsule.extractCompetition()
@@ -231,7 +231,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseAppContext 
   /**
    * get: status
    *
-   * @returns {import('~/app/graphql/client/queries/competition/CompetitionQueryGraphqlCapsule').Status | null}
+   * @returns {schema.graphql.StatusPhase | null}
    */
   get status () {
     return this.extractCompetition()
@@ -416,7 +416,7 @@ export default class HostedCompetitionDetailsPageContext extends BaseAppContext 
   /**
    * get: competitionParticipantStatuses
    *
-   * @returns {Array<import('~/app/graphql/client/queries/competitionParticipantStatuses/CompetitionParticipantStatusesQueryGraphqlCapsule').Status>}
+   * @returns {Array<schema.graphql.Status>}
    */
   get competitionParticipantStatuses () {
     return this.fetcherHash


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/7386?tab=content

# How

* Use generated types in `schema.graphql` instead of self-declared types.

<!--
* All commits have already been reviewed, merge only
-->
