### PR TITLE
Clip overflowing content in leaderboard section

### DIFF
--- a/components/competition-id/SectionLeaderboard.vue
+++ b/components/competition-id/SectionLeaderboard.vue
@@ -715,6 +715,8 @@ export default defineComponent({
     110%,
     top;
 
+  overflow-x: clip;
+
   @media (30rem < width) {
     margin-inline: calc(-1 * var(--size-body-padding-inline-desktop));
   }


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/8264?tab=content

# How

* Clip the horizontal overflow of leaderboard section.
* The top ranking card uses a `div` as their tail so I don't know any better methods to prevent the overflow. To match the design, the "tail" can start off-screen.

# Screenshots

| Before | After |
| -- | -- |
| <img width="977" height="961" alt="Screenshot 2026-03-04 at 10 40 50" src="https://github.com/user-attachments/assets/5ad0ca4a-b1ec-436b-ac1e-ee332ad86291" /> | <img width="977" height="961" alt="Screenshot 2026-03-04 at 10 40 58" src="https://github.com/user-attachments/assets/a4b75b1a-c49d-42dd-857a-d9082ac2ee55" /> |

<!--
* All commits have already been reviewed, merge only
-->
