### PR TITLE
Adjust background image position to avoid layout shift

### DIFF
--- a/components/competition-id/SectionLeague.vue
+++ b/components/competition-id/SectionLeague.vue
@@ -663,9 +663,15 @@ export default defineComponent({
       #181825 46.63%,
       rgba(24, 24, 37, 0.00) 100%
     );
-  background-position: top;
-  background-size: cover;
-  background-repeat: no-repeat;
+  background-position:
+    center top,
+    center top;
+  background-size:
+    100% auto,
+    100% 100%;
+  background-repeat:
+    no-repeat,
+    no-repeat;
 
   @media (30rem < width) {
     margin-inline: calc(-1 * var(--size-body-padding-inline-desktop));


### PR DESCRIPTION
# Why

* Close https://chiho-internal.openreach.tech/tasks/5921?tab=content

# How

* Adjust background image position so that it doesn't grow when the section content is expanded.

# Screenshots

* When not expanded:

<img width="1920" height="962" alt="Screenshot 2026-03-17 at 11 55 46" src="https://github.com/user-attachments/assets/65e084d5-abb3-4914-881f-c174ccb0d391" />

* When expanded:

| Before | After |
| -- | -- |
| <img width="1920" height="964" alt="Screenshot 2026-03-17 at 11 56 03" src="https://github.com/user-attachments/assets/79ade3ef-9502-454b-8236-0a456a8f51db" /> | <img width="1920" height="964" alt="Screenshot 2026-03-17 at 11 55 53" src="https://github.com/user-attachments/assets/7f98138c-0a82-4432-ac6f-7e9ce75c23c0" /> |

<!--
* All commits have already been reviewed, merge only
-->
